### PR TITLE
fix: propagate MediaServerConnectionError instead of silently returning []

### DIFF
--- a/app_setup.py
+++ b/app_setup.py
@@ -262,7 +262,7 @@ def setup_api():
     except Exception as exc:
         app.logger.error('Setup save failed: %s', exc, exc_info=True)
         if is_test_connection:
-            return jsonify({'error': 'Unable to get top player song. Check the server log for details.'}), 500
+            return jsonify({'error': str(exc) or 'Unable to get top played song. Check the server log for details.'}), 500
         return jsonify({'error': 'Unable to save configuration. Check the server log for details.'}), 500
 
     response = make_response(jsonify({

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -48,7 +48,7 @@ from config import (
 
 # Import other project modules
 from ai import get_ai_playlist_name, creative_prompt_template
-from .commons import score_vector
+from .commons import score_vector, MediaServerConnectionError
 # MODIFIED: Import from voyager_manager instead of annoy_manager
 from .voyager_manager import build_and_store_voyager_index
 # Import artist GMM manager for artist similarity index
@@ -1059,7 +1059,17 @@ def run_analysis_task(num_recent_albums, top_n_moods):
             log_and_update_main("🚀 Starting main analysis process...", 0)
             clean_temp(TEMP_DIR)
             # MODIFIED: Call to get_recent_albums no longer needs server parameters.
-            all_albums = get_recent_albums(num_recent_albums)
+            try:
+                all_albums = get_recent_albums(num_recent_albums)
+            except MediaServerConnectionError as conn_err:
+                error_msg = (
+                    f"❌ Cannot connect to the media server: {conn_err}. "
+                    "Please verify your server URL and API token in the Setup page, "
+                    "and ensure the media server is running and reachable from this container."
+                )
+                logger.error(error_msg)
+                log_and_update_main(error_msg, current_progress, task_state=TASK_STATUS_FAILURE, error_message=str(conn_err))
+                raise
             if not all_albums:
                 log_and_update_main("⚠️ No new albums to analyze.", 100, albums_found=0, task_state=TASK_STATUS_SUCCESS)
                 return {"status": "SUCCESS", "message": "No new albums to analyze."}

--- a/tasks/commons.py
+++ b/tasks/commons.py
@@ -8,6 +8,16 @@ from config import (
     ENERGY_MAX, ENERGY_MIN
 )
 
+
+class MediaServerConnectionError(Exception):
+    """Raised when the application cannot communicate with the configured
+    media server (e.g. Jellyfin, Emby, Navidrome).  Using a dedicated
+    exception type lets callers distinguish a connectivity failure from
+    other runtime errors and report a clear, actionable message in the
+    web interface instead of silently swallowing the error.
+    """
+
+
 def score_vector(row, mood_labels_list, other_feature_labels_list): # other_feature_labels_list is now passed
     """Converts a database row into a numerical feature vector for clustering."""
     # Extract features from the database row

--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -6,6 +6,7 @@ import os
 import config
 
 from tasks.mediaserver_helper import detect_path_format
+from tasks.commons import MediaServerConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -77,7 +78,10 @@ def _get_target_library_ids():
 
     except Exception as e:
         logger.error(f"Failed to fetch or parse Emby virtual folders at '{url}': {e}", exc_info=True)
-        return set()
+        raise MediaServerConnectionError(
+            f"Cannot reach Emby at '{url}'. Check your EMBY_URL and EMBY_TOKEN settings. "
+            f"Original error: {e}"
+        ) from e
 
 
 def _emby_base_url(user_creds=None):
@@ -331,7 +335,10 @@ def _get_recent_albums_only(limit, user_creds=None):
                     break
             except Exception as e:
                 logger.error(f"Emby _get_recent_albums_only failed during 'scan all': {e}", exc_info=True)
-                break
+                raise MediaServerConnectionError(
+                    f"Cannot reach Emby at '{config.EMBY_URL}'. Check your EMBY_URL and EMBY_TOKEN settings. "
+                    f"Original error: {e}"
+                ) from e
     
     # Case 3: Config is set and we have library IDs. Scan each of these libraries by using their ID as ParentId.
     else:
@@ -362,7 +369,10 @@ def _get_recent_albums_only(limit, user_creds=None):
                         break
                 except Exception as e:
                     logger.error(f"Emby _get_recent_albums_only failed for library ID {library_id}: {e}", exc_info=True)
-                    break
+                    raise MediaServerConnectionError(
+                        f"Cannot reach Emby at '{config.EMBY_URL}'. Check your EMBY_URL and EMBY_TOKEN settings. "
+                        f"Original error: {e}"
+                    ) from e
 
     # After fetching, a final sort and trim is needed only if we fetched from multiple libraries.
     if target_library_ids is not None and len(target_library_ids) > 1:

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -6,6 +6,7 @@ import os
 import config
 
 from tasks.mediaserver_helper import detect_path_format
+from tasks.commons import MediaServerConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +71,10 @@ def _get_target_library_ids():
 
     except Exception as e:
         logger.error(f"Failed to fetch or parse Jellyfin virtual folders at '{url}': {e}", exc_info=True)
-        return set()
+        raise MediaServerConnectionError(
+            f"Cannot reach Jellyfin at '{url}'. Check your JELLYFIN_URL and JELLYFIN_TOKEN settings. "
+            f"Original error: {e}"
+        ) from e
 
 
 def _jellyfin_base_url(user_creds=None):
@@ -157,7 +161,10 @@ def get_recent_albums(limit):
                     break
             except Exception as e:
                 logger.error(f"Jellyfin get_recent_albums failed during 'scan all': {e}", exc_info=True)
-                break
+                raise MediaServerConnectionError(
+                    f"Cannot reach Jellyfin at '{url}'. Check your JELLYFIN_URL and JELLYFIN_TOKEN settings. "
+                    f"Original error: {e}"
+                ) from e
     
     # Case 3: Config is set and we have library IDs. Scan each of these libraries by using their ID as ParentId.
     else:
@@ -188,7 +195,10 @@ def get_recent_albums(limit):
                         break
                 except Exception as e:
                     logger.error(f"Jellyfin get_recent_albums failed for library ID {library_id}: {e}", exc_info=True)
-                    break
+                    raise MediaServerConnectionError(
+                        f"Cannot reach Jellyfin at '{url}'. Check your JELLYFIN_URL and JELLYFIN_TOKEN settings. "
+                        f"Original error: {e}"
+                    ) from e
 
     # After fetching, a final sort and trim is needed only if we fetched from multiple libraries.
     if target_library_ids is not None and len(target_library_ids) > 1:

--- a/tasks/mediaserver_navidrome.py
+++ b/tasks/mediaserver_navidrome.py
@@ -7,6 +7,7 @@ import random
 import config
 
 from tasks.mediaserver_helper import detect_path_format
+from tasks.commons import MediaServerConnectionError
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +189,12 @@ def get_recent_albums(limit):
 
                 if len(albums) < size_to_fetch: break
             else:
+                if offset == 0:
+                    # First page returned nothing useful — likely a connection/auth failure
+                    raise MediaServerConnectionError(
+                        "Cannot reach Navidrome or received an unexpected response. "
+                        "Check your NAVIDROME_URL, NAVIDROME_USER, and NAVIDROME_PASSWORD settings."
+                    )
                 logger.error("Failed to fetch recent albums page from Navidrome.")
                 break
 
@@ -213,6 +220,11 @@ def get_recent_albums(limit):
 
                     if len(albums) < size_to_fetch: break
                 else:
+                    if offset == 0:
+                        raise MediaServerConnectionError(
+                            f"Cannot reach Navidrome folder ID '{folder_id}' or received an unexpected response. "
+                            "Check your NAVIDROME_URL, NAVIDROME_USER, and NAVIDROME_PASSWORD settings."
+                        )
                     logger.error(f"Failed to fetch recent albums page from Navidrome folder ID {folder_id}.")
                     break
 


### PR DESCRIPTION
I was running an analysis and noticed something weird — when the media server 
credentials were wrong, the task still showed up as successful with the message 
" No new albums to analyze." That's confusing because it looks like everything 
worked fine when it actually couldn't even reach the server.

Dug into it and found the issue: all three providers (Jellyfin, Emby, Navidrome) 
were catching connection errors silently and returning an empty list. The analysis 
task had no way to tell the difference between "genuinely no albums" and "couldn't 
connect at all", so it just reported success either way.
What I changed:
Added a `MediaServerConnectionError` exception in `tasks/commons.py` so we have 
a proper signal for this case. Then updated Jellyfin, Emby, and Navidrome to raise 
it instead of swallowing the error. The analysis task now catches it and marks the 
job as FAILURE with a clear message telling the user to check their Setup page.

Also fixed the Setup page test-connection response — it was returning a hardcoded 
generic string instead of the actual error from the server, so users couldn't tell 
what went wrong. Now it passes the real error through. There was also a small typo 
("top player" → "top played") that I fixed while I was in there.
Pretty small change overall but it makes debugging a misconfigured server much less 
painful.
