### PR TITLE
fix(ui): dark-mode restore warning and scrollable sidebar

### DIFF
--- a/static/menu.css
+++ b/static/menu.css
@@ -9,6 +9,8 @@
     color: white;
     padding: 1.5rem;
     height: 100vh;
+    overflow-y: auto;
+    overscroll-behavior: contain;
     position: fixed;
     top: 0;
     left: 0;

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -20,10 +20,20 @@
     .restore-confirm-area {
         margin-top: 1rem;
         padding: 1rem;
-        background-color: var(--status-error-bg, #fef2f2);
+        background-color: #fef2f2;
         border: 1px solid var(--color-danger, #ef4444);
         border-radius: 8px;
         display: none;
+        color: #7f1d1d;
+    }
+    body.dark-mode .restore-confirm-area,
+    html.dark-mode .restore-confirm-area {
+        background-color: rgba(239, 68, 68, 0.12);
+        color: var(--text-main);
+    }
+    body.dark-mode .restore-confirm-area p,
+    html.dark-mode .restore-confirm-area p {
+        color: var(--text-main) !important;
     }
     .restore-confirm-area.visible {
         display: block;


### PR DESCRIPTION
- **Backup page:** the `.restore-confirm-area` warning box used a hardcoded light-pink background with no dark-mode override, and the inline-styled `<p>` inside pinned its color to `var(--text-main)` (near-white in dark mode), producing unreadable light-on-light text. Added a `html.dark-mode` / `body.dark-mode` override that switches the box to a translucent red background and forces readable text (including an `!important` on the inline-styled `<p>`).
- **Sidebar:** `.sidebar` was `height: 100vh` with no `overflow`, so nav items past the viewport were clipped and unreachable. Added `overflow-y: auto` plus `overscroll-behavior: contain` to prevent scroll-chaining to the page body.