### PR TITLE
pin mistralai lib to below 2.0

### DIFF
--- a/requirements/common-noavx2.txt
+++ b/requirements/common-noavx2.txt
@@ -16,7 +16,7 @@ ftfy
 flasgger
 sqlglot
 google-genai==1.57.0
-mistralai
+mistralai==1.12.4
 umap-learn
 pydub
 python-mpd2

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -16,7 +16,7 @@ ftfy
 flasgger
 sqlglot
 google-genai==1.57.0
-mistralai
+mistralai==1.12.4
 umap-learn 
 # Use pozalabs fork to avoid Python 3.12 SyntaxWarning until upstream releases a proper fix (see: https://github.com/jiaaro/pydub/issues/801)
 pozalabs-pydub==0.37.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -42,7 +42,7 @@ flasgger
 umap-learn
 python-mpd2
 google-genai==1.57.0
-mistralai
+mistralai==1.12.4
 
 # Notes:
 # - ffmpeg (system binary) is NOT included here — keep pydub/ffmpeg calls stubbed or


### PR DESCRIPTION
mistralai API changed in 2.0 release, leading to errors on worker start like "Error importing from app.py: cannot import name 'Mistral' from 'mistralai' (unknown location)"