### PR TITLE
Migration - keep status on reload

### DIFF
--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -164,7 +164,11 @@ def provider_migration_page():
             row = cur.fetchone()
         if row:
             active_session_id = row[0]
-    except Exception:
+    except Exception as e:
+        logger.warning(
+            "provider_migration_page: failed to look up active session: %s",
+            e, exc_info=True,
+        )
         active_session_id = None
 
     return render_template(
@@ -675,8 +679,18 @@ def execute():
                 (json.dumps(state, ensure_ascii=False), session_id),
             )
         db.commit()
-    except Exception:
-        pass
+    except Exception as e:
+        # Non-fatal: the execute job is already enqueued. Losing exec_task_id
+        # only means the UI cannot auto-resume polling after a page refresh.
+        logger.warning(
+            "provider_migration execute: failed to persist exec_task_id "
+            "for session %s (job %s): %s",
+            session_id, job.id, e, exc_info=True,
+        )
+        try:
+            db.rollback()
+        except Exception:
+            pass
     return jsonify({'task_id': job.id})
 
 

--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -150,10 +150,28 @@ def _apply_source_path_overrides(old_rows, overrides):
 
 @migration_bp.route('/provider-migration')
 def provider_migration_page():
+    # Look up an in-flight migration so a page refresh can resume the wizard
+    # at the right step instead of creating a brand new session.
+    active_session_id = None
+    try:
+        db = get_db()
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT id FROM migration_session "
+                "WHERE status NOT IN ('completed', 'failed') "
+                "ORDER BY id DESC LIMIT 1"
+            )
+            row = cur.fetchone()
+        if row:
+            active_session_id = row[0]
+    except Exception:
+        active_session_id = None
+
     return render_template(
         'provider_migration.html',
         title='Provider Migration',
         active='provider_migration',
+        active_session_id=active_session_id,
     )
 
 
@@ -175,6 +193,11 @@ def session_start():
 
     db = get_db()
     with db.cursor() as cur:
+        # Prune terminal rows so the table does not grow unboundedly.
+        # Safe: never touches in-flight sessions (in_progress / dry_run_ready).
+        cur.execute(
+            "DELETE FROM migration_session WHERE status IN ('completed', 'failed')"
+        )
         cur.execute(
             "INSERT INTO migration_session "
             "(source_type, target_type, target_creds, state, status) "
@@ -216,6 +239,29 @@ def session_get(session_id):
 # ---------------------------------------------------------------------------
 # Routes — probe (delegates to tasks.provider_probe, passes creds explicitly)
 # ---------------------------------------------------------------------------
+
+@migration_bp.route('/api/migration/session/<int:session_id>', methods=['DELETE'])
+def session_discard(session_id):
+    """Delete a migration_session row. Used by the wizard's Discard button
+    when the user wants to throw away a resumed session (e.g. creds went
+    stale) and start over from scratch. Refuses to touch sessions that are
+    already in a terminal state — those are pruned automatically on the
+    next session_start."""
+    db = get_db()
+    with db.cursor() as cur:
+        cur.execute(
+            "SELECT status FROM migration_session WHERE id = %s",
+            (session_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return jsonify({'error': 'session not found'}), 404
+        if row[0] in ('completed', 'failed'):
+            return jsonify({'error': 'cannot discard a finished session'}), 400
+        cur.execute("DELETE FROM migration_session WHERE id = %s", (session_id,))
+    db.commit()
+    return jsonify({'ok': True})
+
 
 @migration_bp.route('/api/migration/probe/test', methods=['POST'])
 def probe_test():
@@ -617,6 +663,20 @@ def execute():
         session_id,
         job_timeout=3600,
     )
+    # Persist the RQ task id on the session so a page refresh can resume
+    # polling this job rather than losing track of it.
+    try:
+        state = _load_state(session_id) or {}
+        state['exec_task_id'] = job.id
+        state = _sanitize_json_value(state)
+        with db.cursor() as cur:
+            cur.execute(
+                "UPDATE migration_session SET state = %s::jsonb WHERE id = %s",
+                (json.dumps(state, ensure_ascii=False), session_id),
+            )
+        db.commit()
+    except Exception:
+        pass
     return jsonify({'task_id': job.id})
 
 

--- a/templates/provider_migration.html
+++ b/templates/provider_migration.html
@@ -1318,6 +1318,104 @@
             await new Promise(r => setTimeout(r, 2000));
         }
     }
+
+    // If the server found an in-flight migration session, resume it rather
+    // than making the user start over (which would create a brand new row).
+    // Credentials are never sent back to the browser — they live in the DB
+    // and the server uses them via session_id. We only re-show target_type
+    // and jump the wizard to whichever step matches the persisted state.
+    const resumeSessionId = {{ (active_session_id or 0)|tojson }};
+    async function resumeSession(sid) {
+        try {
+            const s = await jsonFetch(
+                "{{ url_for('migration_bp.session_get', session_id=0) }}".replace('/0', '/' + sid)
+            );
+            sessionId  = s.id;
+            targetType = s.target_type || '';
+            const state = s.state || {};
+
+            // Step 1: pre-check the backup box (user already ticked it last time).
+            $('mig-backup-confirmed').checked = true;
+            unlock(2);
+
+            // Step 2: show the target provider as locked with a "resumed" notice,
+            // hide the cred fields (secrets stay server-side), disable Test.
+            const tt = $('mig-target-type');
+            if (tt && targetType) {
+                tt.value = targetType;
+                tt.disabled = true;
+            }
+            document.querySelectorAll('.mig-cred-field').forEach(f => f.classList.remove('active'));
+            const btn = $('mig-test-connection');
+            if (btn) btn.disabled = true;
+            $('mig-probe-result').innerHTML =
+                '<div class="mig-success">Resumed previous session. ' +
+                'Credentials were saved on the server and will be reused automatically. ' +
+                '<button type="button" id="mig-discard-session" class="btn btn-secondary" ' +
+                'style="margin-left:0.75rem;">Discard and start over</button>' +
+                '</div>';
+            const discardBtn = $('mig-discard-session');
+            if (discardBtn) {
+                discardBtn.addEventListener('click', async () => {
+                    if (!confirm('Discard the saved migration session and start over? ' +
+                                 'Any manual matches from the previous run will be lost.')) return;
+                    discardBtn.disabled = true;
+                    try {
+                        await jsonFetch(
+                            "{{ url_for('migration_bp.session_discard', session_id=0) }}"
+                                .replace('/0', '/' + sessionId),
+                            { method: 'DELETE' }
+                        );
+                    } catch (e) {
+                        // If the row is gone already, still reload to reset UI.
+                        console.warn('discard failed (continuing):', e);
+                    }
+                    window.location.reload();
+                });
+            }
+            unlock(3);
+
+            // Terminal-state safety: if the row is somehow still readable,
+            // don't try to resume.
+            if (s.status === 'completed' || s.status === 'failed') {
+                return;
+            }
+
+            // Step 6: an execute job is already running — jump straight there.
+            if (state.exec_task_id) {
+                [4, 5, 6].forEach(unlock);
+                setActive(6);
+                pollJob(state.exec_task_id);
+                return;
+            }
+
+            // Steps 4 / 5: a dry run was already produced — re-render it so
+            // the user keeps manual matches made before the refresh.
+            if (state.dry_run) {
+                const albums = state.dry_run.unmatched_albums || [];
+                const unmatchedCount = albums.reduce((a, b) => a + (b.track_count || 0), 0);
+                await renderDryRunResult({
+                    tier_counts: state.dry_run.tier_counts || {},
+                    unmatched: unmatchedCount,
+                    unmatched_albums_count: albums.length,
+                });
+                if (s.status === 'dry_run_ready') {
+                    unlock(5);
+                    setActive(5);
+                }
+                return;
+            }
+
+            // Otherwise: session exists but no dry run yet — sit at step 3.
+            setActive(3);
+        } catch (e) {
+            // Resume failed — fall back to a normal fresh wizard.
+            console.warn('migration resume failed:', e);
+        }
+    }
+    if (resumeSessionId) {
+        resumeSession(resumeSessionId);
+    }
 })();
 </script>
 <script src="{{ url_for('static', filename='menu.js') }}"></script>


### PR DESCRIPTION
The migration provider functionality need improvement:

- If user run many migration, the `migration_session` table keep growing. This is wrong. At least one session should be there;
- When you reload the migration page, if a session is still running (in progress or dry_run status) it need to restore the session and give the user the possibility to proceed with the migration;
- When you reload the migration page, and only completed or in error session are there, a new session should be started and old one be deleted
- Credentail of an in progress session MUST NEVER come back in the frotend for security reason