### PR TITLE
Add podman deployment examples

### DIFF
--- a/deployment/podman-quadlets/audiomuse-ai-flask.container
+++ b/deployment/podman-quadlets/audiomuse-ai-flask.container
@@ -1,0 +1,33 @@
+[Unit]
+Description=An open-source environment that brings smart playlist generation to Jellyfin and Navidrome
+Documentation=https://neptunehub.github.io/AudioMuse-AI/
+Requires=audiomuse-redis.service audiomuse-postgres.service
+After=audiomuse-redis.service audiomuse-postgres.service
+
+[Container]
+ContainerName=audiomuse-ai-flask
+Image=ghcr.io/neptunehub/audiomuse-ai:latest
+Pod=audiomuse.pod
+Tmpfs=/app/temp_audio
+AutoUpdate=registry
+
+#Env
+Environment=SERVICE_TYPE=flask MEDIASERVER_TYPE=navidrome 
+Environment=NAVIDROME_URL=YOUR-NAVIDROME-URL
+Environment=NAVIDROME_USER=YOUR-USER NAVIDROME_PASSWORD=YOUR-PASSWORD
+Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
+Environment=POSTGRES_DB=audiomusedb POSTGRES_HOST=localhost POSTGRES_PORT=5432 
+Environment=REDIS_URL=redis://localhost:6379/0 
+Environment=GEMINI_API_KEY=YOUR_GEMINI_API_KEY_HERE
+Environment=GEMINI_MODEL_NAME=gemini-2.5-flash
+Environment=TEMP_DIR=/app/temp_audio
+
+#HealthCheck
+HealthCmd=wget -q --spider --no-proxy localhost:8000 || exit 1
+HealthInterval=60s
+HealthTimeout=5s
+HealthStartPeriod=60s
+HealthOnFailure=kill
+
+[Service]
+Restart=always

--- a/deployment/podman-quadlets/audiomuse-ai-worker.container
+++ b/deployment/podman-quadlets/audiomuse-ai-worker.container
@@ -1,0 +1,25 @@
+[Unit]
+Description=A worker unit for AudioMuse-AI
+Documentation=https://neptunehub.github.io/AudioMuse-AI/
+Requires=audiomuse-redis.service audiomuse-postgres.service
+After=audiomuse-redis.service audiomuse-postgres.service
+
+[Container]
+ContainerName=audiomuse-ai-worker
+Image=ghcr.io/neptunehub/audiomuse-ai:latest
+Pod=audiomuse.pod
+Tmpfs=/app/temp_audio
+AutoUpdate=registry
+
+#Env
+Environment=SERVICE_TYPE=worker MEDIASERVER_TYPE=navidrome 
+Environment=NAVIDROME_URL=YOUR-NAVIDROME-URL
+Environment=NAVIDROME_USER=YOUR-USER NAVIDROME_PASSWORD=YOUR-PASSWORD
+Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
+Environment=POSTGRES_DB=audiomusedb POSTGRES_HOST=localhost POSTGRES_PORT=5432 
+Environment=REDIS_URL=redis://localhost:6379/0 
+Environment=GEMINI_API_KEY=YOUR_GEMINI_API_KEY_HERE
+Environment=TEMP_DIR=/app/temp_audio
+
+[Service]
+Restart=always

--- a/deployment/podman-quadlets/audiomuse-postgres.container
+++ b/deployment/podman-quadlets/audiomuse-postgres.container
@@ -1,0 +1,24 @@
+[Unit]
+Description=A postgres unit for AudioMuse-AI
+Documentation=https://neptunehub.github.io/AudioMuse-AI/
+
+[Container]
+ContainerName=audiomuse-postgres
+Image=docker.io/postgres:17-alpine
+Pod=audiomuse.pod
+Volume=audiomuse-postgres-data:/var/lib/postgresql/data:U
+AutoUpdate=registry
+
+#Env
+Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
+Environment=POSTGRES_DB=audiomusedb
+
+#Healthcheck
+HealthCmd=nc -z localhost 5432 || exit 1
+HealthInterval=60s
+HealthTimeout=5s
+HealthStartPeriod=60s
+HealthOnFailure=kill
+
+[Service]
+Restart=always

--- a/deployment/podman-quadlets/audiomuse-redis.container
+++ b/deployment/podman-quadlets/audiomuse-redis.container
@@ -1,0 +1,20 @@
+[Unit]
+Description=A redis unit for AudioMuse-AI
+Documentation=https://neptunehub.github.io/AudioMuse-AI/
+
+[Container]
+ContainerName=audiomuse-redis
+Image=docker.io/redis:7-alpine
+Pod=audiomuse.pod
+Volume=audiomuse-redis-data:/data:U
+AutoUpdate=registry
+
+#Healthcheck
+HealthCmd=nc -z localhost 6379 || exit 1
+HealthInterval=60s
+HealthTimeout=5s
+HealthStartPeriod=60s
+HealthOnFailure=kill
+
+[Service]
+Restart=always

--- a/deployment/podman-quadlets/audiomuse.pod
+++ b/deployment/podman-quadlets/audiomuse.pod
@@ -1,0 +1,2 @@
+[Pod]
+PublishPort=8000:8000


### PR DESCRIPTION
This PR adds a new folder to the deployment directory containing example podman quadlet files for deploying AudioMuse-AI via podman in a systemd environment. This is another alternative to K3S or Docker-compose. 
It also updates the readme to include a section on how to deploy AudioMuse-AI using the quadlet files. 

Info on quadlet files: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html


PS - first time contributing to someone else's project and writing a PR. Apologies if I botched any PR etiquette. 