### PR TITLE
feat: option to configure Flask listening address

### DIFF
--- a/deployment/supervisord.conf
+++ b/deployment/supervisord.conf
@@ -4,6 +4,7 @@ logfile=/dev/null           ; Run supervisord in the foreground
 logfile_maxbytes=0
 pidfile=/tmp/supervisord.pid
 childlogdir=/tmp
+environment=FLASK_BIND_ADDRESS="0.0.0.0:8000"
 
 [unix_http_server]
 file=/tmp/supervisor.sock
@@ -16,7 +17,7 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:flask]
-command=/usr/local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 app:app
+command=/usr/local/bin/gunicorn --bind %(FLASK_BIND_ADDRESS)s --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 app:app
 autostart=false
 autorestart=true
 stopsignal=TERM

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -35,6 +35,7 @@ This section covers direct deployment with the `deployment/*.yaml` manifests.
   * Ensure cluster connection values are correct (mandatory; env-only):
     * `POSTGRES_HOST`, `POSTGRES_PORT`, `REDIS_URL`
   * Optional: set the timezone with `TZ`
+  * Optional: set the listen address with `FLASK_BIND_ADDRESS` (default `0.0.0.0:8000`)
 
 * **Deploy:**
   ```bash

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -43,6 +43,8 @@ The **mandatory** parameter that you need to change from the example are this:
 | `AUDIOMUSE_PASSWORD`     | Password to login on the AudioMuse-AI integrated frontned   | *(N/A - from Secret)* |
 | `API_TOKEN`     | API_TOLEN for plugin authentication | *(N/A - from Secret)* |
 | `JWT_SECRET`     | Used to inizializate the JWT session with a predefined value | *from Secret OR automatically created if blank* |
+| **Flask**            |                                                              |                |
+| `FLASK_BIND_ADDRESS` | Used to bind flask web server to specified address and port  | `0.0.0.0:8000` |
 
 The following additional parameter control authentication.  Leave
 all four empty to disable auth (default).


### PR DESCRIPTION
Added environment variable to configure gunicorn bind address, so it can be changed to `[::]` for IPv6-only / dual-stack environments