### PR TITLE
Docker: Proper (and faster) shutdown sequence

### DIFF
--- a/deployment/docker-entrypoint.sh
+++ b/deployment/docker-entrypoint.sh
@@ -1,7 +1,38 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-echo "ENTRYPOINT: SERVICE_TYPE=${SERVICE_TYPE:-<unset>}"
+SUPERVISOR_CONF=/etc/supervisor/conf.d/supervisord.conf
+SUPERVISOR_SOCK=/tmp/supervisor.sock
+SERVICE_TYPE="${SERVICE_TYPE:-flask}"
+
+log() {
+  echo "ENTRYPOINT: $*"
+}
+
+run_supervisorctl() {
+  log "SUPERVISORCTL: $*"
+  /usr/bin/supervisorctl -c "$SUPERVISOR_CONF" "$@"
+}
+
+run_supervisorctl_checked() {
+  local output
+  local code
+
+  set +e
+  output=$(run_supervisorctl "$@" 2>&1)
+  code=$?
+  set -e
+
+  log "SUPERVISORCTL OUTPUT: $output"
+  log "SUPERVISORCTL EXIT CODE: $code"
+
+  if [ "$code" -ne 0 ]; then
+    echo "Supervisor command failed: $*" >&2
+    exit "$code"
+  fi
+}
+
+log "SERVICE_TYPE=${SERVICE_TYPE}"
 
 if [ -n "${TZ:-}" ]; then
   if [ -f "/usr/share/zoneinfo/$TZ" ]; then
@@ -12,95 +43,84 @@ if [ -n "${TZ:-}" ]; then
   fi
 fi
 
-if [ ! -f /etc/supervisor/conf.d/supervisord.conf ]; then
-  echo "ERROR: supervisor config file missing: /etc/supervisor/conf.d/supervisord.conf" >&2
+if [ ! -f "$SUPERVISOR_CONF" ]; then
+  echo "ERROR: supervisor config file missing: $SUPERVISOR_CONF" >&2
   exit 1
 fi
 
-exec_supervisorctl() {
-  echo "SUPERVISORCTL: $*"
-  /usr/bin/supervisorctl -c /etc/supervisor/conf.d/supervisord.conf "$@"
-}
-
-/usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
+/usr/bin/supervisord -c "$SUPERVISOR_CONF" &
 SUPERVISORD_PID=$!
 
 shutdown_supervisord() {
   local signal="${1:-TERM}"
-  echo "ENTRYPOINT: received SIG${signal}, forwarding to supervisord pid ${SUPERVISORD_PID}"
+  trap - TERM INT
+  log "received SIG${signal}, forwarding to supervisord pid ${SUPERVISORD_PID}"
 
   set +e
   if [ -n "${SUPERVISORD_PID:-}" ] && kill -0 "$SUPERVISORD_PID" 2>/dev/null; then
     kill -"$signal" "$SUPERVISORD_PID" 2>/dev/null
     wait "$SUPERVISORD_PID"
     local exit_code=$?
-    echo "ENTRYPOINT: supervisord stopped with code ${exit_code}"
+    log "supervisord stopped with code ${exit_code}"
     exit "$exit_code"
   fi
-  echo "ENTRYPOINT: supervisord pid is not running"
+  log "supervisord pid is not running"
   exit 0
 }
 
 trap 'shutdown_supervisord TERM' TERM
 trap 'shutdown_supervisord INT' INT
 
-SUPERVISOR_SOCK=/tmp/supervisor.sock
-while true; do
+for _ in $(seq 1 120); do
   if [ -S "$SUPERVISOR_SOCK" ]; then
-    echo "ENTRYPOINT: supervisord socket ready"
+    log "supervisord socket ready"
     break
   fi
   if ! kill -0 "$SUPERVISORD_PID" 2>/dev/null; then
     echo "supervisord exited unexpectedly" >&2
     exit 1
   fi
-  echo "ENTRYPOINT: waiting for supervisord socket"
+  log "waiting for supervisord socket"
   sleep 0.25
 done
 
-echo "ENTRYPOINT: supervisord RPC is ready"
-exec_supervisorctl avail
-
-echo "ENTRYPOINT: ready to start ${SERVICE_TYPE:-flask}"
-
-if [ "${SERVICE_TYPE:-flask}" = "worker" ]; then
-  echo 'Starting worker processes via supervisord...'
-  set +e
-  START_OUTPUT=$(exec_supervisorctl start rq-worker-default rq-worker-high rq-janitor 2>&1)
-  START_CODE=$?
-  set -e
-  echo "SUPERVISORCTL START OUTPUT: $START_OUTPUT"
-  echo "SUPERVISORCTL START EXIT CODE: $START_CODE"
-  if [ "$START_CODE" -ne 0 ]; then
-    echo "Supervisor start failed for worker processes" >&2
-    exit "$START_CODE"
-  fi
-else
-  echo 'Starting web service via supervisord...'
-  set +e
-  START_OUTPUT=$(exec_supervisorctl start flask 2>&1)
-  START_CODE=$?
-  set -e
-  echo "SUPERVISORCTL START OUTPUT: $START_OUTPUT"
-  echo "SUPERVISORCTL START EXIT CODE: $START_CODE"
-  if [ "$START_CODE" -ne 0 ]; then
-    echo "Supervisor start failed for flask" >&2
-    exit "$START_CODE"
-  fi
+if [ ! -S "$SUPERVISOR_SOCK" ]; then
+  echo "timed out waiting for supervisord socket" >&2
+  shutdown_supervisord TERM
 fi
 
-echo "SUPERVISORCTL STATUS AFTER START:"
+log "supervisord RPC is ready"
+run_supervisorctl_checked avail
+
+log "ready to start ${SERVICE_TYPE}"
+
+case "$SERVICE_TYPE" in
+  worker)
+    log "starting worker processes via supervisord"
+    run_supervisorctl_checked start rq-worker-default rq-worker-high rq-janitor
+    ;;
+  flask)
+    log "starting web service via supervisord"
+    run_supervisorctl_checked start flask
+    ;;
+  *)
+    echo "Unsupported SERVICE_TYPE '$SERVICE_TYPE' (expected: flask or worker)" >&2
+    shutdown_supervisord TERM
+    ;;
+esac
+
+log "SUPERVISORCTL STATUS AFTER START"
 set +e
-exec_supervisorctl status
+run_supervisorctl status
 STATUS_EXIT_CODE=$?
-echo "SUPERVISORCTL STATUS EXIT CODE: $STATUS_EXIT_CODE"
-exec_supervisorctl avail
+log "SUPERVISORCTL STATUS EXIT CODE: $STATUS_EXIT_CODE"
+run_supervisorctl avail
 AVAIL_EXIT_CODE=$?
-echo "SUPERVISORCTL AVAIL EXIT CODE: $AVAIL_EXIT_CODE"
+log "SUPERVISORCTL AVAIL EXIT CODE: $AVAIL_EXIT_CODE"
 set -e
 
-echo "ENTRYPOINT: now waiting on supervisord pid $SUPERVISORD_PID"
+log "now waiting on supervisord pid $SUPERVISORD_PID"
 wait "$SUPERVISORD_PID"
 SUPERVISORD_EXIT_CODE=$?
-echo "ENTRYPOINT: supervisord pid $SUPERVISORD_PID exited with code $SUPERVISORD_EXIT_CODE"
+log "supervisord pid $SUPERVISORD_PID exited with code $SUPERVISORD_EXIT_CODE"
 exit "$SUPERVISORD_EXIT_CODE"

--- a/deployment/docker-entrypoint.sh
+++ b/deployment/docker-entrypoint.sh
@@ -25,6 +25,25 @@ exec_supervisorctl() {
 /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf &
 SUPERVISORD_PID=$!
 
+shutdown_supervisord() {
+  local signal="${1:-TERM}"
+  echo "ENTRYPOINT: received SIG${signal}, forwarding to supervisord pid ${SUPERVISORD_PID}"
+
+  set +e
+  if [ -n "${SUPERVISORD_PID:-}" ] && kill -0 "$SUPERVISORD_PID" 2>/dev/null; then
+    kill -"$signal" "$SUPERVISORD_PID" 2>/dev/null
+    wait "$SUPERVISORD_PID"
+    local exit_code=$?
+    echo "ENTRYPOINT: supervisord stopped with code ${exit_code}"
+    exit "$exit_code"
+  fi
+  echo "ENTRYPOINT: supervisord pid is not running"
+  exit 0
+}
+
+trap 'shutdown_supervisord TERM' TERM
+trap 'shutdown_supervisord INT' INT
+
 SUPERVISOR_SOCK=/tmp/supervisor.sock
 while true; do
   if [ -S "$SUPERVISOR_SOCK" ]; then


### PR DESCRIPTION
> [!Note]
> This PR has been rebased. A portion of it has been voided but the essential remains.

As a user / admin of a setup that includes Audiomuse-AI I have noticed that everytime I want to take down a flask or a worker I usually have to wait 10 seconds. It's a little annoying when reloading ENVs, but now that I'm running dev tests in containers I have found it personally extremely annoying :)

So I had a little look around.  I feared I maybe had to dive deep into the engine, but very quickly found the culprit. SIGTERM does not appear to be broadcasted succesfully (to apparently both the worker and the flask).

# First commit: Proper (and faster!) shutdown

## Before:

```console
docker compose down
 ✔ Container audiomuse-ai-flask-app           Removed 10.5s
 ✔ Container audiomuse-ai-worker-instance     Removed 10.5s
```

```logs
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-50-41]-*** Listening on default...
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-50-41]-Worker 6010fae5980640dfaddd4fbfdac77f3a: cleaning registries for queue: default
audiomuse-ai-flask-app exited with code 137
audiomuse-ai-worker-instance exited with code 137
```

Notice the non-successful  exit codes (137s)!

## After

```console
 ✔ Container audiomuse-ai-worker-instance      Removed 2.4s
 ✔ Container audiomuse-ai-flask-app            Removed 1.3s
```

```logs
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-52-41]-*** Listening on default...
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-52-41]-Worker fd26714f114942b69f3b90fb7d798a07: cleaning registries for queue: default
audiomuse-ai-flask-app        | [2026-04-12 13:52:49 +0000] [1] [INFO] Handling signal: term
audiomuse-ai-flask-app        | [2026-04-12 13:52:49 +0000] [8] [INFO] Worker exiting (pid: 8)
audiomuse-ai-worker-instance  | 2026-04-12 13:52:50,222 WARN received SIGTERM indicating exit request
audiomuse-ai-worker-instance  | 2026-04-12 13:52:50,222 INFO waiting for rq-janitor, rq-worker-default, rq-worker-high to die
audiomuse-ai-worker-instance  | 13:52:50 Worker bed4657828e54fe3bd01c0713636acd2 [PID 10]: warm shut down requested
audiomuse-ai-worker-instance  | 13:52:50 Worker bed4657828e54fe3bd01c0713636acd2: unsubscribing from channel rq:pubsub:bed4657828e54fe3bd01c0713636acd2
audiomuse-ai-worker-instance  | 2026-04-12 13:52:50,301 INFO stopped: rq-worker-high (exit status 0)
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-52-50]-Worker fd26714f114942b69f3b90fb7d798a07 [PID 9]: warm shut down requested
audiomuse-ai-worker-instance  | [INFO]-[12-04-2026 13-52-50]-Worker fd26714f114942b69f3b90fb7d798a07: unsubscribing from channel rq:pubsub:fd26714f114942b69f3b90fb7d798a07
audiomuse-ai-flask-app        | [2026-04-12 13:52:50 +0000] [1] [INFO] Shutting down: Master
audiomuse-ai-flask-app exited with code 0
audiomuse-ai-worker-instance  | 2026-04-12 13:52:51,810 INFO stopped: rq-worker-default (exit status 0)
audiomuse-ai-worker-instance  | 2026-04-12 13:52:51,814 WARN stopped: rq-janitor (terminated by SIGTERM)
audiomuse-ai-worker-instance exited with code 0
```

## Benefits

- This commit adds a `shutdown_supervisord()` function plus trap handlers for TERM and INT.
- Now, when the container gets `SIGTERM`, the entrypoint catches it, forwards it to supervisord, waits for shutdown, and exits with the same code as supervisord.
- Result: clean shutdown in ~2–3s and normal exit code 0.

### Why graceful shutdown matters for Flask/worker/Redis:

- Flask app can finish in-flight requests and close DB/network connections cleanly.
- Workers (e.g., Celery/RQ) can stop taking new jobs, finish/ack current jobs, avoid duplicate/retried work.
- Redis can flush/persist state correctly and close safely.
- You avoid abrupt termination side effects: partial writes, corrupted transient state, noisy error logs, and inconsistent job status.

### Why exit code 0 (vs 137) is important in containerized apps:
- 0 clearly means “stopped normally,” so orchestration/monitoring doesn’t treat it as a crash.
- Fewer false alarms in observability tools and incident channels.
- Better restart behavior: platforms can distinguish intentional stop/deploy from failure.
- More trustworthy health/SLA metrics (crash counts, MTTR, failure rates).
- Cleaner CI/CD and rollout automation, since pipelines and scripts often branch on exit status.
In short: this commit made PID 1 signal handling correct, enabled graceful stop chains, and converted “killed container” behavior into “clean, intentional shutdown.”

## What was actually happening?

- Before this commit, the entrypoint script started supervisord in the background, but didn’t properly handle container stop signals at PID 1 level.
- When Docker sent SIGTERM, it wasn’t reliably forwarded to supervisord (and therefore not to Flask/worker/Redis), so containers hit timeout and got force-killed (SIGKILL) with exit code 137.

# Second commit: Harden supervisord startup/shutdown and service selection

## Before:

The entrypoint handled the "happy" path but had fragile lifecycle control: startup checks were repetitive, supervisorctl error handling was duplicated, socket wait was unbounded-style polling, and invalid SERVICE_TYPE handling was less explicit. Failures could be noisy or ambiguous to debug.

## Now

- This change rewrites the script into structured helpers (`log`, `run_supervisorctl`, `run_supervisorctl_checked`), centralizes config constants, and enforces strict service routing with a case on `SERVICE_TYPE` (flask/worker only).
- Startup is now safer: `supervisord` readiness has a bounded timeout: unexpected supervisord death is detected early and control commands fail fast with explicit exit codes.
- Shutdown is more reliable: traps are cleaned (trap - TERM INT) to avoid re-entrant signal handling, signals are forwarded to supervisord, and supervisord’s exit code is propagated back as the container exit code.
- Even though the script is longer, it is operationally essential: it trades line count for deterministic behavior, clearer observability, predictable failure semantics, and clean container lifecycle management (instead of hidden hangs or force-kill paths like 137).

# ~~Voided second and third commits~~
<details>
<summary>This portion has been voided by the rebase click to see</summary>
# Second commit: Use common Docker entrypoint

Both `Dockerfile` have the same _looong_ hard to read `CMD` entrypoint.

(Actually `Dockerfile-noavx2` doesn't do the timezone sync the other `Dockerfile` does - I figured this was not intentional)

This commit extracts the entrypoint and unfolds it (and also improves it - see below).

## Benefits

- Code in it own file: easier to read, can now havecomments
- Common code: easier to maintain
- Standard "strict" Bash mode so containers will fail instead of starting in a potentially half-broken state.

## Changes to behaviour

- None (aside `noavx2` now takes `TZ` env into account).

## Notes about the 'improvements' to the entrypoint

If you extract and remove the escaping in the original entrypoint from `Dockerfile`:

```txt
CMD ["bash", "-c", "if [ -n \"$TZ\" ] && [ -f \"/usr/share/zoneinfo/$TZ\" ]; then ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone; elif [ -n \"$TZ\" ]; then echo \"Warning: timezone '$TZ' not found in /usr/share/zoneinfo\" >&2; fi; if [ \"$SERVICE_TYPE\" = \"worker\" ]; then echo 'Starting worker processes via supervisord...' && /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf; else echo 'Starting web service...' && gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 300 app:app; fi"]
```

You get:

```bash
if [ -n "$TZ" ] && [ -f "/usr/share/zoneinfo/$TZ" ]; then ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone; elif [ -n "$TZ" ]; then echo "Warning: timezone '$TZ' not found in /usr/share/zoneinfo" >&2; fi; if [ "$SERVICE_TYPE" = "worker" ]; then echo 'Starting worker processes via supervisord...' && /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf; else echo 'Starting web service...' && gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 300 app:app; fi
```

Unfolds as:

```bash
if [ -n "$TZ" ] && [ -f "/usr/share/zoneinfo/$TZ" ]; then
    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
    echo $TZ > /etc/timezone
elif [ -n "$TZ" ]; then
    echo "Warning: timezone '$TZ' not found in /usr/share/zoneinfo" >&2
fi;

if [ "$SERVICE_TYPE" = "worker" ];
    then echo 'Starting worker processes via supervisord...'
    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
else
    echo 'Starting web service...'
    gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 300 app:app
fi
```

Since the docker image runs on ubuntu and was always calling `bash` we can actually use some bash script syntax.
- Define the standard shebang for the script.
- Use standard bash styled `[[` conditional statement.
- Sets standard "strict" bash mode: exit on error, fail when missing variable, returns error code of potential failing command (better for dev, debug and production)

```
#!/bin/bash
set -euo pipefail

if [[ -n "$TZ" && -f "/usr/share/zoneinfo/$TZ" ]]; then
    ln -snf /usr/share/zoneinfo/$TZ /etc/localtime
    echo $TZ > /etc/timezone
elif [[ -n "$TZ" ]]; then
    echo "Warning: timezone '$TZ' not found in /usr/share/zoneinfo" >&2
fi;

if [[ "$SERVICE_TYPE" == "worker" ]]; then
    echo 'Starting worker processes via supervisord...'
    /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
else
    echo 'Starting web service...'
    gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 300 app:app
fi
```

Finally I modified the TZ block to be slightly more readable on first glance:

```bash
#!/bin/bash
set -euo pipefail

if [[ -n "${TZ:-}" ]]; then
  if [[ -f "/usr/share/zoneinfo/$TZ" ]]; then
    ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime
    printf '%s\n' "$TZ" >/etc/timezone
  else
    printf "Warning: timezone '%s' not found in /usr/share/zoneinfo\n" "$TZ" >&2
  fi
fi

if [[ "${SERVICE_TYPE:-flask}" == "worker" ]]; then
  echo "Starting worker processes via supervisord..."
  exec /usr/bin/supervisord -c /etc/supervisor/conf.d/supervisord.conf
else
  echo "Starting web service..."
  exec gunicorn --bind 0.0.0.0:8000 --workers 1 --timeout 300 app:app
fi
```

NOTE: Here I unfolded the original `CMD`, but the actual entrypoint script does include the call to `exec`!

## Modified `.dockerignore`

So it allows for the new `deployment/docker/entrypoint.sh` file to be available inside the containers.

# Third commit: Using `ENTRYPOINT` instead of `CMD`

Now that we have an entrypoint script the proper Dockerfile instruction to use is `ENTRYPOINT`, and [leaves `CMD` free to define potential arguments for the entrypoint](https://docs.docker.com/reference/dockerfile/#cmd).
</details>