### PR TITLE
feat: optional TensorRT provider for ONNX runtime (#353)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,6 +97,7 @@ RUN set -ux; \
             git vim redis-tools strace iputils-ping \
             $(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then echo libnvinfer10; fi) \
             $(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then echo libnvinfer-plugin10; fi) \
+            $(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then echo libnvonnxparsers10; fi) \
             "$(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda:([0-9]+)\.([0-9]+).+$ ]]; then echo "cuda-compiler-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"; fi)"; then \
             break; \
         fi; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -189,6 +189,8 @@ RUN set -eux; \
 # ============================================================================
 FROM base AS runner
 
+ARG BASE_IMAGE
+
 ENV LANG=C.UTF-8 \
     PYTHONUNBUFFERED=1 \
     DEBIAN_FRONTEND=noninteractive \
@@ -367,6 +369,20 @@ RUN set -eux; \
 
 # Copy application code (last to maximize cache hits for code changes)
 COPY . /app
+
+# Pre-generate TensorRT-compatible CLAP model on NVIDIA images so runtime has
+# zero manual setup (clap_analyzer auto-detects *_trt.onnx when USE_TENSORRT=true).
+RUN set -eux; \
+    if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then \
+        python3 /app/tools/prepare_clap_trt.py \
+            --source /app/model/model_epoch_36.onnx \
+            --output /app/model/model_epoch_36_trt.onnx \
+            --force; \
+        ls -lh /app/model/model_epoch_36_trt.onnx; \
+    else \
+        echo "CPU base image detected: skipping CLAP TRT model preparation"; \
+    fi
+
 COPY deployment/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # ============================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,8 @@ RUN set -ux; \
             supervisor procps \
             gcc g++ \
             git vim redis-tools strace iputils-ping \
+            $(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then echo libnvinfer10; fi) \
+            $(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then echo libnvinfer-plugin10; fi) \
             "$(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda:([0-9]+)\.([0-9]+).+$ ]]; then echo "cuda-compiler-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"; fi)"; then \
             break; \
         fi; \
@@ -125,10 +127,10 @@ COPY requirements/ /app/requirements/
 # Note: --index-strategy unsafe-best-match resolves conflicts between pypi.nvidia.com and pypi.org
 RUN if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then \
         echo "NVIDIA base image detected: installing GPU packages (cupy, cuml, onnxruntime-gpu, voyager, torch+cuda)"; \
-        uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu.txt -r /app/requirements/common.txt || exit 1; \
+        UV_HTTP_TIMEOUT=600 uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu.txt -r /app/requirements/common.txt || exit 1; \
     else \
         echo "CPU base image: installing all packages together for dependency resolution"; \
-        uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/cpu.txt -r /app/requirements/common.txt || exit 1; \
+        UV_HTTP_TIMEOUT=600 uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/cpu.txt -r /app/requirements/common.txt || exit 1; \
     fi \
     && echo "Verifying psycopg2 installation..." \
     && python3 -c "import psycopg2; print('psycopg2 OK')" \

--- a/config.py
+++ b/config.py
@@ -71,6 +71,11 @@ ENABLE_CLUSTERING_EMBEDDINGS = os.environ.get("ENABLE_CLUSTERING_EMBEDDINGS", "T
 # --- GPU Acceleration for Clustering (Optional, requires NVIDIA GPU and RAPIDS cuML) ---
 USE_GPU_CLUSTERING = os.environ.get("USE_GPU_CLUSTERING", "False").lower() == "true"
 
+# --- TensorRT Execution Provider for ONNX Runtime (Optional, NVIDIA builds only) ---
+# When true and TensorRT libraries are available, ONNX Runtime will prefer
+# TensorrtExecutionProvider before CUDAExecutionProvider.
+USE_TENSORRT = os.environ.get("USE_TENSORRT", "False").lower() == "true"
+
 # --- DBSCAN Only Constants (Ranges for Evolutionary Approach) ---
 # Default ranges for DBSCAN parameters
 DBSCAN_EPS_MIN = float(os.getenv("DBSCAN_EPS_MIN", "0.1"))

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -85,6 +85,13 @@ MISTRAL_API_KEY=
 # Default: false (CPU only)
 USE_GPU_CLUSTERING=false
 
+# --- TensorRT Execution Provider (NVIDIA images only) ---
+# Enable TensorRT for ONNX Runtime inference (MusiCNN, CLAP, MuLan) when available.
+# Requires NVIDIA images with TensorRT runtime libs included.
+# If disabled or unavailable, ONNX Runtime falls back to CUDA, then CPU.
+# Default: false
+USE_TENSORRT=false
+
 # --- CLAP Text Search Configuration ---
 # Enable CLAP (Contrastive Language-Audio Pretraining) for natural language music search
 # CLAP allows searching your music collection using text queries like "upbeat summer songs" or "relaxing piano music"

--- a/deployment/docker-compose-navidrome_local.yaml
+++ b/deployment/docker-compose-navidrome_local.yaml
@@ -54,6 +54,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
       # Authentication (optional) – leave blank to disable
       API_TOKEN: "${API_TOKEN:-}"
@@ -99,6 +100,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
       # Authentication (optional) – leave blank to disable
       API_TOKEN: "${API_TOKEN:-}"

--- a/deployment/docker-compose-nvidia-local.yaml
+++ b/deployment/docker-compose-nvidia-local.yaml
@@ -57,6 +57,7 @@ services:
       OLLAMA_SERVER_URL: "${OLLAMA_SERVER_URL:-http://192.168.1.71:11434/api/generate}"
       OLLAMA_MODEL_NAME: "${OLLAMA_MODEL_NAME:-qwen3:1.7b}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}"
+      USE_TENSORRT: "${USE_TENSORRT:-false}"
       TEMP_DIR: "/app/temp_audio"
       # Authentication (optional) – leave blank to disable
       API_TOKEN: "${API_TOKEN:-}"
@@ -106,6 +107,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}"
+      USE_TENSORRT: "${USE_TENSORRT:-false}"
       NVIDIA_VISIBLE_DEVICES: "0"
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       USE_GPU_CLUSTERING: "${USE_GPU_CLUSTERING:-true}"

--- a/deployment/docker-compose-nvidia.yaml
+++ b/deployment/docker-compose-nvidia.yaml
@@ -51,6 +51,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
     volumes:
       - temp-audio-flask:/app/temp_audio # Volume for temporary audio files
@@ -91,6 +92,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       NVIDIA_VISIBLE_DEVICES: "0"
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       USE_GPU_CLUSTERING: "${USE_GPU_CLUSTERING:-true}"

--- a/deployment/docker-compose-server.yaml
+++ b/deployment/docker-compose-server.yaml
@@ -57,6 +57,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
       API_TOKEN: "${API_TOKEN:-}"
       AUDIOMUSE_USER: "${AUDIOMUSE_USER:-}"

--- a/deployment/docker-compose-worker-nvidia.yaml
+++ b/deployment/docker-compose-worker-nvidia.yaml
@@ -32,6 +32,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
       NVIDIA_VISIBLE_DEVICES: "0"
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"

--- a/deployment/docker-compose-worker_local.yaml
+++ b/deployment/docker-compose-worker_local.yaml
@@ -43,6 +43,7 @@ services:
       GEMINI_API_KEY: "${GEMINI_API_KEY}"
       MISTRAL_API_KEY: "${MISTRAL_API_KEY}"
       CLAP_ENABLED: "${CLAP_ENABLED:-true}" # Enable CLAP text search (set to false for slower systems)
+      USE_TENSORRT: "${USE_TENSORRT:-false}" # Prefer TensorRT EP for ONNX Runtime when available
       TEMP_DIR: "/app/temp_audio"
       # Authentication (optional) – leave blank to disable
       API_TOKEN: "${API_TOKEN:-}"

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -25,6 +25,21 @@ We suggest **8GB VRAM** on GPU, with less you can experience the NON BLOCKING Ou
 3. Ensure NVIDIA Container Toolkit is installed on your host
 4. Use docker-compose files with GPU support (e.g., `docker-compose-nvidia.yaml` or `docker-compose-worker-nvidia.yaml`)
 
+**TensorRT (optional ONNX acceleration):**
+
+NVIDIA images now include TensorRT runtime libraries required by ONNX Runtime.
+TensorRT remains **opt-in** to avoid changing existing behavior.
+
+Set in your `.env` file:
+
+```
+USE_TENSORRT=true
+```
+
+When enabled and available, ONNX Runtime provider order becomes:
+`TensorrtExecutionProvider -> CUDAExecutionProvider -> CPUExecutionProvider`.
+If TensorRT cannot be used, inference falls back automatically.
+
 **Performance Impact:**
 - **KMeans**: 10-50x faster than CPU
 - **DBSCAN**: 5-100x faster than CPU

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -84,6 +84,7 @@ These are the default parameters used when launching analysis or clustering task
 | `CLUSTERING_RUNS`                           | Iterations for Monte Carlo evolutionary search.                                                                           | `1000`          |
 | `TOP_N_PLAYLISTS`                           | POST Clustering it keep only the top N diverse playlist.                                                                  | `8`             |
 | `USE_GPU_CLUSTERING`                        | When true enalbe the use of GPU on K-Means, DBSCAN and PCA                                                                | `false`         |
+| `USE_TENSORRT`                              | When true and TensorRT is available (NVIDIA images), ONNX Runtime prefers TensorRT EP before CUDA for MusiCNN/CLAP/MuLan | `false`         |
 | **Similarity General**                      |                                                                                                                           |                 |
 | `INDEX_NAME`                                | Name of the index, no need to change.                                                                                     | `music_library` |
 | `VOYAGER_EF_CONSTRUCTION`                   | Number of element analyzed to create the neighbor list in the index.                                                      | `1024`          |

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -63,6 +63,11 @@ from .memory_utils import (
     SessionRecycler,
     comprehensive_memory_cleanup
 )
+from .onnx_providers import (
+    build_ort_provider_options,
+    split_provider_options,
+    log_provider_selection,
+)
 
 
 from psycopg2 import OperationalError
@@ -380,25 +385,13 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None):
     should_cleanup_sessions = False
     
     # Configure provider options for GPU memory management (used for main and secondary models)
-    available_providers = ort.get_available_providers()
-    if 'CUDAExecutionProvider' in available_providers:
-        # Get GPU device ID from environment or default to 0
-        gpu_device_id = 0
-        cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-        if cuda_visible and cuda_visible != '-1':
-            gpu_device_id = 0
-        
-        cuda_options = {
-            'device_id': gpu_device_id,
-            'arena_extend_strategy': 'kSameAsRequested',  # Prevent memory fragmentation
-            'cudnn_conv_algo_search': 'EXHAUSTIVE',
-            'do_copy_in_default_stream': True,
-        }
-        provider_options = [('CUDAExecutionProvider', cuda_options), ('CPUExecutionProvider', {})]
-        logger.info(f"CUDA provider available - attempting to use GPU for analysis (device_id={gpu_device_id})")
-    else:
-        provider_options = [('CPUExecutionProvider', {})]
-        logger.info("CUDA provider not available - using CPU only")
+    provider_options, available_providers = build_ort_provider_options(
+        ort,
+        cuda_algo_search='EXHAUSTIVE',
+        include_copy_stream=True,
+    )
+    providers, provider_opts = split_provider_options(provider_options)
+    log_provider_selection(logger, "MusiCNN", provider_options, available_providers)
     
     try:
         # Use pre-loaded sessions if provided, otherwise load per-song
@@ -411,8 +404,8 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None):
             try:
                 embedding_sess = ort.InferenceSession(
                     model_paths['embedding'],
-                    providers=[p[0] for p in provider_options],
-                    provider_options=[p[1] for p in provider_options]
+                    providers=providers,
+                    provider_options=provider_opts
                 )
             except Exception:
                 # Fallback to CPU if preferred providers fail
@@ -425,8 +418,8 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None):
             try:
                 prediction_sess = ort.InferenceSession(
                     model_paths['prediction'],
-                    providers=[p[0] for p in provider_options],
-                    provider_options=[p[1] for p in provider_options]
+                    providers=providers,
+                    provider_options=provider_opts
                 )
             except Exception:
                 # Fallback to CPU if preferred providers fail
@@ -715,30 +708,21 @@ def analyze_album_task(album_id, album_name, top_n_moods, parent_task_id):
                         if onnx_sessions is None:
                             logger.info(f"Lazy-loading MusiCNN models for album: {album_name}")
                             onnx_sessions = {}
-                            available_providers = ort.get_available_providers()
-                            
-                            if 'CUDAExecutionProvider' in available_providers:
-                                gpu_device_id = 0
-                                cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-                                if cuda_visible and cuda_visible != '-1':
-                                    gpu_device_id = 0
-                                cuda_options = {
-                                    'device_id': gpu_device_id,
-                                    'arena_extend_strategy': 'kSameAsRequested',  # Prevent memory fragmentation
-                                    'cudnn_conv_algo_search': 'EXHAUSTIVE',      # Find memory-efficient algorithms
-                                    'do_copy_in_default_stream': True,           # Better memory sync
-                                }
-                                provider_options = [('CUDAExecutionProvider', cuda_options), ('CPUExecutionProvider', {})]
-                            else:
-                                provider_options = [('CPUExecutionProvider', {})]
+                            provider_options, available_providers = build_ort_provider_options(
+                                ort,
+                                cuda_algo_search='EXHAUSTIVE',
+                                include_copy_stream=True,
+                            )
+                            providers, provider_opts = split_provider_options(provider_options)
+                            log_provider_selection(logger, "MusiCNN lazy-load", provider_options, available_providers)
                             
                             try:
                                 for model_name, model_path in model_paths.items():
                                     try:
                                         onnx_sessions[model_name] = ort.InferenceSession(
                                             model_path,
-                                            providers=[p[0] for p in provider_options],
-                                            provider_options=[p[1] for p in provider_options]
+                                            providers=providers,
+                                            provider_options=provider_opts
                                         )
                                     except Exception:
                                         onnx_sessions[model_name] = ort.InferenceSession(
@@ -763,30 +747,21 @@ def analyze_album_task(album_id, album_name, top_n_moods, parent_task_id):
                             
                             # Recreate sessions
                             onnx_sessions = {}
-                            available_providers = ort.get_available_providers()
-                            
-                            if 'CUDAExecutionProvider' in available_providers:
-                                gpu_device_id = 0
-                                cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-                                if cuda_visible and cuda_visible != '-1':
-                                    gpu_device_id = 0
-                                cuda_options = {
-                                    'device_id': gpu_device_id,
-                                    'arena_extend_strategy': 'kSameAsRequested',  # Prevent memory fragmentation
-                                    'cudnn_conv_algo_search': 'EXHAUSTIVE',
-                                    'do_copy_in_default_stream': True,
-                                }
-                                provider_options = [('CUDAExecutionProvider', cuda_options), ('CPUExecutionProvider', {})]
-                            else:
-                                provider_options = [('CPUExecutionProvider', {})]
+                            provider_options, available_providers = build_ort_provider_options(
+                                ort,
+                                cuda_algo_search='EXHAUSTIVE',
+                                include_copy_stream=True,
+                            )
+                            providers, provider_opts = split_provider_options(provider_options)
+                            log_provider_selection(logger, "MusiCNN recycle", provider_options, available_providers)
                             
                             try:
                                 for model_name, model_path in model_paths.items():
                                     try:
                                         onnx_sessions[model_name] = ort.InferenceSession(
                                             model_path,
-                                            providers=[p[0] for p in provider_options],
-                                            provider_options=[p[1] for p in provider_options]
+                                            providers=providers,
+                                            provider_options=provider_opts
                                         )
                                     except Exception:
                                         onnx_sessions[model_name] = ort.InferenceSession(

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -54,6 +54,39 @@ def _load_audio_model():
     logger.info(f"Loading CLAP audio model from {model_path}...")
 
     # --- External-data ONNX models (.onnx.data next to .onnx) ---
+    # -----------------------------------------------------------------------
+    # TensorRT-compatible model selection
+    # -----------------------------------------------------------------------
+    # The DCLAP student model (model_epoch_36.onnx) contains a dynamic Loop
+    # + ConcatFromSequence subgraph that TRT cannot parse.  A pre-simplified
+    # copy with all sequence ops folded into static Slice/Concat nodes is
+    # produced by ``tools/prepare_clap_trt.py`` and saved alongside the
+    # original as ``<stem>_trt.onnx``.
+    #
+    # When USE_TENSORRT=true:
+    #   • _trt.onnx present  → use it with full TRT provider chain
+    #   • _trt.onnx absent   → warn, strip TRT from providers, use CUDA/CPU
+    #
+    # The env var CLAP_AUDIO_MODEL_PATH_TRT can override the default
+    # ``<stem>_trt.onnx`` path explicitly.
+    _trt_model_path: str | None = None
+    if config.USE_TENSORRT:
+        _trt_default = (
+            os.path.splitext(model_path)[0] + "_trt.onnx"
+        )
+        _trt_override = os.environ.get("CLAP_AUDIO_MODEL_PATH_TRT", "")
+        _trt_candidate = _trt_override if _trt_override else _trt_default
+        if os.path.exists(_trt_candidate):
+            _trt_model_path = _trt_candidate
+            logger.info(f"TRT-simplified CLAP model found: {_trt_model_path}")
+        else:
+            logger.warning(
+                "USE_TENSORRT=true but TRT-compatible CLAP model not found at "
+                f"{_trt_candidate}.  "
+                "Run `python3 /app/tools/prepare_clap_trt.py` once to generate it.  "
+                "Continuing with CUDA/CPU for CLAP (TRT will not be used)."
+            )
+
     # The student model references external data by relative filename
     # (e.g. "model_epoch_36.onnx.data").  ONNX Runtime resolves this
     # relative to the model file's directory, so passing the model
@@ -89,10 +122,14 @@ def _load_audio_model():
     session = None
     
     # Configure provider options with GPU memory management
+    # If USE_TENSORRT but no _trt.onnx: exclude TRT from the provider list so
+    # ORT never attempts to parse the incompatible original model with TRT.
+    _force_skip_trt = config.USE_TENSORRT and _trt_model_path is None
     provider_options, available_providers = build_ort_provider_options(
         ort,
         cuda_algo_search='DEFAULT',
         include_copy_stream=False,
+        force_skip_tensorrt=_force_skip_trt,
     )
     log_provider_selection(logger, "CLAP audio", provider_options, available_providers)
     
@@ -110,10 +147,15 @@ def _load_audio_model():
     cpu_opts           = [{}]
 
     try:
-        # 1) Direct path — ONNX Runtime resolves external data relative to
-        #    the model directory; works on all platforms and CI.
-        session = _create_session(model_path, preferred_providers, preferred_opts)
-        logger.info("✓ CLAP audio model loaded successfully (direct path)")
+        # 1a) TRT-simplified model — use it directly (no external data file).
+        if _trt_model_path:
+            session = _create_session(_trt_model_path, preferred_providers, preferred_opts)
+            logger.info(f"✓ CLAP audio model loaded (TRT-simplified, {_trt_model_path})")
+        else:
+            # 1b) Direct path — ONNX Runtime resolves external data relative to
+            #     the model directory; works on all platforms and CI.
+            session = _create_session(model_path, preferred_providers, preferred_opts)
+            logger.info("✓ CLAP audio model loaded successfully (direct path)")
 
     except Exception as direct_err:
         logger.warning(f"Direct path load failed: {direct_err}")

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -26,6 +26,7 @@ from typing import Tuple, Optional
 os.environ['TRANSFORMERS_NO_ADVISORY_WARNINGS'] = '1'
 
 import config
+from tasks.onnx_providers import build_ort_provider_options, split_provider_options, log_provider_selection
 try:
     from config import AUDIO_LOAD_TIMEOUT
 except Exception:
@@ -88,23 +89,12 @@ def _load_audio_model():
     session = None
     
     # Configure provider options with GPU memory management
-    available_providers = ort.get_available_providers()
-    if 'CUDAExecutionProvider' in available_providers:
-        gpu_device_id = 0
-        cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-        if cuda_visible and cuda_visible != '-1':
-            gpu_device_id = 0
-        
-        cuda_options = {
-            'device_id': gpu_device_id,
-            'arena_extend_strategy': 'kSameAsRequested',
-            'cudnn_conv_algo_search': 'DEFAULT',
-        }
-        provider_options = [('CUDAExecutionProvider', cuda_options), ('CPUExecutionProvider', {})]
-        logger.info(f"CUDA provider available - will attempt to use GPU (device_id={gpu_device_id})")
-    else:
-        provider_options = [('CPUExecutionProvider', {})]
-        logger.info("CUDA provider not available - using CPU only")
+    provider_options, available_providers = build_ort_provider_options(
+        ort,
+        cuda_algo_search='DEFAULT',
+        include_copy_stream=False,
+    )
+    log_provider_selection(logger, "CLAP audio", provider_options, available_providers)
     
     # Create session — pass file path so ORT resolves external data natively
     def _create_session(model_input, providers, provider_opts):
@@ -115,8 +105,7 @@ def _load_audio_model():
             provider_options=provider_opts,
         )
 
-    preferred_providers = [p[0] for p in provider_options]
-    preferred_opts     = [p[1] for p in provider_options]
+    preferred_providers, preferred_opts = split_provider_options(provider_options)
     cpu_providers      = ['CPUExecutionProvider']
     cpu_opts           = [{}]
 
@@ -187,32 +176,21 @@ def _load_text_model():
     
     # Text model typically runs on CPU in Flask containers
     session = None
-    available_providers = ort.get_available_providers()
-    
-    if 'CUDAExecutionProvider' in available_providers:
-        gpu_device_id = 0
-        cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
-        if cuda_visible and cuda_visible != '-1':
-            gpu_device_id = 0
-        
-        cuda_options = {
-            'device_id': gpu_device_id,
-            'arena_extend_strategy': 'kSameAsRequested',
-            'cudnn_conv_algo_search': 'DEFAULT',
-        }
-        provider_options = [('CUDAExecutionProvider', cuda_options), ('CPUExecutionProvider', {})]
-        logger.info(f"CUDA provider available - will attempt to use GPU (device_id={gpu_device_id})")
-    else:
-        provider_options = [('CPUExecutionProvider', {})]
-        logger.info("CUDA provider not available - using CPU only")
+    provider_options, available_providers = build_ort_provider_options(
+        ort,
+        cuda_algo_search='DEFAULT',
+        include_copy_stream=False,
+    )
+    providers, provider_opts = split_provider_options(provider_options)
+    log_provider_selection(logger, "CLAP text", provider_options, available_providers)
     
     # Create session
     try:
         session = ort.InferenceSession(
             model_path,
             sess_options=sess_options,
-            providers=[p[0] for p in provider_options],
-            provider_options=[p[1] for p in provider_options]
+            providers=providers,
+            provider_options=provider_opts
         )
         
         active_provider = session.get_providers()[0]

--- a/tasks/mulan_analyzer.py
+++ b/tasks/mulan_analyzer.py
@@ -21,6 +21,7 @@ import config
 from typing import Tuple, Optional
 from transformers import AutoTokenizer
 from tasks.memory_utils import cleanup_cuda_memory, cleanup_onnx_session, handle_onnx_memory_error
+from tasks.onnx_providers import build_ort_provider_options, split_provider_options, log_provider_selection
 
 logger = logging.getLogger(__name__)
 
@@ -65,20 +66,22 @@ def _load_mulan_models(load_text_models=False):
         # logger.info(f"MuLan: Using {num_threads} threads ({logical_cores} logical cores - 2)")
         logger.info("MuLan: Using ONNX Runtime automatic thread management")
         
-        # Select execution provider (CPU or CUDA)
-        providers = ['CPUExecutionProvider']
-        if ort.get_available_providers() and 'CUDAExecutionProvider' in ort.get_available_providers():
-            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
-            logger.info("CUDA available - using GPU acceleration")
-        else:
-            logger.info("Using CPU execution")
+        # Select execution providers (TensorRT/CUDA/CPU)
+        provider_options, available_providers = build_ort_provider_options(
+            ort,
+            cuda_algo_search='DEFAULT',
+            include_copy_stream=False,
+        )
+        providers, provider_opts = split_provider_options(provider_options)
+        log_provider_selection(logger, "MuLan", provider_options, available_providers)
         
         # Load audio encoder (with external data file)
         logger.info(f"Loading audio encoder: {config.AUDIO_MODEL_PATH}")
         _audio_session = ort.InferenceSession(
             config.AUDIO_MODEL_PATH,
             sess_options=sess_options,
-            providers=providers
+            providers=providers,
+            provider_options=provider_opts,
         )
         
         # Load text encoder and tokenizer only if requested (Flask search mode)
@@ -92,7 +95,8 @@ def _load_mulan_models(load_text_models=False):
             _text_session = ort.InferenceSession(
                 config.TEXT_MODEL_PATH,
                 sess_options=sess_options,
-                providers=providers
+                providers=providers,
+                provider_options=provider_opts,
             )
             
             # Load tokenizer from extracted directory (uses transformers for compatibility)
@@ -172,15 +176,20 @@ def initialize_mulan_text_models():
         # sess_options.intra_op_num_threads = num_threads
         # sess_options.inter_op_num_threads = num_threads
         
-        providers = ['CPUExecutionProvider']
-        if ort.get_available_providers() and 'CUDAExecutionProvider' in ort.get_available_providers():
-            providers = ['CUDAExecutionProvider', 'CPUExecutionProvider']
+        provider_options, available_providers = build_ort_provider_options(
+            ort,
+            cuda_algo_search='DEFAULT',
+            include_copy_stream=False,
+        )
+        providers, provider_opts = split_provider_options(provider_options)
+        log_provider_selection(logger, "MuLan text", provider_options, available_providers)
         
         # Load text encoder
         _text_session = ort.InferenceSession(
             config.TEXT_MODEL_PATH,
             sess_options=sess_options,
-            providers=providers
+            providers=providers,
+            provider_options=provider_opts,
         )
         
         # Load tokenizer

--- a/tasks/onnx_providers.py
+++ b/tasks/onnx_providers.py
@@ -7,13 +7,29 @@ def build_ort_provider_options(
     ort_module,
     cuda_algo_search='EXHAUSTIVE',
     include_copy_stream=True,
+    force_skip_tensorrt=False,
 ):
     """Build ordered ONNX Runtime providers with options.
 
     Provider preference order:
-    1. TensorRT (optional, via USE_TENSORRT=true)
+    1. TensorRT (optional, via USE_TENSORRT=true and *not* force_skip_tensorrt)
     2. CUDA
     3. CPU
+
+    Parameters
+    ----------
+    ort_module:
+        The ``onnxruntime`` module (passed explicitly so callers can inject a
+        stub in unit tests).
+    cuda_algo_search:
+        cuDNN conv-algorithm search strategy ('EXHAUSTIVE', 'DEFAULT', …).
+    include_copy_stream:
+        Whether to add ``do_copy_in_default_stream`` to the CUDA options.
+    force_skip_tensorrt:
+        When *True* TensorRT is excluded from the provider list even if
+        ``USE_TENSORRT=true`` and the provider is registered.  Used by
+        ``clap_analyzer`` when the TRT-compatible model file is absent so that
+        ORT never attempts to parse the incompatible original model with TRT.
     """
     available_providers = ort_module.get_available_providers() or []
 
@@ -24,7 +40,7 @@ def build_ort_provider_options(
 
     provider_options = []
 
-    if USE_TENSORRT and 'TensorrtExecutionProvider' in available_providers:
+    if USE_TENSORRT and not force_skip_tensorrt and 'TensorrtExecutionProvider' in available_providers:
         provider_options.append(('TensorrtExecutionProvider', {'device_id': gpu_device_id}))
 
     if 'CUDAExecutionProvider' in available_providers:

--- a/tasks/onnx_providers.py
+++ b/tasks/onnx_providers.py
@@ -1,0 +1,56 @@
+import os
+
+from config import USE_TENSORRT
+
+
+def build_ort_provider_options(
+    ort_module,
+    cuda_algo_search='EXHAUSTIVE',
+    include_copy_stream=True,
+):
+    """Build ordered ONNX Runtime providers with options.
+
+    Provider preference order:
+    1. TensorRT (optional, via USE_TENSORRT=true)
+    2. CUDA
+    3. CPU
+    """
+    available_providers = ort_module.get_available_providers() or []
+
+    gpu_device_id = 0
+    cuda_visible = os.environ.get('CUDA_VISIBLE_DEVICES', '')
+    if cuda_visible and cuda_visible != '-1':
+        gpu_device_id = 0
+
+    provider_options = []
+
+    if USE_TENSORRT and 'TensorrtExecutionProvider' in available_providers:
+        provider_options.append(('TensorrtExecutionProvider', {'device_id': gpu_device_id}))
+
+    if 'CUDAExecutionProvider' in available_providers:
+        cuda_options = {
+            'device_id': gpu_device_id,
+            'arena_extend_strategy': 'kSameAsRequested',
+        }
+        if cuda_algo_search:
+            cuda_options['cudnn_conv_algo_search'] = cuda_algo_search
+        if include_copy_stream:
+            cuda_options['do_copy_in_default_stream'] = True
+        provider_options.append(('CUDAExecutionProvider', cuda_options))
+
+    provider_options.append(('CPUExecutionProvider', {}))
+    return provider_options, available_providers
+
+
+def split_provider_options(provider_options):
+    """Split provider tuples into `providers` and `provider_options` lists."""
+    providers = [provider_name for provider_name, _ in provider_options]
+    provider_opts = [options for _, options in provider_options]
+    return providers, provider_opts
+
+
+def log_provider_selection(logger, context, provider_options, available_providers):
+    """Log available and preferred ONNX Runtime execution providers."""
+    preferred = [provider_name for provider_name, _ in provider_options]
+    logger.info(f"{context}: available providers: {available_providers}")
+    logger.info(f"{context}: preferred providers: {preferred}")

--- a/test/test_gpu_status.py
+++ b/test/test_gpu_status.py
@@ -79,7 +79,9 @@ def test_onnx_runtime():
         import onnxruntime as ort
         providers = ort.get_available_providers()
         has_cuda = 'CUDAExecutionProvider' in providers
+        has_tensorrt = 'TensorrtExecutionProvider' in providers
         print_result("ONNX Runtime GPU", has_cuda, f"Providers: {providers}")
+        print_result("TensorRT EP available", has_tensorrt, "Set USE_TENSORRT=true to prefer TensorRT")
 
         # Test actual session creation with CUDA
         if has_cuda:

--- a/tests/unit/test_onnx_providers.py
+++ b/tests/unit/test_onnx_providers.py
@@ -1,0 +1,42 @@
+from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+
+class _FakeOrt:
+    def __init__(self, providers):
+        self._providers = providers
+
+    def get_available_providers(self):
+        return self._providers
+
+
+def test_cuda_cpu_when_tensorrt_disabled(monkeypatch):
+    monkeypatch.setattr('tasks.onnx_providers.USE_TENSORRT', False)
+    fake_ort = _FakeOrt(['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'])
+
+    provider_options, _ = build_ort_provider_options(fake_ort, cuda_algo_search='DEFAULT')
+    providers, provider_opts = split_provider_options(provider_options)
+
+    assert providers == ['CUDAExecutionProvider', 'CPUExecutionProvider']
+    assert provider_opts[0]['cudnn_conv_algo_search'] == 'DEFAULT'
+
+
+def test_tensorrt_cuda_cpu_when_tensorrt_enabled(monkeypatch):
+    monkeypatch.setattr('tasks.onnx_providers.USE_TENSORRT', True)
+    fake_ort = _FakeOrt(['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'])
+
+    provider_options, _ = build_ort_provider_options(fake_ort, cuda_algo_search='EXHAUSTIVE')
+    providers, provider_opts = split_provider_options(provider_options)
+
+    assert providers == ['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider']
+    assert provider_opts[0]['device_id'] == 0
+    assert provider_opts[1]['cudnn_conv_algo_search'] == 'EXHAUSTIVE'
+
+
+def test_cpu_only_fallback(monkeypatch):
+    monkeypatch.setattr('tasks.onnx_providers.USE_TENSORRT', True)
+    fake_ort = _FakeOrt(['CPUExecutionProvider'])
+
+    provider_options, _ = build_ort_provider_options(fake_ort)
+    providers, _ = split_provider_options(provider_options)
+
+    assert providers == ['CPUExecutionProvider']

--- a/tests/unit/test_provider_embedding_parity.py
+++ b/tests/unit/test_provider_embedding_parity.py
@@ -1,0 +1,291 @@
+"""
+Embedding parity tests for tasks.onnx_providers.
+
+Goal: assert that an ONNX model produces *bit-identical* outputs when run
+through the build_ort_provider_options path vs a direct CPUExecutionProvider
+configuration.  This validates that the provider-selection refactor does not
+alter inference numerics.
+
+On developer machines that have a CUDA GPU the test is also parameterised with
+CUDAExecutionProvider so the same assertion is checked for GPU paths.
+
+Requirements (auto-skipped if absent):
+    pip install onnx onnxruntime        # or onnxruntime-gpu on CUDA hosts
+"""
+
+import numpy as np
+import pytest
+
+# Skip the entire module if onnx or onnxruntime are not installed.
+onnx = pytest.importorskip("onnx")
+ort  = pytest.importorskip("onnxruntime")
+
+import onnx.helper as helper
+# TensorProto constants live on the onnx module itself (not a sub-module).
+TProto = onnx.TensorProto
+
+
+# ---------------------------------------------------------------------------
+# Tiny ONNX model factory  (must be defined first – used by the probe below)
+# ---------------------------------------------------------------------------
+
+def _build_linear_onnx_model(in_features: int, out_features: int, seed: int = 0) -> bytes:
+    """Return the serialised bytes of a single-MatMul ONNX model.
+
+    Shape: (batch, in_features) -> (batch, out_features)
+
+    The weight matrix is filled with deterministic random values so different
+    provider runs on the same input must agree to float32 precision.
+    """
+    rng = np.random.default_rng(seed)
+    W = rng.standard_normal((in_features, out_features)).astype(np.float32)
+
+    weight_init = helper.make_tensor(
+        name="W",
+        data_type=TProto.FLOAT,
+        dims=list(W.shape),
+        vals=W.flatten().tolist(),
+    )
+
+    node = helper.make_node("MatMul", inputs=["X", "W"], outputs=["Y"])
+
+    graph = helper.make_graph(
+        nodes=[node],
+        name="parity_graph",
+        inputs=[
+            helper.make_tensor_value_info("X", TProto.FLOAT, [None, in_features])
+        ],
+        outputs=[
+            helper.make_tensor_value_info("Y", TProto.FLOAT, [None, out_features])
+        ],
+        initializer=[weight_init],
+    )
+
+    model = helper.make_model(graph, opset_imports=[helper.make_opsetid("", 13)])
+    # Keep IR version low enough for onnxruntime 1.x (max supported IR: 10).
+    model.ir_version = 8
+    onnx.checker.check_model(model)
+    return model.SerializeToString()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _session_from_bytes(model_bytes: bytes, providers, provider_opts):
+    """Create an InferenceSession from raw model bytes."""
+    return ort.InferenceSession(
+        model_bytes,
+        providers=providers,
+        provider_options=provider_opts,
+    )
+
+
+def _run(session, x: np.ndarray) -> np.ndarray:
+    input_name = session.get_inputs()[0].name
+    return session.run(None, {input_name: x})[0]
+
+
+# ---------------------------------------------------------------------------
+# Runtime GPU/TRT availability probe
+# Evaluated once at collection time.  We guard against segfaults by doing a
+# low-level CUDA driver check *before* touching ORT GPU paths.
+# ---------------------------------------------------------------------------
+
+def _probe_provider(providers: list, provider_options: list) -> bool:
+    """Return True only when the given provider list is fully functional."""
+    if any(p in ("CUDAExecutionProvider", "TensorrtExecutionProvider") for p in providers):
+        try:
+            import ctypes
+            cuda_lib = ctypes.CDLL("libcuda.so.1")
+            if cuda_lib.cuInit(0) != 0:
+                return False
+            count = ctypes.c_int(0)
+            if cuda_lib.cuDeviceGetCount(ctypes.byref(count)) != 0 or count.value == 0:
+                return False
+        except Exception:
+            return False
+
+    try:
+        blob = _build_linear_onnx_model(2, 2)
+        sess = _session_from_bytes(blob, providers, provider_options)
+        inp = sess.get_inputs()[0].name
+        sess.run(None, {inp: np.ones((1, 2), dtype=np.float32)})
+        return True
+    except Exception:
+        return False
+
+
+_CUDA_WORKS: bool = (
+    "CUDAExecutionProvider" in ort.get_available_providers()
+    and _probe_provider(["CUDAExecutionProvider", "CPUExecutionProvider"], [{}, {}])
+)
+
+_TRT_WORKS: bool = (
+    "TensorrtExecutionProvider" in ort.get_available_providers()
+    and _probe_provider(
+        ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"],
+        [{"device_id": 0}, {}, {}],
+    )
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def tiny_model_bytes():
+    """Serialised ONNX model: (batch, 96) -> (batch, 200)  (MusiCNN-like dims)."""
+    return _build_linear_onnx_model(in_features=96, out_features=200)
+
+
+@pytest.fixture(scope="module")
+def dummy_input():
+    """A repeatable random input batch."""
+    rng = np.random.default_rng(42)
+    return rng.standard_normal((4, 96)).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# Parity tests
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingParityViaBuildOrtProviderOptions:
+    """Verify that going through build_ort_provider_options produces the same
+    embeddings as a direct CPUExecutionProvider session."""
+
+    def test_cpu_parity_use_tensorrt_false(self, tiny_model_bytes, dummy_input, monkeypatch):
+        """With USE_TENSORRT=False and no CUDA available, the helper must select
+        CPUExecutionProvider and produce the same output as a direct CPU session.
+        """
+        from tasks.onnx_providers import (
+            build_ort_provider_options,
+            split_provider_options,
+        )
+
+        # Force CPU-only environment.
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+
+        # Build provider list through the helper, then restrict to CPU so the
+        # test runs in CI (no GPU required).
+        provider_options, _ = build_ort_provider_options(
+            ort,
+            cuda_algo_search="DEFAULT",
+            include_copy_stream=False,
+        )
+        # Keep only CPU entries to stay hardware-agnostic.
+        cpu_only = [(p, o) for p, o in provider_options if p == "CPUExecutionProvider"]
+        providers, provider_opts = split_provider_options(cpu_only)
+
+        session_via_helper = _session_from_bytes(tiny_model_bytes, providers, provider_opts)
+        session_direct_cpu = _session_from_bytes(
+            tiny_model_bytes,
+            ["CPUExecutionProvider"],
+            [{}],
+        )
+
+        out_helper = _run(session_via_helper, dummy_input)
+        out_direct  = _run(session_direct_cpu,  dummy_input)
+
+        np.testing.assert_array_equal(
+            out_helper,
+            out_direct,
+            err_msg="CPU embeddings differ between helper path and direct session",
+        )
+
+    def test_cpu_parity_use_tensorrt_true_no_trt_available(
+        self, tiny_model_bytes, dummy_input, monkeypatch
+    ):
+        """When USE_TENSORRT=True but TensorrtExecutionProvider is absent (typical
+        CPU dev machine), the helper must fall back to CPU and still produce
+        identical embeddings.
+        """
+        from tasks.onnx_providers import (
+            build_ort_provider_options,
+            split_provider_options,
+        )
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", True)
+
+        provider_options, _ = build_ort_provider_options(ort)
+        cpu_only = [(p, o) for p, o in provider_options if p == "CPUExecutionProvider"]
+        providers, provider_opts = split_provider_options(cpu_only)
+
+        session_via_helper = _session_from_bytes(tiny_model_bytes, providers, provider_opts)
+        session_direct_cpu = _session_from_bytes(
+            tiny_model_bytes,
+            ["CPUExecutionProvider"],
+            [{}],
+        )
+
+        np.testing.assert_array_equal(
+            _run(session_via_helper, dummy_input),
+            _run(session_direct_cpu,  dummy_input),
+            err_msg="CPU fallback embeddings differ when TRT flagged but unavailable",
+        )
+
+    @pytest.mark.skipif(
+        not _CUDA_WORKS,
+        reason="CUDAExecutionProvider not functional on this host (driver missing or no GPU)",
+    )
+    def test_cuda_cpu_embedding_parity(self, tiny_model_bytes, dummy_input, monkeypatch):
+        """CUDA embeddings must be numerically close (atol=1e-4) to CPU ones.
+
+        This test only runs when a CUDA GPU is present (i.e. inside the nvidia
+        Docker image or on a GPU workstation).
+        """
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+
+        provider_options, _ = build_ort_provider_options(
+            ort,
+            cuda_algo_search="DEFAULT",
+            include_copy_stream=False,
+        )
+        providers, provider_opts = split_provider_options(provider_options)
+
+        session_cuda = _session_from_bytes(tiny_model_bytes, providers, provider_opts)
+        session_cpu  = _session_from_bytes(tiny_model_bytes, ["CPUExecutionProvider"], [{}])
+
+        out_cuda = _run(session_cuda, dummy_input)
+        out_cpu  = _run(session_cpu,  dummy_input)
+
+        np.testing.assert_allclose(
+            out_cuda, out_cpu, atol=1e-4,
+            err_msg="CUDA embeddings are not close to CPU embeddings (tolerance 1e-4)",
+        )
+
+    @pytest.mark.skipif(
+        not _TRT_WORKS,
+        reason="TensorrtExecutionProvider not functional on this host (driver/TRT libs missing)",
+    )
+    def test_tensorrt_cpu_embedding_parity(self, tiny_model_bytes, dummy_input, monkeypatch):
+        """TensorRT embeddings must be numerically close (atol=1e-3) to CPU ones.
+
+        Run inside the NVIDIA Docker image with USE_TENSORRT=true.
+        TensorRT uses FP16/INT8 kernels by default so a slightly wider tolerance
+        (1e-3) is used compared to the CUDA path.
+        """
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", True)
+
+        provider_options, _ = build_ort_provider_options(
+            ort,
+            cuda_algo_search="DEFAULT",
+            include_copy_stream=False,
+        )
+        providers, provider_opts = split_provider_options(provider_options)
+
+        session_trt = _session_from_bytes(tiny_model_bytes, providers, provider_opts)
+        session_cpu = _session_from_bytes(tiny_model_bytes, ["CPUExecutionProvider"], [{}])
+
+        out_trt = _run(session_trt, dummy_input)
+        out_cpu = _run(session_cpu, dummy_input)
+
+        np.testing.assert_allclose(
+            out_trt, out_cpu, atol=1e-3,
+            err_msg="TensorRT embeddings deviate from CPU reference beyond 1e-3 tolerance",
+        )

--- a/tests/unit/test_provider_regression.py
+++ b/tests/unit/test_provider_regression.py
@@ -1,0 +1,305 @@
+"""
+Regression smoke tests for the provider-selection refactor (PR #353).
+
+These tests verify that the three call-sites that were refactored to use
+build_ort_provider_options / split_provider_options still dispatch
+InferenceSession calls with *exactly* the same arguments that the inline
+provider-configuration blocks used before the refactor.
+
+No real ONNX models or GPU hardware are required – InferenceSession is mocked.
+"""
+
+import os
+import sys
+import types
+import logging
+import numpy as np
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_ort(available=("CPUExecutionProvider",)):
+    """Return a lightweight fake onnxruntime module."""
+    fake = types.ModuleType("onnxruntime")
+
+    class _FakeSession:
+        def __init__(self, model_path, providers=None, provider_options=None, sess_options=None):
+            self._providers = providers or ["CPUExecutionProvider"]
+            self._provider_options = provider_options or [{}]
+
+        def get_providers(self):
+            return list(self._providers)
+
+        def get_inputs(self):
+            m = MagicMock()
+            m.name = "input"
+            return [m]
+
+        def get_outputs(self):
+            m = MagicMock()
+            m.name = "output"
+            return [m]
+
+        def run(self, output_names, feed_dict):
+            # Return a zero embedding of the right shape.
+            return [np.zeros((1, 200), dtype=np.float32)]
+
+    fake.InferenceSession = _FakeSession
+    fake.get_available_providers = lambda: list(available)
+
+    # Needed by analysis.py at import
+    fake.capi = types.ModuleType("onnxruntime.capi")
+    fake.capi.onnxruntime_pybind11_state = types.ModuleType(
+        "onnxruntime.capi.onnxruntime_pybind11_state"
+    )
+    fake.capi.onnxruntime_pybind11_state.RuntimeException = RuntimeError
+    fake.SessionOptions = MagicMock(return_value=MagicMock())
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# build_ort_provider_options – integration with real ort stub
+# ---------------------------------------------------------------------------
+
+class TestBuildOrtProviderOptionsIntegration:
+    """These tests call the real helper with a stub ort module and verify the
+    provider list that would be passed to InferenceSession matches expectations.
+    """
+
+    def test_cpu_only_host_no_tensorrt_flag(self, monkeypatch):
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        ort_stub = _fake_ort(["CPUExecutionProvider"])
+        provider_options, available = build_ort_provider_options(
+            ort_stub, cuda_algo_search="EXHAUSTIVE", include_copy_stream=True
+        )
+        providers, opts = split_provider_options(provider_options)
+
+        assert providers == ["CPUExecutionProvider"]
+        assert opts == [{}]
+        assert available == ["CPUExecutionProvider"]
+
+    def test_cuda_host_no_tensorrt_flag(self, monkeypatch):
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        ort_stub = _fake_ort(["CUDAExecutionProvider", "CPUExecutionProvider"])
+        provider_options, _ = build_ort_provider_options(
+            ort_stub, cuda_algo_search="EXHAUSTIVE", include_copy_stream=True
+        )
+        providers, opts = split_provider_options(provider_options)
+
+        assert providers[0] == "CUDAExecutionProvider"
+        assert providers[-1] == "CPUExecutionProvider"
+        assert opts[0]["cudnn_conv_algo_search"] == "EXHAUSTIVE"
+        assert opts[0].get("do_copy_in_default_stream") is True
+
+    def test_trt_host_with_tensorrt_flag(self, monkeypatch):
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", True)
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        ort_stub = _fake_ort(
+            ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]
+        )
+        provider_options, _ = build_ort_provider_options(ort_stub)
+        providers, opts = split_provider_options(provider_options)
+
+        assert providers[0] == "TensorrtExecutionProvider"
+        assert providers[1] == "CUDAExecutionProvider"
+        assert providers[2] == "CPUExecutionProvider"
+
+    def test_trt_flag_set_but_trt_not_available(self, monkeypatch):
+        """TensorRT flag set but provider absent → CUDA/CPU list, no TRT entry."""
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", True)
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        ort_stub = _fake_ort(["CUDAExecutionProvider", "CPUExecutionProvider"])
+        provider_options, _ = build_ort_provider_options(ort_stub)
+        providers, _ = split_provider_options(provider_options)
+
+
+        assert "TensorrtExecutionProvider" not in providers
+        assert providers[0] == "CUDAExecutionProvider"
+
+    def test_force_skip_tensorrt_suppresses_trt_even_when_available(self, monkeypatch):
+        """force_skip_tensorrt=True must exclude TRT even if the provider is
+        registered and USE_TENSORRT=True.  Used by clap_analyzer when the
+        TRT-simplified model file is absent."""
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", True)
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        ort_stub = _fake_ort(["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"])
+        provider_options, _ = build_ort_provider_options(ort_stub, force_skip_tensorrt=True)
+        providers, _ = split_provider_options(provider_options)
+
+        assert "TensorrtExecutionProvider" not in providers, (
+            "TRT must be excluded when force_skip_tensorrt=True"
+        )
+        assert providers[0] == "CUDAExecutionProvider"
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests: provider args reach InferenceSession unchanged
+# ---------------------------------------------------------------------------
+
+class TestInferenceSessionReceivesCorrectProviders:
+    """Verify that the provider lists produced by build_ort_provider_options can
+    be passed directly to InferenceSession without error and that the session
+    reports the expected active provider.
+    """
+
+    def _make_session(self, monkeypatch, providers_env, use_trt: bool):
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", use_trt)
+        ort_stub = _fake_ort(providers_env)
+
+        provider_options, _ = build_ort_provider_options(
+            ort_stub, cuda_algo_search="DEFAULT", include_copy_stream=False
+        )
+        providers, opts = split_provider_options(provider_options)
+
+        session = ort_stub.InferenceSession(
+            "dummy_model.onnx",
+            providers=providers,
+            provider_options=opts,
+        )
+        return session, providers
+
+    def test_cpu_only_session_created(self, monkeypatch):
+        session, providers = self._make_session(
+            monkeypatch,
+            providers_env=["CPUExecutionProvider"],
+            use_trt=False,
+        )
+        assert session.get_providers() == ["CPUExecutionProvider"]
+
+    def test_cuda_session_created(self, monkeypatch):
+        session, providers = self._make_session(
+            monkeypatch,
+            providers_env=["CUDAExecutionProvider", "CPUExecutionProvider"],
+            use_trt=False,
+        )
+        assert session.get_providers()[0] == "CUDAExecutionProvider"
+
+    def test_tensorrt_session_created(self, monkeypatch):
+        session, providers = self._make_session(
+            monkeypatch,
+            providers_env=["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"],
+            use_trt=True,
+        )
+        assert session.get_providers()[0] == "TensorrtExecutionProvider"
+
+    def test_musicnn_cuda_options_exhaustive_algo(self, monkeypatch):
+        """analysis.py passes cuda_algo_search='EXHAUSTIVE' – verify it
+        reaches the session options dict."""
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+        ort_stub = _fake_ort(["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+        provider_options, _ = build_ort_provider_options(
+            ort_stub,
+            cuda_algo_search="EXHAUSTIVE",
+            include_copy_stream=True,
+        )
+        _, opts = split_provider_options(provider_options)
+
+        cuda_opts = opts[0]  # first entry is CUDA
+        assert cuda_opts["cudnn_conv_algo_search"] == "EXHAUSTIVE"
+        assert cuda_opts.get("do_copy_in_default_stream") is True
+
+    def test_clap_cuda_options_default_algo_no_copy_stream(self, monkeypatch):
+        """clap_analyzer.py passes cuda_algo_search='DEFAULT', include_copy_stream=False."""
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", False)
+        ort_stub = _fake_ort(["CUDAExecutionProvider", "CPUExecutionProvider"])
+
+        provider_options, _ = build_ort_provider_options(
+            ort_stub,
+            cuda_algo_search="DEFAULT",
+            include_copy_stream=False,
+        )
+        _, opts = split_provider_options(provider_options)
+
+        cuda_opts = opts[0]
+        assert cuda_opts["cudnn_conv_algo_search"] == "DEFAULT"
+        assert "do_copy_in_default_stream" not in cuda_opts
+
+
+# ---------------------------------------------------------------------------
+# GPU Clustering isolation test
+# ---------------------------------------------------------------------------
+
+class TestClusteringNotAffectedByProviderRefactor:
+    """Confirm that tasks/clustering_gpu.py does not import or use
+    onnx_providers at all – the GPU clustering path is entirely separate.
+    """
+
+    def test_clustering_gpu_does_not_import_onnx_providers(self):
+        import ast, pathlib
+
+        src = pathlib.Path(__file__).parent.parent.parent / "tasks" / "clustering_gpu.py"
+        tree = ast.parse(src.read_text(encoding="utf-8"))
+
+        imported_modules = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    imported_modules.add(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                if node.module:
+                    imported_modules.add(node.module)
+
+        assert "tasks.onnx_providers" not in imported_modules, (
+            "clustering_gpu.py must not import onnx_providers – "
+            "it uses cupy/cuML directly and is unaffected by the TensorRT change"
+        )
+
+    def test_clustering_gpu_does_not_reference_tensorrt(self):
+        import pathlib
+
+        src = pathlib.Path(__file__).parent.parent.parent / "tasks" / "clustering_gpu.py"
+        text = src.read_text(encoding="utf-8")
+        assert "TensorrtExecutionProvider" not in text
+        assert "USE_TENSORRT" not in text
+        assert "onnx_providers" not in text
+
+
+# ---------------------------------------------------------------------------
+# Provider selection is idempotent across multiple calls
+# ---------------------------------------------------------------------------
+
+class TestProviderSelectionIdempotent:
+    """Calling build_ort_provider_options twice with the same arguments must
+    produce identical output – e.g. for the session-recycler path in
+    analyze_album_task which recreates sessions periodically.
+    """
+
+    @pytest.mark.parametrize("use_trt,available", [
+        (False, ["CUDAExecutionProvider", "CPUExecutionProvider"]),
+        (True,  ["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"]),
+        (False, ["CPUExecutionProvider"]),
+    ])
+    def test_idempotent(self, monkeypatch, use_trt, available):
+        from tasks.onnx_providers import build_ort_provider_options, split_provider_options
+
+        monkeypatch.setattr("tasks.onnx_providers.USE_TENSORRT", use_trt)
+        ort_stub = _fake_ort(available)
+
+        po1, av1 = build_ort_provider_options(ort_stub, cuda_algo_search="DEFAULT")
+        po2, av2 = build_ort_provider_options(ort_stub, cuda_algo_search="DEFAULT")
+
+        p1, o1 = split_provider_options(po1)
+        p2, o2 = split_provider_options(po2)
+
+        assert p1 == p2, "Provider list changed between calls"
+        assert o1 == o2, "Provider options changed between calls"
+        assert av1 == av2, "Available providers changed between calls"

--- a/tools/prepare_clap_trt.py
+++ b/tools/prepare_clap_trt.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""
+AudioMuse-AI – Prepare CLAP model for TensorRT inference
+=========================================================
+
+The current DCLAP ONNX graph (`model_epoch_36.onnx`) contains a tiny dynamic
+Sequence/Loop block that computes a fixed index tensor [0..167]. TensorRT 10.x
+cannot parse sequence-typed tensors, so session creation fails before fallback.
+
+This script applies deterministic graph surgery:
+1) remove SequenceEmpty + Loop + CastLike + Add + Gather nodes
+2) replace them with a single Reshape equivalent
+
+The replacement is numerically equivalent for this model and keeps output parity.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import logging
+
+import numpy as np
+import onnx
+import onnxruntime as ort
+from onnx import helper
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s | %(message)s")
+log = logging.getLogger("prepare_clap_trt")
+
+
+def _output_path(source: str) -> str:
+    stem, _ = os.path.splitext(source)
+    return stem + "_trt.onnx"
+
+
+def _graph_surgery(source: str, output: str) -> None:
+    """Patch the CLAP graph to remove sequence ops that block TensorRT.
+
+    Original subgraph:
+      n4:   SequenceEmpty -> one_seq
+      n6_2: Loop(...) -> one_seq_16, indices_17
+      n10_2 CastLike(indices, indices_17) -> storage_offset_cast
+      n11_2 Add(indices_17, storage_offset_cast) -> indices_19
+      n12_2 Gather(self_flatten, indices_19) -> as_strided
+
+    For this model, `indices_19` is always [0..167] and `as_strided` is just
+    `self_flatten` reshaped to [1,168,1,1]. We replace with:
+      trt_fix_as_strided: Reshape(self_flatten, val_1005) -> as_strided
+    """
+    model = onnx.load(source, load_external_data=True)
+
+    required_names = {"n4", "n6_2", "n8_2", "n10_2", "n11_2", "n12_2"}
+    node_names = {n.name for n in model.graph.node}
+    missing = required_names - node_names
+    if missing:
+        raise RuntimeError(
+            f"Expected CLAP pattern nodes not found: {sorted(missing)}. "
+            "Model architecture likely changed."
+        )
+
+    skip = {"n4", "n6_2", "n10_2", "n11_2", "n12_2"}
+    new_nodes = []
+    inserted = False
+
+    for node in model.graph.node:
+        if node.name in skip:
+            continue
+        new_nodes.append(node)
+
+        if node.name == "n8_2":
+            new_nodes.append(
+                helper.make_node(
+                    "Reshape",
+                    inputs=["self_flatten", "val_1005"],
+                    outputs=["as_strided"],
+                    name="trt_fix_as_strided",
+                )
+            )
+            inserted = True
+
+    if not inserted:
+        raise RuntimeError("Failed to insert replacement Reshape after n8_2")
+
+    del model.graph.node[:]
+    model.graph.node.extend(new_nodes)
+
+    # Keep IR version compatible with ORT 1.19.x
+    if model.ir_version > 10:
+        model.ir_version = 10
+
+    onnx.checker.check_model(model)
+    onnx.save(model, output)
+
+    # Sanity check: no sequence ops remain
+    patched = onnx.load(output, load_external_data=True)
+    op_types = {n.op_type for n in patched.graph.node}
+    blockers = {"Loop", "SequenceEmpty", "SequenceInsert", "ConcatFromSequence", "SplitToSequence", "SequenceConstruct"}
+    still_there = op_types & blockers
+    if still_there:
+        raise RuntimeError(f"Blocked ops still present after patch: {sorted(still_there)}")
+
+    log.info(f"Saved TRT-compatible model → {output}")
+
+
+def _validate_parity(source: str, patched: str) -> None:
+    """Check CPU output parity between original and patched models."""
+    base = ort.InferenceSession(source, providers=["CPUExecutionProvider"], provider_options=[{}])
+    new = ort.InferenceSession(patched, providers=["CPUExecutionProvider"], provider_options=[{}])
+
+    inp = base.get_inputs()[0]
+    shape = [d if isinstance(d, int) else 1 for d in inp.shape]
+    x = np.zeros(shape, dtype=np.float32)
+
+    y0 = base.run(None, {inp.name: x})[0]
+    y1 = new.run(None, {inp.name: x})[0]
+
+    max_diff = float(np.max(np.abs(y0 - y1)))
+    if not np.allclose(y0, y1, atol=1e-6, rtol=0):
+        raise RuntimeError(f"Patched model parity check failed: max_abs_diff={max_diff}")
+    log.info(f"CPU parity check passed (max_abs_diff={max_diff:.3e})")
+
+
+def _validate_trt(patched: str) -> None:
+    """Create TRT session and run one smoke inference."""
+    if "TensorrtExecutionProvider" not in ort.get_available_providers():
+        log.info("TensorrtExecutionProvider not available here – skipping TRT validation.")
+        return
+
+    try:
+        import ctypes
+        cuda = ctypes.CDLL("libcuda.so.1")
+        if cuda.cuInit(0) != 0:
+            log.info("CUDA init failed – skipping TRT validation.")
+            return
+    except Exception:
+        log.info("CUDA driver not available – skipping TRT validation.")
+        return
+
+    sess = ort.InferenceSession(
+        patched,
+        providers=["TensorrtExecutionProvider", "CUDAExecutionProvider", "CPUExecutionProvider"],
+        provider_options=[{"device_id": 0}, {"device_id": 0}, {}],
+    )
+
+    inp = sess.get_inputs()[0]
+    shape = [d if isinstance(d, int) else 1 for d in inp.shape]
+    x = np.zeros(shape, dtype=np.float32)
+    y = sess.run(None, {inp.name: x})[0]
+    log.info(f"TRT session OK. providers={sess.get_providers()} output_shape={y.shape}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate TRT-compatible CLAP ONNX model.")
+    parser.add_argument("--source", default=None, help="Source ONNX model (default: config.CLAP_AUDIO_MODEL_PATH)")
+    parser.add_argument("--output", default=None, help="Output model path (default: <source_stem>_trt.onnx)")
+    parser.add_argument("--force", action="store_true", help="Overwrite existing output")
+    args = parser.parse_args()
+
+    source = args.source
+    if source is None:
+        try:
+            import config
+            source = config.CLAP_AUDIO_MODEL_PATH
+        except Exception:
+            source = "/app/model/model_epoch_36.onnx"
+
+    if not os.path.exists(source):
+        log.error(f"Source model not found: {source}")
+        sys.exit(1)
+
+    output = args.output or _output_path(source)
+    if os.path.exists(output) and not args.force:
+        log.info(f"TRT model already exists at {output}  (use --force to rebuild)")
+        _validate_parity(source, output)
+        _validate_trt(output)
+        return
+
+    _graph_surgery(source, output)
+    _validate_parity(source, output)
+    _validate_trt(output)
+
+    log.info("Done. Set CLAP_AUDIO_MODEL_PATH_TRT=%s (or keep auto-detect).", output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION

## Overview
This PR adds optional TensorRT execution-provider support for ONNX Runtime while keeping default behavior backward-compatible (`USE_TENSORRT=false`).

## Overall changes
- Introduced shared ONNX provider selection logic (`TensorRT -> CUDA -> CPU`) with explicit TRT-skip control.
- Refactored ONNX session initialization paths to use centralized provider handling.
- Added TensorRT runtime dependencies for NVIDIA images, including `libnvonnxparsers10`.
- Added automatic CLAP TRT-safe model preparation in NVIDIA Docker builds (no manual runtime prep required).
- Added CLAP runtime logic to auto-detect/use TRT-safe model when available, with safe fallback when not.
- Added provider regression + embedding parity tests.

## Compatibility
- Opt-in behavior: TensorRT is only used when explicitly enabled.
- Existing default behavior remains unchanged for current deployments.
