### PR TITLE
refactor: mini fixes

### DIFF
--- a/app.py
+++ b/app.py
@@ -780,7 +780,6 @@ def listen_for_index_reloads():
   """
   # Create a new Redis connection for this thread.
   # Sharing the main redis_conn object across threads is not recommended.
-  from redis import Redis
   thread_redis_conn = Redis.from_url(
     REDIS_URL,
     socket_connect_timeout=30,

--- a/tasks/clustering.py
+++ b/tasks/clustering.py
@@ -657,7 +657,6 @@ def _monitor_and_process_batches(state_dict, parent_task_id, initial_check=False
     CRITICAL: This prevents the main task from hanging at 4980/5000 runs
     by implementing timeouts and forced progress tracking.
     """
-    import time
     from app_helper import (redis_conn, get_child_tasks_from_db, get_task_info_from_db,
                     TASK_STATUS_SUCCESS, TASK_STATUS_FAILURE, TASK_STATUS_REVOKED, 
                     TASK_STATUS_PENDING, TASK_STATUS_STARTED, TASK_STATUS_PROGRESS)
@@ -893,7 +892,6 @@ def _launch_batch_job(state_dict, parent_task_id, batch_idx, total_runs, genre_m
     state_dict["active_jobs"][new_job.id] = new_job
     
     # Record batch start time for timeout detection
-    import time
     state_dict.setdefault("batch_start_times", {})[new_job.id] = time.time()
     
     logger.info(f"Enqueued batch job {new_job.id} for runs {start_run}-{start_run + num_iterations - 1}.")


### PR DESCRIPTION
Just 2 mini fixes!

- ~~`auth_configured` is only defined and read **once** and is a simple compound boolean expression~~  
This has been voided by #413 `auth_configured` is now a proper dynamic variable and is actually very useful!!
- `app.py` already imports `Redis` at  [line 18](https://github.com/NeptuneHub/AudioMuse-AI/blob/ecd0ca0304de8c6bcc22f993e467f287e062b099/app.py#L18)
- `tasks/clustering.py` already imports `time` at [line 8](https://github.com/NeptuneHub/AudioMuse-AI/blob/ecd0ca0304de8c6bcc22f993e467f287e062b099/tasks/clustering.py#L8)

Absolutely no change to app behaviour, just a negative line count (which is always a positive!)