### PR TITLE
add option to change default port with docker compose deployement

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -48,7 +48,10 @@ POSTGRES_PASSWORD=audiomusepassword
 POSTGRES_DB=audiomusedb
 POSTGRES_PORT=5432
 POSTGRES_HOST=postgres
-REDIS_URL=redis://redis:6379/0
+REDIS_URL=redis://redis:6379/0 # /!\ change port adress if you change REDIS_PORT below
+REDIS_PORT=6379
+FRONTEND_PORT=8000
+WORKER_PORT=8029
 
 # --- AI Model Configuration ---
 # Choose your AI provider: NONE, OLLAMA, OPENAI, GEMINI, OPENAI, or MISTRAL

--- a/deployment/docker-compose-dmr.yaml
+++ b/deployment/docker-compose-dmr.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest # Reflects deployment.yaml
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000" # Map host port 8000 to container port 8000
+      - "${FRONTEND_PORT:-8000}:8000" # Map host port 8000 to container port 8000
     environment:
       SERVICE_TYPE: "flask" # Tells the container to run the Flask app
       MEDIASERVER_TYPE: "jellyfin" # Specify the media server type

--- a/deployment/docker-compose-emby.yaml
+++ b/deployment/docker-compose-emby.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest # Reflects deployment.yaml
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000" # Map host port 8000 to container port 8000
+      - "${FRONTEND_PORT:-8000}:8000" # Map host port 8000 to container port 8000
     environment:
       SERVICE_TYPE: "flask" # Tells the container to run the Flask app
       MEDIASERVER_TYPE: "emby" # Specify the media server type

--- a/deployment/docker-compose-lyrion.yaml
+++ b/deployment/docker-compose-lyrion.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000"
+      - "${FRONTEND_PORT:-8000}:8000"
     environment:
       SERVICE_TYPE: "flask"
       MEDIASERVER_TYPE: "lyrion"

--- a/deployment/docker-compose-navidrome.yaml
+++ b/deployment/docker-compose-navidrome.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000"
+      - "${FRONTEND_PORT:-8000}:8000"
     environment:
       SERVICE_TYPE: "flask"
       MEDIASERVER_TYPE: "navidrome"

--- a/deployment/docker-compose-navidrome_local.yaml
+++ b/deployment/docker-compose-navidrome_local.yaml
@@ -4,7 +4,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -18,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -33,7 +33,7 @@ services:
         BASE_IMAGE: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000"
+      - "${FRONTEND_PORT:-8000}:8000"
     environment:
       SERVICE_TYPE: "flask"
       MEDIASERVER_TYPE: "navidrome"

--- a/deployment/docker-compose-navidrome_local_cpu.yaml
+++ b/deployment/docker-compose-navidrome_local_cpu.yaml
@@ -4,7 +4,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -18,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -33,7 +33,7 @@ services:
     pull_policy: never  # Always use locally built image, never pull from registry
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000"
+      - "${FRONTEND_PORT:-8000}:8000"
     environment:
       SERVICE_TYPE: "flask"
       MEDIASERVER_TYPE: "navidrome"

--- a/deployment/docker-compose-nvidia.yaml
+++ b/deployment/docker-compose-nvidia.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest-nvidia
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000" # Map host port 8000 to container port 8000
+      - "${FRONTEND_PORT:-8000}:8000" # Map host port 8000 to container port 8000
     environment:
       SERVICE_TYPE: "flask" # Tells the container to run the Flask app
       MEDIASERVER_TYPE: "jellyfin" # Specify the media server type

--- a/deployment/docker-compose-server.yaml
+++ b/deployment/docker-compose-server.yaml
@@ -12,7 +12,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     volumes:
       - redis-data:/data
     restart: unless-stopped
@@ -26,7 +26,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest-nvidia
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000"
+      - "${FRONTEND_PORT:-8000}:8000"
     environment:
       SERVICE_TYPE: "flask"
       MEDIASERVER_TYPE: "jellyfin"

--- a/deployment/docker-compose-worker-nvidia.yaml
+++ b/deployment/docker-compose-worker-nvidia.yaml
@@ -11,7 +11,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest-nvidia
     container_name: audiomuse-ai-worker-instance
     ports:
-      - "8029:8000"  # Expose worker API
+      - "${WORKER_PORT:-8029}:8000"  # Expose worker API
     environment:
       SERVICE_TYPE: "worker"
       MEDIASERVER_TYPE: "jellyfin"

--- a/deployment/docker-compose-worker.yaml
+++ b/deployment/docker-compose-worker.yaml
@@ -8,7 +8,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest
     container_name: audiomuse-ai-worker-instance
     ports:
-      - "8029:8000"  # Expose worker API
+      - "${WORKER_PORT:-8029}:8000"  # Expose worker API
     environment:
       SERVICE_TYPE: "worker"
       MEDIASERVER_TYPE: "jellyfin"

--- a/deployment/docker-compose-worker_local.yaml
+++ b/deployment/docker-compose-worker_local.yaml
@@ -15,7 +15,7 @@ services:
         BASE_IMAGE: nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
     container_name: audiomuse-ai-worker-instance
     ports:
-      - "8029:8000"  # Expose worker API
+      - "${WORKER_PORT:-8029}:8000"  # Expose worker API
     environment:
       SERVICE_TYPE: "worker"
       MEDIASERVER_TYPE: "${MEDIASERVER_TYPE:-jellyfin}"

--- a/deployment/docker-compose-worker_local_cpu.yaml
+++ b/deployment/docker-compose-worker_local_cpu.yaml
@@ -14,7 +14,7 @@ services:
       # No args needed - defaults to ubuntu:22.04 (CPU-only)
     container_name: audiomuse-ai-worker-cpu-instance
     ports:
-      - "8029:8000"  # Expose worker API
+      - "${WORKER_PORT:-8029}:8000"  # Expose worker API
     environment:
       SERVICE_TYPE: "worker"
       MEDIASERVER_TYPE: "${MEDIASERVER_TYPE:-jellyfin}"

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -19,7 +19,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -29,7 +29,7 @@ services:
     image: ghcr.io/neptunehub/audiomuse-ai:latest # Reflects deployment.yaml
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000" # Map host port 8000 to container port 8000
+      - "${FRONTEND_PORT:-8000}:8000" # Map host port 8000 to container port 8000
     environment:
       SERVICE_TYPE: "flask" # Tells the container to run the Flask app
       MEDIASERVER_TYPE: "jellyfin" # Specify the media server type

--- a/deployment/docker-compose_local_cpu.yaml
+++ b/deployment/docker-compose_local_cpu.yaml
@@ -4,7 +4,7 @@ services:
     image: redis:7-alpine
     container_name: audiomuse-redis
     ports:
-      - "6379:6379" # Expose Redis port to the host
+      - "${REDIS_PORT:-6379}:6379" # Expose Redis port to the host
     volumes:
       - redis-data:/data # Persistent storage for Redis data
     restart: unless-stopped
@@ -18,7 +18,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
-      - "5432:5432" # Expose PostgreSQL port to the host
+      - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
       - postgres-data:/var/lib/postgresql/data # Persistent storage for PostgreSQL data
     restart: unless-stopped
@@ -33,7 +33,7 @@ services:
     pull_policy: never  # Always use locally built image, never pull from registry
     container_name: audiomuse-ai-flask-app
     ports:
-      - "8000:8000" # Map host port 8000 to container port 8000
+      - "${FRONTEND_PORT:-8000}:8000" # Map host port 8000 to container port 8000
     environment:
       SERVICE_TYPE: "flask" # Tells the container to run the Flask app
       MEDIASERVER_TYPE: "jellyfin" # Specify the media server type

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -99,7 +99,7 @@ Choose the appropriate file based on your media server setup.
 
     **IMPORTANT:** both `docker-compose.yaml` and `.env` file need to be in the same directory.
 5.  **Access the Application:**
-    Once the containers are up, you can access the web UI at `http://localhost:8000`.
+    Once the containers are up, you can access the web UI at `http://localhost:8000`. You can change the value of the used port by changing the FRONTEND_PORT value
 6.  **Stopping the Services:**
     ```bash
     docker compose -f deployment/docker-compose.yaml down


### PR DESCRIPTION
in relation with the issue #254 

I add 3 variables in the .env.example :

- FRONTEND_PORT : port number for the flask app ( by default it's 8000) 
- WORKER_PORT : port number for the worker (by default it's 8029)
- REDIS_PORT : port number for the Redis crawler ( default it's 6379)

Normally all the yaml file have been changer and the older default port for the database have linked with variable POSTGRES_PORT ( not changed everywhere ...).

I also add a bit of doc for mentioning the existence of variable FRONTEND_PORT

I never used podman yet so i didn't change anything on this side ( don't want to make any mistake) 
