### PR TITLE
fix: monkeypatch np.float_ to make clustering work again

### DIFF
--- a/tasks/clustering.py
+++ b/tasks/clustering.py
@@ -42,6 +42,12 @@ from .clustering_helper import (
     _perform_single_clustering_iteration
 )
 
+# we want to maintain np.float_ for backwards compatibility but it was removed in numpy 2.0
+# the check below in sanitize_for_json causes an AttributeError that crashes the clustering algo
+# since it tries to access np.float_ so we monkeypatch np.float_ to point to np.float64
+if not np.__dict__.get('float_'):
+    np.float_ = np.float64
+
 logger = logging.getLogger(__name__)
 
 def _sanitize_for_json(obj):


### PR DESCRIPTION
When running K-Means clustering, I was getting an AttributeError every clustering iteration:

```
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
```

I was able to trace this to the clustering module which is checking the type of a value from a list of types including `np.float_`, `np.float64` and so on. I did not do any kind of analysis over why the module checks for the old deprecated `np.float_` type and instead, to maintain backwards compatibility, I opted to monkeypatch the `np.float_`, setting it to `np.float64` if it does not exist.

This has now fixed clustering behaviour for me.

Tested and validated in `audiomuse-ai:latest-nvidia`