### PR TITLE
Example on using an EnvironmentFile in the container files

### DIFF
--- a/deployment/podman-quadlets/audiomuse-ai-flask.container
+++ b/deployment/podman-quadlets/audiomuse-ai-flask.container
@@ -12,11 +12,8 @@ Tmpfs=/app/temp_audio
 AutoUpdate=registry
 
 #Env
-Environment=SERVICE_TYPE=flask MEDIASERVER_TYPE=navidrome 
-Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
-Environment=POSTGRES_DB=audiomusedb POSTGRES_HOST=localhost POSTGRES_PORT=5432 
-Environment=REDIS_URL=redis://localhost:6379/0 
-Environment=TEMP_DIR=/app/temp_audio
+Environment=SERVICE_TYPE=flask
+EnvironmentFile=/etc/containers/systemd/AudioMuseAI/audiomuse.env
 
 #HealthCheck
 HealthCmd=wget -q --spider --no-proxy localhost:8000 || exit 1

--- a/deployment/podman-quadlets/audiomuse-ai-worker.container
+++ b/deployment/podman-quadlets/audiomuse-ai-worker.container
@@ -12,11 +12,8 @@ Tmpfs=/app/temp_audio
 AutoUpdate=registry
 
 #Env
-Environment=SERVICE_TYPE=worker MEDIASERVER_TYPE=navidrome 
-Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
-Environment=POSTGRES_DB=audiomusedb POSTGRES_HOST=localhost POSTGRES_PORT=5432 
-Environment=REDIS_URL=redis://localhost:6379/0 
-Environment=TEMP_DIR=/app/temp_audio
+Environment=SERVICE_TYPE=worker
+EnvironmentFile=/etc/containers/systemd/AudioMuseAI/audiomuse.env
 
 [Service]
 Restart=always

--- a/deployment/podman-quadlets/audiomuse-postgres.container
+++ b/deployment/podman-quadlets/audiomuse-postgres.container
@@ -10,8 +10,7 @@ Volume=audiomuse-postgres-data:/var/lib/postgresql/data:U
 AutoUpdate=registry
 
 #Env
-Environment=POSTGRES_USER=audiomuse POSTGRES_PASSWORD=audiomusepassword 
-Environment=POSTGRES_DB=audiomusedb
+EnvironmentFile=/etc/containers/systemd/AudioMuseAI/audiomuse.env
 
 #Healthcheck
 HealthCmd=nc -z localhost 5432 || exit 1

--- a/deployment/podman-quadlets/audiomuse.env
+++ b/deployment/podman-quadlets/audiomuse.env
@@ -1,0 +1,20 @@
+# This file needs to be referenced with absolute paths from .container files
+MEDIASERVER_TYPE=jellyfin
+JELLYFIN_URL=http://jellyfin:8096
+JELLYFIN_USER_ID=
+JELLYFIN_TOKEN=
+POSTGRES_USER=audiomuse
+POSTGRES_PASSWORD=audiomuse
+POSTGRES_DB=audiomusedb
+POSTGRES_HOST=localhost
+POSTGRES_PORT=5432
+REDIS_URL=redis://localhost:6379/0
+GEMINI_API_KEY=
+GEMINI_MODEL_NAME=google/gemini-3-flash-preview
+TEMP_DIR=/app/temp_audio
+ENABLE_PROXY_FIX=false
+AUTH_ENABLED=true
+AUDIOMUSE_USER=
+AUDIOMUSE_PASSWORD=
+API_TOKEN=
+AI_MODEL_PROVIDER=

--- a/deployment/podman-quadlets/audiomuse.env
+++ b/deployment/podman-quadlets/audiomuse.env
@@ -1,16 +1,28 @@
 # This file needs to be referenced with absolute paths from .container files
-MEDIASERVER_TYPE=jellyfin
+MEDIASERVER_TYPE=navidrome
+# --- Emby ---
+EMBY_USER_ID=
+EMBY_TOKEN=
+EMBY_URL=
+
+# --- Navidrome ---
+NAVIDROME_URL=
+NAVIDROME_USER=
+NAVIDROME_PASSWORD=
+
+# --- Jellyfin ---
 JELLYFIN_URL=http://jellyfin:8096
 JELLYFIN_USER_ID=
 JELLYFIN_TOKEN=
+
 POSTGRES_USER=audiomuse
-POSTGRES_PASSWORD=audiomuse
+POSTGRES_PASSWORD=audiomusepassword
 POSTGRES_DB=audiomusedb
 POSTGRES_HOST=localhost
 POSTGRES_PORT=5432
 REDIS_URL=redis://localhost:6379/0
 GEMINI_API_KEY=
-GEMINI_MODEL_NAME=google/gemini-3-flash-preview
+GEMINI_MODEL_NAME=gemini-2.5-pro
 TEMP_DIR=/app/temp_audio
 ENABLE_PROXY_FIX=false
 AUTH_ENABLED=true


### PR DESCRIPTION
Instead of repeating the same Environment entry in each container file. Unfortunately you need to specify the absolute path which may be different.