### PR TITLE
[FIX BUG] 'tuple' object has no attribute 'replace'

### DIFF
--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -442,7 +442,9 @@ def get_tracks_from_album(album_id, user_creds=None):
         # Apply artist field prioritization to each track
         for item in items:
             title = item.get('Name', 'Unknown')
-            item['AlbumArtist'] = _select_best_artist(item, title)
+            artist_name, artist_id = _select_best_artist(item, title)
+            item['AlbumArtist'] = artist_name
+            item['ArtistId'] = artist_id
         
         return items
     except Exception as e:


### PR DESCRIPTION
- `_select_best_artist(item, title)` returns `(artist_name, artist_id)` as a tuple.
- Old code assigned the entire tuple to `item['AlbumArtist']`.
- Downstream code expects `item['AlbumArtist']` (passed as `author`) to be a string so it can call `.replace()`.
- The patch unpacks the tuple and stores only the string in `AlbumArtist` and the `ID` separately in `ArtistId`.
- This prevents the `'tuple' object has no attribute 'replace'` error.