### PR TITLE
WIP: Fix `refresh_auth_state()`

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,22 +124,6 @@ def is_bootstrap_mode():
     return not config.AUTH_ENABLED or bootstrap_auth_mode
 
 
-def refresh_auth_state():
-    global AUDIOMUSE_USER, AUDIOMUSE_PASSWORD, effective_audiomuse_user, effective_audiomuse_password, auth_configured, bootstrap_auth_mode
-    AUDIOMUSE_USER = config.AUDIOMUSE_USER
-    AUDIOMUSE_PASSWORD = config.AUDIOMUSE_PASSWORD
-    if AUDIOMUSE_USER and AUDIOMUSE_USER.strip():
-        effective_audiomuse_user = AUDIOMUSE_USER.strip()
-    else:
-        effective_audiomuse_user = ""
-    if AUDIOMUSE_PASSWORD and AUDIOMUSE_PASSWORD.strip():
-        effective_audiomuse_password = AUDIOMUSE_PASSWORD.strip()
-    else:
-        effective_audiomuse_password = ""
-    auth_configured = bool(effective_audiomuse_user and effective_audiomuse_password)
-    bootstrap_auth_mode = config.AUTH_ENABLED and not auth_configured
-
-
 _password_hasher = PasswordHasher()
 
 

--- a/app.py
+++ b/app.py
@@ -116,7 +116,7 @@ if not _jwt_secret and AUTH_ENABLED:
 # Auth is considered configured whenever the app has effective credentials,
 # including runtime-generated temporary auth values.
 auth_configured = bool(effective_audiomuse_user and effective_audiomuse_password)
-bootstrap_auth_mode = AUTH_ENABLED and not (AUDIOMUSE_USER and AUDIOMUSE_PASSWORD)
+bootstrap_auth_mode = config.AUTH_ENABLED and not auth_configured
 
 # If auth is enabled but no explicit credentials were provided, the app is
 # in bootstrap auth mode. Setup can be accessed via the temporary credentials.

--- a/app.py
+++ b/app.py
@@ -129,10 +129,14 @@ def refresh_auth_state():
     AUDIOMUSE_USER = config.AUDIOMUSE_USER
     AUDIOMUSE_PASSWORD = config.AUDIOMUSE_PASSWORD
     if AUDIOMUSE_USER and AUDIOMUSE_USER.strip():
-        effective_audiomuse_user = AUDIOMUSE_USER
+        effective_audiomuse_user = AUDIOMUSE_USER.strip()
+    else:
+        effective_audiomuse_user = ""
     if AUDIOMUSE_PASSWORD and AUDIOMUSE_PASSWORD.strip():
-        effective_audiomuse_password = AUDIOMUSE_PASSWORD
-    auth_configured = bool(AUDIOMUSE_USER and AUDIOMUSE_PASSWORD)
+        effective_audiomuse_password = AUDIOMUSE_PASSWORD.strip()
+    else:
+        effective_audiomuse_password = ""
+    auth_configured = bool(effective_audiomuse_user and effective_audiomuse_password)
     bootstrap_auth_mode = config.AUTH_ENABLED and not auth_configured
 
 

--- a/app_setup.py
+++ b/app_setup.py
@@ -2,7 +2,7 @@ import json
 import re
 from flask import request, jsonify, render_template, make_response, after_this_request
 import config
-from app import app, setup_manager, is_bootstrap_mode, refresh_auth_state
+from app import app, setup_manager, is_bootstrap_mode
 import restart_manager
 import tasks.mediaserver as mediaserver
 
@@ -216,7 +216,6 @@ def setup_api():
                 setup_manager.delete_config_values(obsolete_fields)
         setup_manager.save_config_values(filtered_values)
         config.refresh_config()
-        refresh_auth_state()
         restart_manager.publish_restart_request()
         restart_requested = True
     except Exception as exc:


### PR DESCRIPTION
- `auth_configured` and `bootstrap_auth_mode` were not being assigned values the exact same ways.
- We now assign the stripped version to `effective_audiomuse_user` and `effective_audiomuse_password`: if you're going to check for  the stripped version, might as-well directly use the stripped version as well (its indeed the proper thing to do in this context)

