### PR TITLE
CLAP INDEX creation for fast load - #452

### DIFF
--- a/app_helper.py
+++ b/app_helper.py
@@ -68,7 +68,7 @@ def get_db():
                 keepalives_idle=600,       # Start keepalives after 10 min idle
                 keepalives_interval=30,    # Send keepalive every 30 sec
                 keepalives_count=3,        # 3 failed keepalives = dead connection
-                options='-c statement_timeout=300000'  # 5 min query timeout (300 seconds)
+                options='-c statement_timeout=600000'  # 10 min query timeout (600 seconds)
             )
         except psycopg2.OperationalError as e:
             logger.error(f"Failed to connect to database: {e}")
@@ -219,6 +219,8 @@ def init_db():
                 if not cur.fetchone()[0]: cur.execute("ALTER TABLE mulan_embedding ADD COLUMN embedding BYTEA")
             # Create 'voyager_index_data' table
             cur.execute("CREATE TABLE IF NOT EXISTS voyager_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+            # Create 'clap_index_data' table for stored CLAP text search indexes
+            cur.execute("CREATE TABLE IF NOT EXISTS clap_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
             # Create 'artist_index_data' table for artist GMM-based HNSW index
             cur.execute("CREATE TABLE IF NOT EXISTS artist_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, artist_map_json TEXT NOT NULL, gmm_params_json TEXT NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
             # Create 'map_projection_data' table for precomputed 2D map projections

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -267,6 +267,7 @@ def rebuild_all_indexes_task():
 
             # Build CLAP text search index
             try:
+                logger.info('Building CLAP text search index...')
                 build_and_store_clap_index(get_db())
                 logger.info('✓ CLAP text search index rebuilt')
             except Exception as e:
@@ -1290,6 +1291,7 @@ def run_analysis_task(num_recent_albums, top_n_moods):
 
             # Build CLAP search index and store it in the database
             log_and_update_main("Building CLAP text search index...", 96)
+            logger.info('Building CLAP text search index...')
             try:
                 build_and_store_clap_index(get_db())
                 logger.info('CLAP text search index built and stored.')

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -267,9 +267,7 @@ def rebuild_all_indexes_task():
 
             # Build CLAP text search index
             try:
-                logger.info('Building CLAP text search index...')
                 build_and_store_clap_index(get_db())
-                logger.info('✓ CLAP text search index rebuilt')
             except Exception as e:
                 logger.warning(f"Failed to build/store CLAP text search index: {e}")
             
@@ -1291,10 +1289,8 @@ def run_analysis_task(num_recent_albums, top_n_moods):
 
             # Build CLAP search index and store it in the database
             log_and_update_main("Building CLAP text search index...", 96)
-            logger.info('Building CLAP text search index...')
             try:
                 build_and_store_clap_index(get_db())
-                logger.info('CLAP text search index built and stored.')
             except Exception as e:
                 logger.warning(f"Failed to build/store CLAP text search index: {e}")
             

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -51,6 +51,8 @@ from ai import get_ai_playlist_name, creative_prompt_template
 from .commons import score_vector
 # MODIFIED: Import from voyager_manager instead of annoy_manager
 from .voyager_manager import build_and_store_voyager_index
+# Import CLAP index builder for persisted text search index storage
+from .clap_text_search import build_and_store_clap_index
 # Import artist GMM manager for artist similarity index
 from .artist_gmm_manager import build_and_store_artist_index
 # MODIFIED: The functions from mediaserver no longer need server-specific parameters.
@@ -262,6 +264,13 @@ def rebuild_all_indexes_task():
             # Build Voyager index
             build_and_store_voyager_index(get_db())
             logger.info('✓ Voyager index rebuilt')
+
+            # Build CLAP text search index
+            try:
+                build_and_store_clap_index(get_db())
+                logger.info('✓ CLAP text search index rebuilt')
+            except Exception as e:
+                logger.warning(f"Failed to build/store CLAP text search index: {e}")
             
             # Build artist similarity index
             try:
@@ -1278,9 +1287,17 @@ def run_analysis_task(num_recent_albums, top_n_moods):
             log_and_update_main("Performing final index rebuild...", 95)
             # Build Voyager index (song embeddings)
             build_and_store_voyager_index(get_db())
+
+            # Build CLAP search index and store it in the database
+            log_and_update_main("Building CLAP text search index...", 96)
+            try:
+                build_and_store_clap_index(get_db())
+                logger.info('CLAP text search index built and stored.')
+            except Exception as e:
+                logger.warning(f"Failed to build/store CLAP text search index: {e}")
             
             # Build artist similarity index
-            log_and_update_main("Building artist similarity index...", 96)
+            log_and_update_main("Building artist similarity index...", 97)
             try:
                 build_and_store_artist_index(get_db())
                 logger.info('Artist similarity index built and stored.')

--- a/tasks/artist_gmm_manager.py
+++ b/tasks/artist_gmm_manager.py
@@ -849,26 +849,21 @@ def load_artist_index_for_querying(force_reload=False):
 
             parts.sort(key=lambda p: p[0])
 
-            # Reassemble binary and pick metadata from first non-empty segment
-            index_bytes = b"".join([p[1] for p in parts])
-            if not index_bytes:
-                logger.error("Reassembled Artist index binary is empty. Aborting load.")
-                artist_index = None
-                artist_map = None
-                reverse_artist_map = None
-                artist_gmm_params = None
-                return
-
-            if not artist_map_json_candidate or not gmm_params_json_candidate:
-                logger.error("No non-empty artist_map_json/gmm_params_json found in segmented Artist index rows. Aborting load.")
-                artist_index = None
-                artist_map = None
-                reverse_artist_map = None
-                artist_gmm_params = None
-                return
-
+            # Reassemble segments into a temporary file and load from that stream
+            index_stream = tempfile.TemporaryFile()
             try:
-                index_stream = io.BytesIO(index_bytes)
+                for _, part_data, _, _ in parts:
+                    index_stream.write(part_data)
+                index_stream.seek(0)
+
+                if not artist_map_json_candidate or not gmm_params_json_candidate:
+                    logger.error("No non-empty artist_map_json/gmm_params_json found in segmented Artist index rows. Aborting load.")
+                    artist_index = None
+                    artist_map = None
+                    reverse_artist_map = None
+                    artist_gmm_params = None
+                    return
+
                 index = voyager.Index.load(index_stream)
 
                 parsed_artist_map = {int(k): v for k, v in json.loads(artist_map_json_candidate).items()}
@@ -900,6 +895,11 @@ def load_artist_index_for_querying(force_reload=False):
                 reverse_artist_map = None
                 artist_gmm_params = None
                 return
+            finally:
+                try:
+                    index_stream.close()
+                except Exception as close_error:
+                    logger.warning("Failed to close Artist index stream: %s", close_error, exc_info=True)
             
         except Exception as e:
             logger.error(f"Failed to load artist index: {e}", exc_info=True)

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -188,19 +188,8 @@ def _load_clap_index_from_db() -> bool:
         finally:
             cur.close()
     except Exception as e:
-        logger.error(f"Failed to load CLAP index from DB: {e}")
-        import traceback
-        traceback.print_exc()
+        logger.error(f"Failed to load CLAP index from DB: {e}", exc_info=True)
         return False
-
-
-def _ensure_clap_index_table():
-    """Ensure the clap_index_data table exists before storing/loading an index."""
-    from app_helper import get_db
-    conn = get_db()
-    with conn.cursor() as cur:
-        cur.execute("CREATE TABLE IF NOT EXISTS clap_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
-    conn.commit()
 
 
 def build_and_store_clap_index(db_conn=None):

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -142,22 +142,23 @@ def _load_clap_index_from_db() -> bool:
 
             if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
                 logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
-                if hasattr(index_stream, 'close'):
-                    index_stream.close()
                 return False
 
             try:
-                import voyager  # type: ignore
-            except ImportError:
-                logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
-                if hasattr(index_stream, 'close'):
-                    index_stream.close()
-                return False
+                try:
+                    import voyager  # type: ignore
+                except ImportError:
+                    logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
+                    return False
 
-            loaded_index = voyager.Index.load(index_stream)
-            if hasattr(index_stream, 'close'):
-                index_stream.close()
-            loaded_index.ef = VOYAGER_QUERY_EF
+                loaded_index = voyager.Index.load(index_stream)
+                loaded_index.ef = VOYAGER_QUERY_EF
+            finally:
+                if hasattr(index_stream, 'close'):
+                    try:
+                        index_stream.close()
+                    except Exception as close_error:
+                        logger.warning("Failed to close CLAP index stream: %s", close_error, exc_info=True)
 
             id_map = {int(k): v for k, v in json.loads(id_map_json).items()}
             reverse_id_map = {v: k for k, v in id_map.items()}
@@ -494,7 +495,7 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
                 return []
 
             neighbor_ids, distances = voyager_index.query(text_embedding, k=num_to_query)
-            metadata_by_item = {m['item_id']: m for m in (_CLAP_CACHE['metadata'] or [])}
+            metadata_list = _CLAP_CACHE['metadata'] or []
 
             results = []
             artist_counts: dict = {}
@@ -504,7 +505,8 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
                 item_id = id_map.get(int(voyager_id))
                 if item_id is None:
                     continue
-                metadata = metadata_by_item.get(item_id, {'item_id': item_id, 'title': '', 'author': ''})
+                idx = int(voyager_id)
+                metadata = metadata_list[idx] if 0 <= idx < len(metadata_list) else {'item_id': item_id, 'title': '', 'author': ''}
                 author = metadata.get('author', '')
 
                 if artist_cap and author:
@@ -552,260 +554,6 @@ def get_cache_stats() -> Dict:
         'memory_mb': round(total_size_mb, 2)
     }
 
-
-def generate_top_queries(num_queries=None, top_n=50, return_scores=False):
-    """
-    Generate top N diverse queries by sampling from query.json.
-    Uses probabilistic category selection to ensure balanced representation.
-    Each query has exactly 3 terms from different categories.
-    Avoids mixing Instrumentation and Voice_Type in same query.
-    
-    Args:
-        num_queries: Number of random queries to generate (defaults to config.CLAP_TOP_QUERIES_COUNT)
-        top_n: Number of top queries to return
-        return_scores: If True, return list of dicts with 'query' and 'score' keys
-    
-    Returns:
-        List of query strings (or dicts if return_scores=True) sorted by score and diversity.
-    """
-    import json
-    import os
-    import random
-    from concurrent.futures import ThreadPoolExecutor
-    from collections import defaultdict
-    import multiprocessing
-    
-    # Use config default if not specified
-    if num_queries is None:
-        num_queries = config.CLAP_TOP_QUERIES_COUNT
-    
-    if not is_clap_cache_loaded():
-        logger.error("CLAP cache not loaded, cannot generate top queries")
-        return []
-    
-    # Load query.json
-    query_file = os.path.join(os.path.dirname(__file__), 'query.json')
-    with open(query_file, 'r') as f:
-        query_data = json.load(f)
-    
-    # Get category weights from config (optimized for CLAP's strengths)
-    category_weights = config.CLAP_CATEGORY_WEIGHTS
-    
-    # Generate random queries with smart category selection
-    def generate_random_query():
-        """Generate a query with exactly 3 terms from different categories using weighted sampling."""
-        # Weighted random sampling of 3 different categories
-        categories = list(query_data.keys())
-        weights = [category_weights.get(cat, 1.0) for cat in categories]
-        
-        # Sample 3 unique categories
-        selected_categories = []
-        available_categories = list(categories)
-        available_weights = list(weights)
-        
-        for _ in range(3):
-            if not available_categories:
-                break
-                
-            # Normalize weights
-            total_weight = sum(available_weights)
-            normalized_weights = [w / total_weight for w in available_weights]
-            
-            # Choose category
-            chosen_idx = random.choices(range(len(available_categories)), weights=normalized_weights)[0]
-            selected_categories.append(available_categories[chosen_idx])
-            
-            # Remove selected category from pool
-            available_categories.pop(chosen_idx)
-            available_weights.pop(chosen_idx)
-        
-        # Sample one term from each selected category
-        terms = [random.choice(query_data[cat]) for cat in selected_categories]
-        # Shuffle terms so category order varies
-        random.shuffle(terms)
-        return ' '.join(terms).lower()
-    
-    # Generate unique queries
-    queries = list(set([generate_random_query() for _ in range(num_queries)]))
-    logger.info(f"Generated {len(queries)} unique queries")
-    
-    # Compute embeddings in parallel using multithreading
-    from .clap_analyzer import get_text_embedding
-    
-    try:
-        # Use single core to prevent OOM on memory-constrained systems
-        # CLAP model is memory-intensive (3GB+), not urgent to run fast
-        num_cores = 1
-        
-        logger.info(f"Computing text embeddings for {len(queries)} queries using {num_cores} thread...")
-        
-        with ThreadPoolExecutor(max_workers=num_cores) as executor:
-            query_embeddings = list(executor.map(get_text_embedding, queries))
-        
-        # Filter out any None results
-        valid_data = [(q, e) for q, e in zip(queries, query_embeddings) if e is not None]
-        if not valid_data:
-            logger.error("No valid embeddings generated")
-            return []
-        
-        queries = [q for q, _ in valid_data]
-        query_embeddings = np.vstack([e for _, e in valid_data])
-        
-        logger.info(f"Computed {len(query_embeddings)} text embeddings")
-        
-    except Exception as e:
-        logger.error(f"Failed to compute text embeddings: {e}")
-        import traceback
-        traceback.print_exc()
-        return []
-    
-    # Now score ALL queries at once using vectorized matrix multiplication
-    song_embeddings = _CLAP_CACHE['embeddings']  # Shape: (N_songs, 512)
-    
-    logger.info(f"Scoring {len(queries)} queries against {len(song_embeddings)} songs using vectorized operations...")
-    
-    # Compute similarity matrix: (num_queries, N_songs)
-    # This is a single matrix multiplication - FAST!
-    similarity_matrix = np.dot(query_embeddings, song_embeddings.T)  # Shape: (500, N_songs)
-    
-    # For each query, get top 50 scores and sum them
-    top_k = 50
-    top_indices = np.argsort(similarity_matrix, axis=1)[:, ::-1][:, :top_k]  # Top 50 per query
-    
-    # Get the actual scores for top 50
-    row_indices = np.arange(len(queries))[:, None]
-    top_scores = similarity_matrix[row_indices, top_indices]  # Shape: (num_queries, 50)
-    
-    # Sum top 50 scores for each query
-    total_scores = np.sum(top_scores, axis=1)  # Shape: (num_queries,)
-    
-    logger.info(f"Computed scores for all queries in vectorized pass")
-    
-    # Now process term tracking in parallel
-    def analyze_query_terms(idx):
-        """Track which terms are used in a query."""
-        query = queries[idx]
-        terms_used = defaultdict(set)
-        # Split query into words for exact matching
-        query_words = set(query.lower().split())
-        for category, terms_list in query_data.items():
-            for term in terms_list:
-                # Check if term appears as complete words in query
-                term_words = set(term.lower().split())
-                if term_words.issubset(query_words):
-                    terms_used[category].add(term)
-        return (query, float(total_scores[idx]), dict(terms_used))
-    
-    # Use physical CPU cores for term analysis
-    num_cores = multiprocessing.cpu_count() // 2  # Physical cores
-    num_cores = max(1, num_cores)
-    # Use single core to prevent OOM on memory-constrained systems
-    num_cores = 1
-    
-    logger.info(f"Analyzing term diversity using {num_cores} thread...")
-    
-    with ThreadPoolExecutor(max_workers=num_cores) as executor:
-        scored_queries = list(executor.map(analyze_query_terms, range(len(queries))))
-    
-    # Sort by score
-    scored_queries.sort(key=lambda x: x[1], reverse=True)
-    
-    # Multi-pass selection to guarantee exactly top_n results
-    selected = []
-    term_usage_count = defaultdict(int)
-    category_usage_count = defaultdict(int)
-    
-    # Pass 1: Strict diversity (aim for first 40%)
-    target_pass1 = int(top_n * 0.4)
-    for query, score, terms_used in scored_queries:
-        if len(selected) >= target_pass1:
-            break
-        
-        # Calculate diversity penalty
-        term_penalty = 0
-        category_penalty = 0
-        
-        for category, terms_set in terms_used.items():
-            category_penalty += category_usage_count.get(category, 0) * 2
-            for term in terms_set:
-                term_penalty += term_usage_count.get(term, 0) * 5
-        
-        total_penalty = term_penalty + category_penalty
-        
-        # Skip if exact term appears more than once in pass 1
-        has_overused_term = False
-        for category, terms_set in terms_used.items():
-            for term in terms_set:
-                if term_usage_count.get(term, 0) >= 1:
-                    has_overused_term = True
-                    break
-            if has_overused_term:
-                break
-        
-        if has_overused_term:
-            continue
-        
-        selected.append(query)
-        
-        # Update usage counts
-        for category, terms_set in terms_used.items():
-            category_usage_count[category] += 1
-            for term in terms_set:
-                term_usage_count[term] += 1
-    
-    # Pass 2: Relaxed diversity (next 40%, allow terms up to 2x)
-    target_pass2 = int(top_n * 0.8)
-    for query, score, terms_used in scored_queries:
-        if len(selected) >= target_pass2:
-            break
-        
-        if query in selected:
-            continue
-        
-        # Allow terms to appear up to 2 times
-        has_overused_term = False
-        for category, terms_set in terms_used.items():
-            for term in terms_set:
-                if term_usage_count.get(term, 0) >= 2:
-                    has_overused_term = True
-                    break
-            if has_overused_term:
-                break
-        
-        if has_overused_term:
-            continue
-        
-        selected.append(query)
-        
-        # Update usage counts
-        for category, terms_set in terms_used.items():
-            category_usage_count[category] += 1
-            for term in terms_set:
-                term_usage_count[term] += 1
-    
-    # Pass 3: Fill remaining slots with highest scores (no restrictions)
-    for query, score, terms_used in scored_queries:
-        if len(selected) >= top_n:
-            break
-        
-        if query in selected:
-            continue
-        
-        selected.append(query)
-    
-    logger.info(f"Selected {len(selected)} diverse queries from {len(scored_queries)} candidates")
-    
-    # Return with or without scores
-    if return_scores:
-        # Return list of dicts with query and score
-        result = []
-        for query in selected:
-            # Find the score for this query
-            score = next((s for q, s, _ in scored_queries if q == query), 0.0)
-            result.append({'query': query, 'score': score})
-        return result
-    else:
-        return selected
 
 
 def ensure_text_search_queries_table():
@@ -983,52 +731,6 @@ def save_top_queries_to_db(queries: List[str], scores: List[float]):
         if conn:
             conn.rollback()
         return False
-
-
-def precompute_top_queries_background():
-    """
-    Precompute top queries in background thread.
-    Saves to database and updates in-memory cache.
-    Users get old queries from DB until new ones are ready.
-    """
-    global _TOP_QUERIES_CACHE
-    
-    if _TOP_QUERIES_CACHE['computing']:
-        logger.info("Top queries already being computed")
-        return
-    
-    _TOP_QUERIES_CACHE['computing'] = True
-    logger.info("Starting background computation of top queries...")
-    
-    try:
-        # Generate queries with scores (uses config.CLAP_TOP_QUERIES_COUNT)
-        scored_queries = generate_top_queries(top_n=50, return_scores=True)
-        
-        # Safety check: don't save empty query lists
-        if not scored_queries:
-            logger.warning("Query generation returned empty list - skipping save")
-            return
-        
-        queries = [q['query'] for q in scored_queries]
-        scores = [q['score'] for q in scored_queries]
-        
-        # Save to database needs Flask app context
-        from app import app
-        with app.app_context():
-            # Save to database first (atomic replacement)
-            if save_top_queries_to_db(queries, scores):
-                # Update in-memory cache
-                _TOP_QUERIES_CACHE['queries'] = queries
-                _TOP_QUERIES_CACHE['ready'] = True
-                logger.info(f"Top queries precomputed successfully: {len(queries)} queries ready")
-            else:
-                logger.error("Failed to save queries to database")
-    except Exception as e:
-        logger.error(f"Failed to precompute top queries: {e}")
-        import traceback
-        traceback.print_exc()
-    finally:
-        _TOP_QUERIES_CACHE['computing'] = False
 
 
 def get_cached_top_queries() -> List[str]:

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -54,7 +54,9 @@ _WARM_CACHE_TIMER = {
 
 def get_clap_cache_size() -> int:
     """Return the number of embeddings in the CLAP cache."""
-    global _CLAP_CACHE
+    global _CLAP_CACHE, _CLAP_INDEX_CACHE
+    if _CLAP_INDEX_CACHE['loaded'] and _CLAP_INDEX_CACHE['id_map'] is not None:
+        return len(_CLAP_INDEX_CACHE['id_map'])
     if _CLAP_CACHE['loaded'] and _CLAP_CACHE['metadata'] is not None:
         return len(_CLAP_CACHE['metadata'])
     return 0
@@ -70,7 +72,7 @@ def _load_clap_index_from_db() -> bool:
     global _CLAP_CACHE, _CLAP_INDEX_CACHE
 
     from app_helper import get_db
-    from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB
+    from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_QUERY_EF
 
     try:
         conn = get_db()
@@ -81,88 +83,94 @@ def _load_clap_index_from_db() -> bool:
                 ('clap_index',)
             )
             row = cur.fetchone()
+
             index_stream = None
-
-            if row:
-                index_binary_data, id_map_json, db_embedding_dim = row
-                index_stream = io.BytesIO(index_binary_data)
-            else:
-                cur.execute(
-                    "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
-                    (r'clap_index\_%\_%',)
-                )
-                rows = cur.fetchall()
-                if not rows:
-                    return False
-
-                seg_pattern = re.compile(r'^clap_index_(\d+)_(\d+)$')
-                parts = []
-                total_expected = None
-                id_map_json_candidate = None
-                for name, part_data, part_id_map_json, part_dim in rows:
-                    m = seg_pattern.match(name)
-                    if not m:
-                        continue
-                    part_no = int(m.group(1))
-                    total = int(m.group(2))
-                    if total_expected is None:
-                        total_expected = total
-                    elif total_expected != total:
-                        logger.error(f"Segment total mismatch for CLAP index parts ({total_expected} vs {total}).")
-                        return False
-                    parts.append((part_no, part_data, part_id_map_json, part_dim))
-                    if part_id_map_json and not id_map_json_candidate:
-                        id_map_json_candidate = part_id_map_json
-
-                if total_expected is None or len(parts) != total_expected:
-                    logger.error(f"Incomplete CLAP index segments: expected {total_expected}, found {len(parts)}.")
-                    return False
-
-                parts.sort(key=lambda p: p[0])
-                for _, _, _, part_dim in parts:
-                    if part_dim != CLAP_EMBEDDING_DIMENSION:
-                        logger.error(f"CLAP index embedding_dimension mismatch in segmented parts: expected {CLAP_EMBEDDING_DIMENSION}, got {part_dim}.")
-                        return False
-
-                if id_map_json_candidate is None:
-                    logger.error("No id_map_json found in segmented CLAP index rows.")
-                    return False
-
-                db_embedding_dim = parts[0][3]
-                index_stream = tempfile.TemporaryFile()
-                for _, part_data, _, _ in parts:
-                    index_stream.write(part_data)
-                index_stream.seek(0)
-                id_map_json = id_map_json_candidate
-
-            if index_stream is None:
-                logger.error("CLAP index binary data was empty.")
-                return False
-
-            if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
-                logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
-                if hasattr(index_stream, 'close'):
-                    try:
-                        index_stream.close()
-                    except Exception as close_error:
-                        logger.warning("Failed to close CLAP index stream: %s", close_error, exc_info=True)
-                return False
-
             try:
-                try:
-                    import voyager  # type: ignore
-                except ImportError:
-                    logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
+                if row:
+                    index_binary_data, id_map_json, db_embedding_dim = row
+                    index_stream = tempfile.TemporaryFile()
+                    index_stream.write(index_binary_data)
+                    index_stream.seek(0)
+                else:
+                    cur.execute(
+                        "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
+                        (r'clap_index\_%\_%',)
+                    )
+                    rows = cur.fetchall()
+                    if not rows:
+                        return False
+
+                    seg_pattern = re.compile(r'^clap_index_(\d+)_(\d+)$')
+                    parts = []
+                    total_expected = None
+                    id_map_json_candidate = None
+                    for name, part_data, part_id_map_json, part_dim in rows:
+                        m = seg_pattern.match(name)
+                        if not m:
+                            continue
+                        part_no = int(m.group(1))
+                        total = int(m.group(2))
+                        if total_expected is None:
+                            total_expected = total
+                        elif total_expected != total:
+                            logger.error(f"Segment total mismatch for CLAP index parts ({total_expected} vs {total}).")
+                            return False
+                        parts.append((part_no, part_data, part_id_map_json, part_dim))
+                        if part_id_map_json and not id_map_json_candidate:
+                            id_map_json_candidate = part_id_map_json
+
+                    if total_expected is None or len(parts) != total_expected:
+                        logger.error(f"Incomplete CLAP index segments: expected {total_expected}, found {len(parts)}.")
+                        return False
+
+                    parts.sort(key=lambda p: p[0])
+                    for _, _, _, part_dim in parts:
+                        if part_dim != CLAP_EMBEDDING_DIMENSION:
+                            logger.error(f"CLAP index embedding_dimension mismatch in segmented parts: expected {CLAP_EMBEDDING_DIMENSION}, got {part_dim}.")
+                            return False
+
+                    if id_map_json_candidate is None:
+                        logger.error("No id_map_json found in segmented CLAP index rows.")
+                        return False
+
+                    db_embedding_dim = parts[0][3]
+                    index_stream = tempfile.TemporaryFile()
+                    for _, part_data, _, _ in parts:
+                        index_stream.write(part_data)
+                    index_stream.seek(0)
+                    id_map_json = id_map_json_candidate
+
+                if index_stream is None:
+                    logger.error("CLAP index binary data was empty.")
                     return False
 
-                loaded_index = voyager.Index.load(index_stream)
-                loaded_index.ef = VOYAGER_QUERY_EF
-            finally:
-                if hasattr(index_stream, 'close'):
+                if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
+                    logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
+                    return False
+
+                try:
+                    try:
+                        import voyager  # type: ignore
+                    except ImportError:
+                        logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
+                        return False
+
+                    loaded_index = voyager.Index.load(index_stream)
+                    loaded_index.ef = VOYAGER_QUERY_EF
+                finally:
+                    if index_stream is not None:
+                        try:
+                            index_stream.close()
+                        except Exception as close_error:
+                            logger.warning("Failed to close CLAP index stream: %s", close_error, exc_info=True)
+
+            except Exception:
+                if index_stream is not None:
                     try:
                         index_stream.close()
-                    except Exception as close_error:
-                        logger.warning("Failed to close CLAP index stream: %s", close_error, exc_info=True)
+                    except Exception:
+                        pass
+                raise
 
             id_map = {int(k): v for k, v in json.loads(id_map_json).items()}
             reverse_id_map = {v: k for k, v in id_map.items()}
@@ -171,30 +179,9 @@ def _load_clap_index_from_db() -> bool:
                 logger.error("CLAP index id_map is empty.")
                 return False
 
-            item_ids = list(id_map.values())
-            metadata_by_id = {}
-            batch_size = 1000
-            for i in range(0, len(item_ids), batch_size):
-                batch_ids = item_ids[i:i + batch_size]
-                with conn.cursor(cursor_factory=DictCursor) as meta_cur:
-                    meta_cur.execute(
-                        "SELECT item_id, title, author FROM score WHERE item_id = ANY(%s)",
-                        (batch_ids,)
-                    )
-                    score_rows = meta_cur.fetchall()
-                for row in score_rows:
-                    metadata_by_id[row['item_id']] = {'title': row['title'], 'author': row['author']}
-            metadata_list = []
-            item_ids_list = []
-            for voyager_id in sorted(id_map.keys()):
-                item_id = id_map[voyager_id]
-                meta = metadata_by_id.get(item_id, {'title': '', 'author': ''})
-                metadata_list.append({'item_id': item_id, 'title': meta['title'], 'author': meta['author']})
-                item_ids_list.append(item_id)
-
             _CLAP_CACHE['embeddings'] = None
-            _CLAP_CACHE['metadata'] = metadata_list
-            _CLAP_CACHE['item_ids'] = item_ids_list
+            _CLAP_CACHE['metadata'] = None
+            _CLAP_CACHE['item_ids'] = None
             _CLAP_CACHE['loaded'] = True
 
             _CLAP_INDEX_CACHE['index'] = loaded_index
@@ -202,7 +189,7 @@ def _load_clap_index_from_db() -> bool:
             _CLAP_INDEX_CACHE['reverse_id_map'] = reverse_id_map
             _CLAP_INDEX_CACHE['loaded'] = True
 
-            logger.info(f"CLAP index loaded from database with {len(metadata_list)} items.")
+            logger.info(f"CLAP index loaded from database with {len(id_map)} items.")
             return True
     except Exception as e:
         logger.error(f"Failed to load CLAP index from DB: {e}", exc_info=True)
@@ -495,7 +482,17 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
                 return []
 
             neighbor_ids, distances = voyager_index.query(text_embedding, k=num_to_query)
-            metadata_list = _CLAP_CACHE['metadata'] or []
+            candidate_item_ids = [id_map.get(int(voyager_id)) for voyager_id in neighbor_ids]
+            candidate_item_ids = [item_id for item_id in candidate_item_ids if item_id is not None]
+
+            metadata_map = {}
+            if candidate_item_ids:
+                from app_helper import get_score_data_by_ids
+                try:
+                    track_details_list = get_score_data_by_ids(candidate_item_ids)
+                    metadata_map = {row['item_id']: {'title': row.get('title', ''), 'author': row.get('author', '')} for row in track_details_list}
+                except Exception:
+                    metadata_map = {}
 
             results = []
             artist_counts: dict = {}
@@ -505,8 +502,8 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
                 item_id = id_map.get(int(voyager_id))
                 if item_id is None:
                     continue
-                idx = int(voyager_id)
-                metadata = metadata_list[idx] if 0 <= idx < len(metadata_list) else {'item_id': item_id, 'title': '', 'author': ''}
+
+                metadata = metadata_map.get(item_id, {'title': '', 'author': ''})
                 author = metadata.get('author', '')
 
                 if artist_cap and author:
@@ -517,9 +514,9 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
 
                 similarity = 1.0 - float(distance)
                 results.append({
-                    'item_id': metadata['item_id'],
-                    'title': metadata['title'],
-                    'author': metadata['author'],
+                    'item_id': item_id,
+                    'title': metadata.get('title', ''),
+                    'author': metadata.get('author', ''),
                     'similarity': similarity
                 })
 
@@ -544,12 +541,17 @@ def get_cache_stats() -> Dict:
         }
     
     embeddings_size = _CLAP_CACHE['embeddings'].nbytes if _CLAP_CACHE['embeddings'] is not None else 0
-    metadata_size = sum(len(str(m)) for m in _CLAP_CACHE['metadata']) if _CLAP_CACHE['metadata'] else 0
+    metadata_size = 0
     total_size_mb = (embeddings_size + metadata_size) / (1024 * 1024)
-    
+    song_count = 0
+    if _CLAP_CACHE['metadata'] is not None:
+        song_count = len(_CLAP_CACHE['metadata'])
+    elif _CLAP_INDEX_CACHE['id_map'] is not None:
+        song_count = len(_CLAP_INDEX_CACHE['id_map'])
+
     return {
         'loaded': True,
-        'song_count': len(_CLAP_CACHE['metadata']) if _CLAP_CACHE['metadata'] else 0,
+        'song_count': song_count,
         'embedding_dimension': _CLAP_CACHE['embeddings'].shape[1] if _CLAP_CACHE['embeddings'] is not None else config.CLAP_EMBEDDING_DIMENSION,
         'memory_mb': round(total_size_mb, 2)
     }

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -142,6 +142,11 @@ def _load_clap_index_from_db() -> bool:
 
             if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
                 logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
+                if hasattr(index_stream, 'close'):
+                    try:
+                        index_stream.close()
+                    except Exception as close_error:
+                        logger.warning("Failed to close CLAP index stream: %s", close_error, exc_info=True)
                 return False
 
             try:
@@ -243,7 +248,8 @@ def build_and_store_clap_index(db_conn=None):
 
         id_map = {}
         vectors = []
-        for idx, (item_id, embedding_blob) in enumerate(all_embeddings):
+        voyager_id = 0
+        for item_id, embedding_blob in all_embeddings:
             if embedding_blob is None:
                 logger.warning(f"Skipping CLAP item {item_id} because embedding is NULL.")
                 continue
@@ -252,7 +258,8 @@ def build_and_store_clap_index(db_conn=None):
                 logger.warning(f"Skipping CLAP item {item_id}: dimension {embedding_vector.shape[0]} != {CLAP_EMBEDDING_DIMENSION}")
                 continue
             vectors.append(embedding_vector)
-            id_map[idx] = item_id
+            id_map[voyager_id] = item_id
+            voyager_id += 1
 
         if not vectors:
             logger.warning("No valid CLAP embedding vectors found for CLAP index build.")

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -82,9 +82,11 @@ def _load_clap_index_from_db() -> bool:
                 ('clap_index',)
             )
             row = cur.fetchone()
+            index_stream = None
 
             if row:
                 index_binary_data, id_map_json, db_embedding_dim = row
+                index_stream = io.BytesIO(index_binary_data)
             else:
                 cur.execute(
                     "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
@@ -128,25 +130,33 @@ def _load_clap_index_from_db() -> bool:
                     return False
 
                 db_embedding_dim = parts[0][3]
-                index_binary_data = b"".join(p[1] for p in parts)
+                index_stream = tempfile.TemporaryFile()
+                for _, part_data, _, _ in parts:
+                    index_stream.write(part_data)
+                index_stream.seek(0)
                 id_map_json = id_map_json_candidate
 
-            if not index_binary_data:
+            if index_stream is None:
                 logger.error("CLAP index binary data was empty.")
                 return False
 
             if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
                 logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
+                if hasattr(index_stream, 'close'):
+                    index_stream.close()
                 return False
 
             try:
                 import voyager  # type: ignore
             except ImportError:
                 logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
+                if hasattr(index_stream, 'close'):
+                    index_stream.close()
                 return False
 
-            index_stream = io.BytesIO(index_binary_data)
             loaded_index = voyager.Index.load(index_stream)
+            if hasattr(index_stream, 'close'):
+                index_stream.close()
             loaded_index.ef = VOYAGER_QUERY_EF
 
             id_map = {int(k): v for k, v in json.loads(id_map_json).items()}
@@ -156,14 +166,19 @@ def _load_clap_index_from_db() -> bool:
                 logger.error("CLAP index id_map is empty.")
                 return False
 
-            with conn.cursor(cursor_factory=DictCursor) as meta_cur:
-                meta_cur.execute(
-                    "SELECT item_id, title, author FROM score WHERE item_id = ANY(%s)",
-                    (list(id_map.values()),)
-                )
-                score_rows = meta_cur.fetchall()
-
-            metadata_by_id = {row['item_id']: {'title': row['title'], 'author': row['author']} for row in score_rows}
+            item_ids = list(id_map.values())
+            metadata_by_id = {}
+            batch_size = 1000
+            for i in range(0, len(item_ids), batch_size):
+                batch_ids = item_ids[i:i + batch_size]
+                with conn.cursor(cursor_factory=DictCursor) as meta_cur:
+                    meta_cur.execute(
+                        "SELECT item_id, title, author FROM score WHERE item_id = ANY(%s)",
+                        (batch_ids,)
+                    )
+                    score_rows = meta_cur.fetchall()
+                for row in score_rows:
+                    metadata_by_id[row['item_id']] = {'title': row['title'], 'author': row['author']}
             metadata_list = []
             item_ids_list = []
             for voyager_id in sorted(id_map.keys()):

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -160,6 +160,7 @@ def _load_clap_index_from_db() -> bool:
 
                 if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
                     logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
+                    index_stream.close()
                     return False
 
                 try:
@@ -212,7 +213,6 @@ def build_and_store_clap_index(db_conn=None):
     from app_helper import get_db
     from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_METRIC, VOYAGER_M, VOYAGER_EF_CONSTRUCTION, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB
 
-    logger.info("Building CLAP text search index...")
     try:
         import voyager  # type: ignore
     except ImportError:
@@ -299,7 +299,6 @@ def build_and_store_clap_index(db_conn=None):
                 logger.info(f"Stored CLAP index in {num_parts} segmented rows in clap_index_data.")
 
         db_conn.commit()
-        logger.info("CLAP index build and storage complete.")
         logger.info("CLAP text search index build successful.")
         return True
     except Exception as e:

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -212,6 +212,7 @@ def build_and_store_clap_index(db_conn=None):
     from app_helper import get_db
     from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_METRIC, VOYAGER_M, VOYAGER_EF_CONSTRUCTION, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB
 
+    logger.info("Building CLAP text search index...")
     try:
         import voyager  # type: ignore
     except ImportError:
@@ -299,6 +300,7 @@ def build_and_store_clap_index(db_conn=None):
 
         db_conn.commit()
         logger.info("CLAP index build and storage complete.")
+        logger.info("CLAP text search index build successful.")
         return True
     except Exception as e:
         logger.error(f"Failed to build and store CLAP index: {e}", exc_info=True)
@@ -401,7 +403,6 @@ def get_warm_cache_status() -> Dict:
 def load_clap_cache_from_db():
     """
     Load the persisted CLAP Voyager index from the database.
-    If no persisted index exists but raw CLAP embeddings are present, build the persisted index.
     Returns True if successful, False otherwise.
     """
     global _CLAP_CACHE
@@ -542,7 +543,13 @@ def get_cache_stats() -> Dict:
             'memory_mb': 0
         }
 
-    index_size = sys.getsizeof(_CLAP_INDEX_CACHE['index'])
+    index_obj = _CLAP_INDEX_CACHE['index']
+    index_size = sys.getsizeof(index_obj)
+    if isinstance(index_obj, np.ndarray):
+        index_size = index_obj.nbytes
+    elif hasattr(index_obj, 'embeddings') and isinstance(index_obj.embeddings, np.ndarray):
+        index_size = index_obj.embeddings.nbytes
+
     id_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['id_map']) if _CLAP_INDEX_CACHE['id_map'] is not None else 0
     reverse_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['reverse_id_map']) if _CLAP_INDEX_CACHE['reverse_id_map'] is not None else 0
     total_size_mb = (index_size + id_map_size + reverse_map_size) / (1024 * 1024)

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 import threading
 import time
-from collections import OrderedDict
 
 import numpy as np
 import psycopg2
@@ -22,11 +21,8 @@ import config
 
 logger = logging.getLogger(__name__)
 
-# Global in-memory cache
+# Global in-memory cache state
 _CLAP_CACHE = {
-    'embeddings': None,  # NumPy array (N, 512)
-    'metadata': None,    # List of dicts with item_id, title, author
-    'item_ids': None,    # List of item_ids
     'loaded': False
 }
 
@@ -45,10 +41,6 @@ _TOP_QUERIES_CACHE = {
     'computing': False
 }
 
-# Lightweight in-memory metadata cache for CLAP search results
-_CLAP_METADATA_CACHE: OrderedDict[str, Dict[str, str]] = OrderedDict()
-_CLAP_METADATA_CACHE_MAX_SIZE = 2000
-
 # Warm cache timer for text search (keeps model loaded)
 _WARM_CACHE_TIMER = {
     'expiry_time': None,  # Unix timestamp when model should unload
@@ -59,43 +51,27 @@ _WARM_CACHE_TIMER = {
 
 
 def get_clap_cache_size() -> int:
-    """Return the number of embeddings in the CLAP cache."""
-    global _CLAP_CACHE, _CLAP_INDEX_CACHE
+    """Return the number of items in the loaded CLAP index."""
     if _CLAP_INDEX_CACHE['loaded'] and _CLAP_INDEX_CACHE['id_map'] is not None:
         return len(_CLAP_INDEX_CACHE['id_map'])
-    if _CLAP_CACHE['loaded'] and _CLAP_CACHE['metadata'] is not None:
-        return len(_CLAP_CACHE['metadata'])
     return 0
 
 
-def _get_cached_clap_metadata(item_ids: list) -> Dict[str, Dict[str, str]]:
-    """Fetch metadata for CLAP result item_ids, using an in-memory cache where possible."""
-    global _CLAP_METADATA_CACHE
-
+def _fetch_clap_metadata(item_ids: list) -> Dict[str, Dict[str, str]]:
+    """Fetch metadata for CLAP result item_ids from the database."""
     metadata_map: Dict[str, Dict[str, str]] = {}
-    ids_to_fetch = []
-
-    for item_id in item_ids:
-        if item_id in _CLAP_METADATA_CACHE:
-            metadata_map[item_id] = _CLAP_METADATA_CACHE[item_id]
-        else:
-            ids_to_fetch.append(item_id)
-
-    if not ids_to_fetch:
+    if not item_ids:
         return metadata_map
 
     from app_helper import get_score_data_by_ids
     try:
-        track_details_list = get_score_data_by_ids(ids_to_fetch)
+        track_details_list = get_score_data_by_ids(item_ids)
         for row in track_details_list:
             item_id = row['item_id']
-            metadata = {'title': row.get('title', ''), 'author': row.get('author', '')}
-            metadata_map[item_id] = metadata
-            _CLAP_METADATA_CACHE[item_id] = metadata
-            _CLAP_METADATA_CACHE.move_to_end(item_id)
-
-        while len(_CLAP_METADATA_CACHE) > _CLAP_METADATA_CACHE_MAX_SIZE:
-            _CLAP_METADATA_CACHE.popitem(last=False)
+            metadata_map[item_id] = {
+                'title': row.get('title', ''),
+                'author': row.get('author', '')
+            }
     except Exception:
         pass
 
@@ -132,32 +108,30 @@ def _load_clap_index_from_db() -> bool:
                     index_stream.write(index_binary_data)
                     index_stream.seek(0)
                 else:
-                    cur.execute(
-                        "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
-                        (r'clap_index\_%\_%',)
-                    )
-                    rows = cur.fetchall()
-                    if not rows:
-                        return False
-
                     seg_pattern = re.compile(r'^clap_index_(\d+)_(\d+)$')
                     parts = []
                     total_expected = None
                     id_map_json_candidate = None
-                    for name, part_data, part_id_map_json, part_dim in rows:
-                        m = seg_pattern.match(name)
-                        if not m:
-                            continue
-                        part_no = int(m.group(1))
-                        total = int(m.group(2))
-                        if total_expected is None:
-                            total_expected = total
-                        elif total_expected != total:
-                            logger.error(f"Segment total mismatch for CLAP index parts ({total_expected} vs {total}).")
-                            return False
-                        parts.append((part_no, part_data, part_id_map_json, part_dim))
-                        if part_id_map_json and not id_map_json_candidate:
-                            id_map_json_candidate = part_id_map_json
+                    with conn.cursor(name='clap_index_segments') as seg_cur:
+                        seg_cur.itersize = 50
+                        seg_cur.execute(
+                            "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
+                            (r'clap_index\_%\_%',)
+                        )
+                        for name, part_data, part_id_map_json, part_dim in seg_cur:
+                            m = seg_pattern.match(name)
+                            if not m:
+                                continue
+                            part_no = int(m.group(1))
+                            total = int(m.group(2))
+                            if total_expected is None:
+                                total_expected = total
+                            elif total_expected != total:
+                                logger.error(f"Segment total mismatch for CLAP index parts ({total_expected} vs {total}).")
+                                return False
+                            parts.append((part_no, part_data, part_id_map_json, part_dim))
+                            if part_id_map_json and not id_map_json_candidate:
+                                id_map_json_candidate = part_id_map_json
 
                     if total_expected is None or len(parts) != total_expected:
                         logger.error(f"Incomplete CLAP index segments: expected {total_expected}, found {len(parts)}.")
@@ -219,9 +193,6 @@ def _load_clap_index_from_db() -> bool:
                 logger.error("CLAP index id_map is empty.")
                 return False
 
-            _CLAP_CACHE['embeddings'] = None
-            _CLAP_CACHE['metadata'] = None
-            _CLAP_CACHE['item_ids'] = None
             _CLAP_CACHE['loaded'] = True
 
             _CLAP_INDEX_CACHE['index'] = loaded_index
@@ -429,13 +400,14 @@ def get_warm_cache_status() -> Dict:
 
 def load_clap_cache_from_db():
     """
-    Load all CLAP embeddings and metadata into memory for fast searching.
+    Load the persisted CLAP Voyager index from the database.
+    If no persisted index exists but raw CLAP embeddings are present, build the persisted index.
     Returns True if successful, False otherwise.
     """
     global _CLAP_CACHE
     
     from app_helper import get_db
-    from config import CLAP_ENABLED, CLAP_EMBEDDING_DIMENSION
+    from config import CLAP_ENABLED
     
     if not CLAP_ENABLED:
         logger.info("CLAP is disabled, skipping cache load.")
@@ -446,9 +418,6 @@ def load_clap_cache_from_db():
         return True
 
     logger.error("Failed to load persisted CLAP index. CLAP text search will be unavailable.")
-    _CLAP_CACHE['embeddings'] = None
-    _CLAP_CACHE['metadata'] = None
-    _CLAP_CACHE['item_ids'] = None
     _CLAP_CACHE['loaded'] = False
     _CLAP_INDEX_CACHE['index'] = None
     _CLAP_INDEX_CACHE['id_map'] = None
@@ -525,12 +494,7 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
             candidate_item_ids = [id_map.get(int(voyager_id)) for voyager_id in neighbor_ids]
             candidate_item_ids = [item_id for item_id in candidate_item_ids if item_id is not None]
 
-            metadata_map = {}
-            if _CLAP_CACHE['metadata']:
-                metadata_map = {item['item_id']: {'title': item.get('title', ''), 'author': item.get('author', '')} for item in _CLAP_CACHE['metadata']}
-
-            if candidate_item_ids:
-                metadata_map.update(_get_cached_clap_metadata(candidate_item_ids))
+            metadata_map = _fetch_clap_metadata(candidate_item_ids)
 
             results = []
             artist_counts: dict = {}
@@ -570,7 +534,7 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
 
 def get_cache_stats() -> Dict:
     """Get statistics about the CLAP cache."""
-    if not _CLAP_CACHE['loaded']:
+    if not _CLAP_INDEX_CACHE['loaded'] or _CLAP_INDEX_CACHE['index'] is None:
         return {
             'loaded': False,
             'song_count': 0,
@@ -578,28 +542,16 @@ def get_cache_stats() -> Dict:
             'memory_mb': 0
         }
 
-    embeddings_size = _CLAP_CACHE['embeddings'].nbytes if _CLAP_CACHE['embeddings'] is not None else 0
-    metadata_size = 0
-    if _CLAP_CACHE['metadata'] is not None:
-        metadata_size = sum(len(str(m)) for m in _CLAP_CACHE['metadata'])
-    elif _CLAP_INDEX_CACHE['index'] is not None:
-        index_size = sys.getsizeof(_CLAP_INDEX_CACHE['index'])
-        id_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['id_map']) if _CLAP_INDEX_CACHE['id_map'] is not None else 0
-        reverse_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['reverse_id_map']) if _CLAP_INDEX_CACHE['reverse_id_map'] is not None else 0
-        metadata_cache_size = sum(sys.getsizeof(k) + sys.getsizeof(v) for k, v in _CLAP_METADATA_CACHE.items())
-        metadata_size = index_size + id_map_size + reverse_map_size + metadata_cache_size
-
-    total_size_mb = (embeddings_size + metadata_size) / (1024 * 1024)
-    song_count = 0
-    if _CLAP_CACHE['metadata'] is not None:
-        song_count = len(_CLAP_CACHE['metadata'])
-    elif _CLAP_INDEX_CACHE['id_map'] is not None:
-        song_count = len(_CLAP_INDEX_CACHE['id_map'])
+    index_size = sys.getsizeof(_CLAP_INDEX_CACHE['index'])
+    id_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['id_map']) if _CLAP_INDEX_CACHE['id_map'] is not None else 0
+    reverse_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['reverse_id_map']) if _CLAP_INDEX_CACHE['reverse_id_map'] is not None else 0
+    total_size_mb = (index_size + id_map_size + reverse_map_size) / (1024 * 1024)
+    song_count = len(_CLAP_INDEX_CACHE['id_map']) if _CLAP_INDEX_CACHE['id_map'] is not None else 0
 
     return {
         'loaded': True,
         'song_count': song_count,
-        'embedding_dimension': _CLAP_CACHE['embeddings'].shape[1] if _CLAP_CACHE['embeddings'] is not None else config.CLAP_EMBEDDING_DIMENSION,
+        'embedding_dimension': config.CLAP_EMBEDDING_DIMENSION,
         'memory_mb': round(total_size_mb, 2)
     }
 

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -8,9 +8,11 @@ import json
 import logging
 import os
 import re
+import sys
 import tempfile
 import threading
 import time
+from collections import OrderedDict
 
 import numpy as np
 import psycopg2
@@ -43,6 +45,10 @@ _TOP_QUERIES_CACHE = {
     'computing': False
 }
 
+# Lightweight in-memory metadata cache for CLAP search results
+_CLAP_METADATA_CACHE: OrderedDict[str, Dict[str, str]] = OrderedDict()
+_CLAP_METADATA_CACHE_MAX_SIZE = 2000
+
 # Warm cache timer for text search (keeps model loaded)
 _WARM_CACHE_TIMER = {
     'expiry_time': None,  # Unix timestamp when model should unload
@@ -60,6 +66,40 @@ def get_clap_cache_size() -> int:
     if _CLAP_CACHE['loaded'] and _CLAP_CACHE['metadata'] is not None:
         return len(_CLAP_CACHE['metadata'])
     return 0
+
+
+def _get_cached_clap_metadata(item_ids: list) -> Dict[str, Dict[str, str]]:
+    """Fetch metadata for CLAP result item_ids, using an in-memory cache where possible."""
+    global _CLAP_METADATA_CACHE
+
+    metadata_map: Dict[str, Dict[str, str]] = {}
+    ids_to_fetch = []
+
+    for item_id in item_ids:
+        if item_id in _CLAP_METADATA_CACHE:
+            metadata_map[item_id] = _CLAP_METADATA_CACHE[item_id]
+        else:
+            ids_to_fetch.append(item_id)
+
+    if not ids_to_fetch:
+        return metadata_map
+
+    from app_helper import get_score_data_by_ids
+    try:
+        track_details_list = get_score_data_by_ids(ids_to_fetch)
+        for row in track_details_list:
+            item_id = row['item_id']
+            metadata = {'title': row.get('title', ''), 'author': row.get('author', '')}
+            metadata_map[item_id] = metadata
+            _CLAP_METADATA_CACHE[item_id] = metadata
+            _CLAP_METADATA_CACHE.move_to_end(item_id)
+
+        while len(_CLAP_METADATA_CACHE) > _CLAP_METADATA_CACHE_MAX_SIZE:
+            _CLAP_METADATA_CACHE.popitem(last=False)
+    except Exception:
+        pass
+
+    return metadata_map
 
 
 def _split_bytes(data: bytes, part_size: int) -> list:
@@ -486,13 +526,11 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
             candidate_item_ids = [item_id for item_id in candidate_item_ids if item_id is not None]
 
             metadata_map = {}
+            if _CLAP_CACHE['metadata']:
+                metadata_map = {item['item_id']: {'title': item.get('title', ''), 'author': item.get('author', '')} for item in _CLAP_CACHE['metadata']}
+
             if candidate_item_ids:
-                from app_helper import get_score_data_by_ids
-                try:
-                    track_details_list = get_score_data_by_ids(candidate_item_ids)
-                    metadata_map = {row['item_id']: {'title': row.get('title', ''), 'author': row.get('author', '')} for row in track_details_list}
-                except Exception:
-                    metadata_map = {}
+                metadata_map.update(_get_cached_clap_metadata(candidate_item_ids))
 
             results = []
             artist_counts: dict = {}
@@ -539,9 +577,18 @@ def get_cache_stats() -> Dict:
             'embedding_dimension': 0,
             'memory_mb': 0
         }
-    
+
     embeddings_size = _CLAP_CACHE['embeddings'].nbytes if _CLAP_CACHE['embeddings'] is not None else 0
     metadata_size = 0
+    if _CLAP_CACHE['metadata'] is not None:
+        metadata_size = sum(len(str(m)) for m in _CLAP_CACHE['metadata'])
+    elif _CLAP_INDEX_CACHE['index'] is not None:
+        index_size = sys.getsizeof(_CLAP_INDEX_CACHE['index'])
+        id_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['id_map']) if _CLAP_INDEX_CACHE['id_map'] is not None else 0
+        reverse_map_size = sys.getsizeof(_CLAP_INDEX_CACHE['reverse_id_map']) if _CLAP_INDEX_CACHE['reverse_id_map'] is not None else 0
+        metadata_cache_size = sum(sys.getsizeof(k) + sys.getsizeof(v) for k, v in _CLAP_METADATA_CACHE.items())
+        metadata_size = index_size + id_map_size + reverse_map_size + metadata_cache_size
+
     total_size_mb = (embeddings_size + metadata_size) / (1024 * 1024)
     song_count = 0
     if _CLAP_CACHE['metadata'] is not None:

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -74,8 +74,7 @@ def _load_clap_index_from_db() -> bool:
 
     try:
         conn = get_db()
-        cur = conn.cursor()
-        try:
+        with conn.cursor() as cur:
             cur.execute("SET LOCAL statement_timeout = 0")
             cur.execute(
                 "SELECT index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name = %s",
@@ -205,9 +204,6 @@ def _load_clap_index_from_db() -> bool:
 
             logger.info(f"CLAP index loaded from database with {len(metadata_list)} items.")
             return True
-
-        finally:
-            cur.close()
     except Exception as e:
         logger.error(f"Failed to load CLAP index from DB: {e}", exc_info=True)
         return False
@@ -230,78 +226,78 @@ def build_and_store_clap_index(db_conn=None):
     max_part_size = VOYAGER_MAX_PART_SIZE_MB * 1024 * 1024
 
     try:
-        cur = db_conn.cursor()
-        cur.execute("SELECT item_id, embedding FROM clap_embedding")
-        all_embeddings = cur.fetchall()
+        with db_conn.cursor() as cur:
+            cur.execute("SELECT item_id, embedding FROM clap_embedding")
+            all_embeddings = cur.fetchall()
 
-        if not all_embeddings:
-            logger.warning("No CLAP embeddings found in DB to build CLAP index.")
-            return False
+            if not all_embeddings:
+                logger.warning("No CLAP embeddings found in DB to build CLAP index.")
+                return False
 
-        space = voyager.Space.Cosine if VOYAGER_METRIC == 'angular' else {
-            'euclidean': voyager.Space.Euclidean,
-            'dot': voyager.Space.InnerProduct
-        }.get(VOYAGER_METRIC, voyager.Space.Cosine)
+            space = voyager.Space.Cosine if VOYAGER_METRIC == 'angular' else {
+                'euclidean': voyager.Space.Euclidean,
+                'dot': voyager.Space.InnerProduct
+            }.get(VOYAGER_METRIC, voyager.Space.Cosine)
 
-        logger.info(f"Building CLAP voyager index for {len(all_embeddings)} items...")
-        index_builder = voyager.Index(space=space, num_dimensions=CLAP_EMBEDDING_DIMENSION, M=VOYAGER_M, ef_construction=VOYAGER_EF_CONSTRUCTION)
+            logger.info(f"Building CLAP voyager index for {len(all_embeddings)} items...")
+            index_builder = voyager.Index(space=space, num_dimensions=CLAP_EMBEDDING_DIMENSION, M=VOYAGER_M, ef_construction=VOYAGER_EF_CONSTRUCTION)
 
-        id_map = {}
-        vectors = []
-        voyager_id = 0
-        for item_id, embedding_blob in all_embeddings:
-            if embedding_blob is None:
-                logger.warning(f"Skipping CLAP item {item_id} because embedding is NULL.")
-                continue
-            embedding_vector = np.frombuffer(embedding_blob, dtype=np.float32)
-            if embedding_vector.shape[0] != CLAP_EMBEDDING_DIMENSION:
-                logger.warning(f"Skipping CLAP item {item_id}: dimension {embedding_vector.shape[0]} != {CLAP_EMBEDDING_DIMENSION}")
-                continue
-            vectors.append(embedding_vector)
-            id_map[voyager_id] = item_id
-            voyager_id += 1
+            id_map = {}
+            vectors = []
+            voyager_id = 0
+            for item_id, embedding_blob in all_embeddings:
+                if embedding_blob is None:
+                    logger.warning(f"Skipping CLAP item {item_id} because embedding is NULL.")
+                    continue
+                embedding_vector = np.frombuffer(embedding_blob, dtype=np.float32)
+                if embedding_vector.shape[0] != CLAP_EMBEDDING_DIMENSION:
+                    logger.warning(f"Skipping CLAP item {item_id}: dimension {embedding_vector.shape[0]} != {CLAP_EMBEDDING_DIMENSION}")
+                    continue
+                vectors.append(embedding_vector)
+                id_map[voyager_id] = item_id
+                voyager_id += 1
 
-        if not vectors:
-            logger.warning("No valid CLAP embedding vectors found for CLAP index build.")
-            return False
+            if not vectors:
+                logger.warning("No valid CLAP embedding vectors found for CLAP index build.")
+                return False
 
-        index_builder.add_items(np.vstack(vectors), ids=np.array(list(id_map.keys())))
+            index_builder.add_items(np.vstack(vectors), ids=np.array(list(id_map.keys())))
 
-        with tempfile.NamedTemporaryFile(delete=False, suffix='.voyager') as tmp:
-            temp_file_path = tmp.name
-        try:
-            index_builder.save(temp_file_path)
-            with open(temp_file_path, 'rb') as f:
-                index_binary_data = f.read()
-        finally:
-            if os.path.exists(temp_file_path):
-                os.remove(temp_file_path)
+            with tempfile.NamedTemporaryFile(delete=False, suffix='.voyager') as tmp:
+                temp_file_path = tmp.name
+            try:
+                index_builder.save(temp_file_path)
+                with open(temp_file_path, 'rb') as f:
+                    index_binary_data = f.read()
+            finally:
+                if os.path.exists(temp_file_path):
+                    os.remove(temp_file_path)
 
-        if not index_binary_data:
-            logger.error("Generated CLAP index binary is empty. Aborting storage.")
-            return False
+            if not index_binary_data:
+                logger.error("Generated CLAP index binary is empty. Aborting storage.")
+                return False
 
-        id_map_json = json.dumps(id_map)
-        cur.execute(
-            "DELETE FROM clap_index_data WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
-            ('clap_index', r'clap_index\_%\_%')
-        )
-
-        if len(index_binary_data) <= max_part_size:
+            id_map_json = json.dumps(id_map)
             cur.execute(
-                "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP) ON CONFLICT (index_name) DO UPDATE SET index_data = EXCLUDED.index_data, id_map_json = EXCLUDED.id_map_json, embedding_dimension = EXCLUDED.embedding_dimension, created_at = EXCLUDED.created_at",
-                ('clap_index', psycopg2.Binary(index_binary_data), id_map_json, CLAP_EMBEDDING_DIMENSION)
+                "DELETE FROM clap_index_data WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
+                ('clap_index', r'clap_index\_%\_%')
             )
-            logger.info("Stored CLAP index as single row in clap_index_data.")
-        else:
-            parts = _split_bytes(index_binary_data, max_part_size)
-            num_parts = len(parts)
-            insert_q = "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)"
-            for idx, part in enumerate(parts, start=1):
-                part_name = f"clap_index_{idx}_{num_parts}"
-                part_id_map_json = id_map_json if idx == 1 else ''
-                cur.execute(insert_q, (part_name, psycopg2.Binary(part), part_id_map_json, CLAP_EMBEDDING_DIMENSION))
-            logger.info(f"Stored CLAP index in {num_parts} segmented rows in clap_index_data.")
+
+            if len(index_binary_data) <= max_part_size:
+                cur.execute(
+                    "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP) ON CONFLICT (index_name) DO UPDATE SET index_data = EXCLUDED.index_data, id_map_json = EXCLUDED.id_map_json, embedding_dimension = EXCLUDED.embedding_dimension, created_at = EXCLUDED.created_at",
+                    ('clap_index', psycopg2.Binary(index_binary_data), id_map_json, CLAP_EMBEDDING_DIMENSION)
+                )
+                logger.info("Stored CLAP index as single row in clap_index_data.")
+            else:
+                parts = _split_bytes(index_binary_data, max_part_size)
+                num_parts = len(parts)
+                insert_q = "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)"
+                for idx, part in enumerate(parts, start=1):
+                    part_name = f"clap_index_{idx}_{num_parts}"
+                    part_id_map_json = id_map_json if idx == 1 else ''
+                    cur.execute(insert_q, (part_name, psycopg2.Binary(part), part_id_map_json, CLAP_EMBEDDING_DIMENSION))
+                logger.info(f"Stored CLAP index in {num_parts} segmented rows in clap_index_data.")
 
         db_conn.commit()
         logger.info("CLAP index build and storage complete.")
@@ -313,9 +309,6 @@ def build_and_store_clap_index(db_conn=None):
         except Exception:
             pass
         return False
-    finally:
-        if 'cur' in locals():
-            cur.close()
 
 
 def _unload_timer_worker():

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -3,13 +3,20 @@ CLAP Text Search Manager
 Provides in-memory caching and fast text-based music search using CLAP embeddings.
 """
 
+import io
+import json
 import logging
-import numpy as np
-from typing import List, Dict, Optional
-from psycopg2.extras import DictCursor
-import config
+import os
+import re
+import tempfile
 import threading
 import time
+
+import numpy as np
+import psycopg2
+from psycopg2.extras import DictCursor
+from typing import List, Dict, Optional
+import config
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +25,14 @@ _CLAP_CACHE = {
     'embeddings': None,  # NumPy array (N, 512)
     'metadata': None,    # List of dicts with item_id, title, author
     'item_ids': None,    # List of item_ids
+    'loaded': False
+}
+
+# Global in-memory CLAP index cache
+_CLAP_INDEX_CACHE = {
+    'index': None,
+    'id_map': None,
+    'reverse_id_map': None,
     'loaded': False
 }
 
@@ -40,9 +55,255 @@ _WARM_CACHE_TIMER = {
 def get_clap_cache_size() -> int:
     """Return the number of embeddings in the CLAP cache."""
     global _CLAP_CACHE
-    if _CLAP_CACHE['loaded'] and _CLAP_CACHE['embeddings'] is not None:
-        return len(_CLAP_CACHE['embeddings'])
+    if _CLAP_CACHE['loaded'] and _CLAP_CACHE['metadata'] is not None:
+        return len(_CLAP_CACHE['metadata'])
     return 0
+
+
+def _split_bytes(data: bytes, part_size: int) -> list:
+    """Split a bytes object into chunks no larger than part_size."""
+    return [data[i:i + part_size] for i in range(0, len(data), part_size)]
+
+
+def _load_clap_index_from_db() -> bool:
+    """Load a persisted CLAP voyager index from the database."""
+    global _CLAP_CACHE, _CLAP_INDEX_CACHE
+
+    from app_helper import get_db
+    from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB
+
+    try:
+        conn = get_db()
+        cur = conn.cursor()
+        try:
+            cur.execute("SET LOCAL statement_timeout = 0")
+            cur.execute(
+                "SELECT index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name = %s",
+                ('clap_index',)
+            )
+            row = cur.fetchone()
+
+            if row:
+                index_binary_data, id_map_json, db_embedding_dim = row
+            else:
+                cur.execute(
+                    "SELECT index_name, index_data, id_map_json, embedding_dimension FROM clap_index_data WHERE index_name LIKE %s ESCAPE '\\'",
+                    (r'clap_index\_%\_%',)
+                )
+                rows = cur.fetchall()
+                if not rows:
+                    return False
+
+                seg_pattern = re.compile(r'^clap_index_(\d+)_(\d+)$')
+                parts = []
+                total_expected = None
+                id_map_json_candidate = None
+                for name, part_data, part_id_map_json, part_dim in rows:
+                    m = seg_pattern.match(name)
+                    if not m:
+                        continue
+                    part_no = int(m.group(1))
+                    total = int(m.group(2))
+                    if total_expected is None:
+                        total_expected = total
+                    elif total_expected != total:
+                        logger.error(f"Segment total mismatch for CLAP index parts ({total_expected} vs {total}).")
+                        return False
+                    parts.append((part_no, part_data, part_id_map_json, part_dim))
+                    if part_id_map_json and not id_map_json_candidate:
+                        id_map_json_candidate = part_id_map_json
+
+                if total_expected is None or len(parts) != total_expected:
+                    logger.error(f"Incomplete CLAP index segments: expected {total_expected}, found {len(parts)}.")
+                    return False
+
+                parts.sort(key=lambda p: p[0])
+                for _, _, _, part_dim in parts:
+                    if part_dim != CLAP_EMBEDDING_DIMENSION:
+                        logger.error(f"CLAP index embedding_dimension mismatch in segmented parts: expected {CLAP_EMBEDDING_DIMENSION}, got {part_dim}.")
+                        return False
+
+                if id_map_json_candidate is None:
+                    logger.error("No id_map_json found in segmented CLAP index rows.")
+                    return False
+
+                db_embedding_dim = parts[0][3]
+                index_binary_data = b"".join(p[1] for p in parts)
+                id_map_json = id_map_json_candidate
+
+            if not index_binary_data:
+                logger.error("CLAP index binary data was empty.")
+                return False
+
+            if db_embedding_dim != CLAP_EMBEDDING_DIMENSION:
+                logger.error(f"CLAP index dimension mismatch: db={db_embedding_dim} expected={CLAP_EMBEDDING_DIMENSION}")
+                return False
+
+            try:
+                import voyager  # type: ignore
+            except ImportError:
+                logger.warning("Voyager library is unavailable; cannot load persisted CLAP index.")
+                return False
+
+            index_stream = io.BytesIO(index_binary_data)
+            loaded_index = voyager.Index.load(index_stream)
+            loaded_index.ef = VOYAGER_QUERY_EF
+
+            id_map = {int(k): v for k, v in json.loads(id_map_json).items()}
+            reverse_id_map = {v: k for k, v in id_map.items()}
+
+            if not id_map:
+                logger.error("CLAP index id_map is empty.")
+                return False
+
+            with conn.cursor(cursor_factory=DictCursor) as meta_cur:
+                meta_cur.execute(
+                    "SELECT item_id, title, author FROM score WHERE item_id = ANY(%s)",
+                    (list(id_map.values()),)
+                )
+                score_rows = meta_cur.fetchall()
+
+            metadata_by_id = {row['item_id']: {'title': row['title'], 'author': row['author']} for row in score_rows}
+            metadata_list = []
+            item_ids_list = []
+            for voyager_id in sorted(id_map.keys()):
+                item_id = id_map[voyager_id]
+                meta = metadata_by_id.get(item_id, {'title': '', 'author': ''})
+                metadata_list.append({'item_id': item_id, 'title': meta['title'], 'author': meta['author']})
+                item_ids_list.append(item_id)
+
+            _CLAP_CACHE['embeddings'] = None
+            _CLAP_CACHE['metadata'] = metadata_list
+            _CLAP_CACHE['item_ids'] = item_ids_list
+            _CLAP_CACHE['loaded'] = True
+
+            _CLAP_INDEX_CACHE['index'] = loaded_index
+            _CLAP_INDEX_CACHE['id_map'] = id_map
+            _CLAP_INDEX_CACHE['reverse_id_map'] = reverse_id_map
+            _CLAP_INDEX_CACHE['loaded'] = True
+
+            logger.info(f"CLAP index loaded from database with {len(metadata_list)} items.")
+            return True
+
+        finally:
+            cur.close()
+    except Exception as e:
+        logger.error(f"Failed to load CLAP index from DB: {e}")
+        import traceback
+        traceback.print_exc()
+        return False
+
+
+def _ensure_clap_index_table():
+    """Ensure the clap_index_data table exists before storing/loading an index."""
+    from app_helper import get_db
+    conn = get_db()
+    with conn.cursor() as cur:
+        cur.execute("CREATE TABLE IF NOT EXISTS clap_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+    conn.commit()
+
+
+def build_and_store_clap_index(db_conn=None):
+    """Build a CLAP text search voyager index from stored CLAP embeddings and save it to the DB."""
+    from app_helper import get_db
+    from config import CLAP_EMBEDDING_DIMENSION, VOYAGER_METRIC, VOYAGER_M, VOYAGER_EF_CONSTRUCTION, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB
+
+    try:
+        import voyager  # type: ignore
+    except ImportError:
+        logger.warning("Voyager library is unavailable; cannot build CLAP index.")
+        return False
+
+    if db_conn is None:
+        db_conn = get_db()
+
+    max_part_size = VOYAGER_MAX_PART_SIZE_MB * 1024 * 1024
+
+    try:
+        cur = db_conn.cursor()
+        cur.execute("SELECT item_id, embedding FROM clap_embedding")
+        all_embeddings = cur.fetchall()
+
+        if not all_embeddings:
+            logger.warning("No CLAP embeddings found in DB to build CLAP index.")
+            return False
+
+        space = voyager.Space.Cosine if VOYAGER_METRIC == 'angular' else {
+            'euclidean': voyager.Space.Euclidean,
+            'dot': voyager.Space.InnerProduct
+        }.get(VOYAGER_METRIC, voyager.Space.Cosine)
+
+        logger.info(f"Building CLAP voyager index for {len(all_embeddings)} items...")
+        index_builder = voyager.Index(space=space, num_dimensions=CLAP_EMBEDDING_DIMENSION, M=VOYAGER_M, ef_construction=VOYAGER_EF_CONSTRUCTION)
+
+        id_map = {}
+        vectors = []
+        for idx, (item_id, embedding_blob) in enumerate(all_embeddings):
+            if embedding_blob is None:
+                logger.warning(f"Skipping CLAP item {item_id} because embedding is NULL.")
+                continue
+            embedding_vector = np.frombuffer(embedding_blob, dtype=np.float32)
+            if embedding_vector.shape[0] != CLAP_EMBEDDING_DIMENSION:
+                logger.warning(f"Skipping CLAP item {item_id}: dimension {embedding_vector.shape[0]} != {CLAP_EMBEDDING_DIMENSION}")
+                continue
+            vectors.append(embedding_vector)
+            id_map[idx] = item_id
+
+        if not vectors:
+            logger.warning("No valid CLAP embedding vectors found for CLAP index build.")
+            return False
+
+        index_builder.add_items(np.vstack(vectors), ids=np.array(list(id_map.keys())))
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.voyager') as tmp:
+            temp_file_path = tmp.name
+        try:
+            index_builder.save(temp_file_path)
+            with open(temp_file_path, 'rb') as f:
+                index_binary_data = f.read()
+        finally:
+            if os.path.exists(temp_file_path):
+                os.remove(temp_file_path)
+
+        if not index_binary_data:
+            logger.error("Generated CLAP index binary is empty. Aborting storage.")
+            return False
+
+        id_map_json = json.dumps(id_map)
+        cur.execute(
+            "DELETE FROM clap_index_data WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
+            ('clap_index', r'clap_index\_%\_%')
+        )
+
+        if len(index_binary_data) <= max_part_size:
+            cur.execute(
+                "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP) ON CONFLICT (index_name) DO UPDATE SET index_data = EXCLUDED.index_data, id_map_json = EXCLUDED.id_map_json, embedding_dimension = EXCLUDED.embedding_dimension, created_at = EXCLUDED.created_at",
+                ('clap_index', psycopg2.Binary(index_binary_data), id_map_json, CLAP_EMBEDDING_DIMENSION)
+            )
+            logger.info("Stored CLAP index as single row in clap_index_data.")
+        else:
+            parts = _split_bytes(index_binary_data, max_part_size)
+            num_parts = len(parts)
+            insert_q = "INSERT INTO clap_index_data (index_name, index_data, id_map_json, embedding_dimension, created_at) VALUES (%s, %s, %s, %s, CURRENT_TIMESTAMP)"
+            for idx, part in enumerate(parts, start=1):
+                part_name = f"clap_index_{idx}_{num_parts}"
+                part_id_map_json = id_map_json if idx == 1 else ''
+                cur.execute(insert_q, (part_name, psycopg2.Binary(part), part_id_map_json, CLAP_EMBEDDING_DIMENSION))
+            logger.info(f"Stored CLAP index in {num_parts} segmented rows in clap_index_data.")
+
+        db_conn.commit()
+        logger.info("CLAP index build and storage complete.")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to build and store CLAP index: {e}", exc_info=True)
+        try:
+            db_conn.rollback()
+        except Exception:
+            pass
+        return False
+    finally:
+        if 'cur' in locals():
+            cur.close()
 
 
 def _unload_timer_worker():
@@ -147,77 +408,21 @@ def load_clap_cache_from_db():
     if not CLAP_ENABLED:
         logger.info("CLAP is disabled, skipping cache load.")
         return False
-    
-    try:
-        conn = get_db()
-        cur = conn.cursor(cursor_factory=DictCursor)
-        
-        # Fetch all CLAP embeddings with metadata from score table
-        cur.execute("""
-            SELECT 
-                ce.item_id,
-                ce.embedding,
-                s.title,
-                s.author
-            FROM clap_embedding ce
-            JOIN score s ON ce.item_id = s.item_id
-            ORDER BY ce.item_id
-        """)
-        
-        rows = cur.fetchall()
-        cur.close()
-        
-        if not rows:
-            logger.warning("No CLAP embeddings found in database.")
-            _CLAP_CACHE['loaded'] = False
-            return False
-        
-        # Build cache structures
-        embeddings_list = []
-        metadata_list = []
-        item_ids_list = []
-        
-        for row in rows:
-            item_id = row['item_id']
-            embedding_blob = row['embedding']
-            title = row['title']
-            author = row['author']
-            
-            # Convert BYTEA to numpy array
-            embedding = np.frombuffer(embedding_blob, dtype=np.float32)
-            
-            if embedding.shape[0] != CLAP_EMBEDDING_DIMENSION:
-                logger.warning(f"Skipping {item_id}: wrong dimension {embedding.shape[0]} (expected {CLAP_EMBEDDING_DIMENSION})")
-                continue
-            
-            embeddings_list.append(embedding)
-            metadata_list.append({
-                'item_id': item_id,
-                'title': title,
-                'author': author
-            })
-            item_ids_list.append(item_id)
-        
-        if not embeddings_list:
-            logger.error("No valid CLAP embeddings loaded.")
-            _CLAP_CACHE['loaded'] = False
-            return False
-        
-        # Convert to NumPy matrix for vectorized operations
-        _CLAP_CACHE['embeddings'] = np.vstack(embeddings_list)
-        _CLAP_CACHE['metadata'] = metadata_list
-        _CLAP_CACHE['item_ids'] = item_ids_list
-        _CLAP_CACHE['loaded'] = True
-        
-        logger.info(f"CLAP cache loaded: {len(metadata_list)} songs with 512-dim embeddings in memory")
+
+    if _load_clap_index_from_db():
+        logger.info("CLAP text cache loaded from persisted index.")
         return True
-        
-    except Exception as e:
-        logger.error(f"Failed to load CLAP cache: {e}")
-        import traceback
-        traceback.print_exc()
-        _CLAP_CACHE['loaded'] = False
-        return False
+
+    logger.error("Failed to load persisted CLAP index. CLAP text search will be unavailable.")
+    _CLAP_CACHE['embeddings'] = None
+    _CLAP_CACHE['metadata'] = None
+    _CLAP_CACHE['item_ids'] = None
+    _CLAP_CACHE['loaded'] = False
+    _CLAP_INDEX_CACHE['index'] = None
+    _CLAP_INDEX_CACHE['id_map'] = None
+    _CLAP_INDEX_CACHE['reverse_id_map'] = None
+    _CLAP_INDEX_CACHE['loaded'] = False
+    return False
 
 
 def refresh_clap_cache():
@@ -256,9 +461,9 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
     if not CLAP_ENABLED:
         return []
     
-    # Cache must be loaded at startup - no lazy loading
-    if not _CLAP_CACHE['loaded']:
-        logger.error("Cannot search: CLAP cache not loaded. Ensure Flask started successfully.")
+    # CLAP search must use the persisted index only
+    if not _CLAP_INDEX_CACHE['loaded'] or _CLAP_INDEX_CACHE['index'] is None:
+        logger.error("Cannot search: persisted CLAP index not loaded. Ensure Flask startup loaded the CLAP index.")
         return []
     
     try:
@@ -270,44 +475,50 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
         if text_embedding is None:
             logger.error(f"Failed to generate text embedding for: {query_text}")
             return []
-        
-        # Vectorized similarity computation (cosine similarity via dot product)
-        # Both embeddings are already normalized
-        similarities = _CLAP_CACHE['embeddings'] @ text_embedding
-        
-        # Over-fetch candidates to allow per-artist filtering.
-        # Formula matches voyager: n + max(20, n * 4) + 1
+
         from config import MAX_SONGS_PER_ARTIST
         artist_cap = MAX_SONGS_PER_ARTIST if MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0 else 0
         fetch_size = (limit + max(20, limit * 4) + 1) if artist_cap else limit
-        top_indices = np.argsort(similarities)[::-1][:fetch_size]
-        
-        results = []
-        artist_counts: dict = {}
-        for idx in top_indices:
-            if len(results) >= limit:
-                break
-            idx = int(idx)
-            similarity = float(similarities[idx])
-            metadata = _CLAP_CACHE['metadata'][idx]
-            author = metadata.get('author', '')
-            
-            # Enforce per-artist cap when enabled
-            if artist_cap and author:
-                author_norm = author.strip().lower()
-                if artist_counts.get(author_norm, 0) >= artist_cap:
+
+        if _CLAP_INDEX_CACHE['loaded'] and _CLAP_INDEX_CACHE['index'] is not None:
+            voyager_index = _CLAP_INDEX_CACHE['index']
+            id_map = _CLAP_INDEX_CACHE['id_map'] or {}
+            num_to_query = min(fetch_size, len(voyager_index))
+
+            if num_to_query <= 0:
+                logger.warning("CLAP index is loaded but contains no items.")
+                return []
+
+            neighbor_ids, distances = voyager_index.query(text_embedding, k=num_to_query)
+            metadata_by_item = {m['item_id']: m for m in (_CLAP_CACHE['metadata'] or [])}
+
+            results = []
+            artist_counts: dict = {}
+            for voyager_id, distance in zip(neighbor_ids, distances):
+                if len(results) >= limit:
+                    break
+                item_id = id_map.get(int(voyager_id))
+                if item_id is None:
                     continue
-                artist_counts[author_norm] = artist_counts.get(author_norm, 0) + 1
-            
-            results.append({
-                'item_id': metadata['item_id'],
-                'title': metadata['title'],
-                'author': metadata['author'],
-                'similarity': similarity
-            })
-        
-        logger.info(f"Text search '{query_text}': found {len(results)} results (artist cap: {artist_cap or 'disabled'})")
-        return results
+                metadata = metadata_by_item.get(item_id, {'item_id': item_id, 'title': '', 'author': ''})
+                author = metadata.get('author', '')
+
+                if artist_cap and author:
+                    author_norm = author.strip().lower()
+                    if artist_counts.get(author_norm, 0) >= artist_cap:
+                        continue
+                    artist_counts[author_norm] = artist_counts.get(author_norm, 0) + 1
+
+                similarity = 1.0 - float(distance)
+                results.append({
+                    'item_id': metadata['item_id'],
+                    'title': metadata['title'],
+                    'author': metadata['author'],
+                    'similarity': similarity
+                })
+
+            logger.info(f"Text search '{query_text}': found {len(results)} results via CLAP index (artist cap: {artist_cap or 'disabled'})")
+            return results
         
     except Exception as e:
         logger.error(f"Text search failed for '{query_text}': {e}")
@@ -333,7 +544,7 @@ def get_cache_stats() -> Dict:
     return {
         'loaded': True,
         'song_count': len(_CLAP_CACHE['metadata']) if _CLAP_CACHE['metadata'] else 0,
-        'embedding_dimension': _CLAP_CACHE['embeddings'].shape[1] if _CLAP_CACHE['embeddings'] is not None else 0,
+        'embedding_dimension': _CLAP_CACHE['embeddings'].shape[1] if _CLAP_CACHE['embeddings'] is not None else config.CLAP_EMBEDDING_DIMENSION,
         'memory_mb': round(total_size_mb, 2)
     }
 

--- a/tasks/voyager_manager.py
+++ b/tasks/voyager_manager.py
@@ -243,20 +243,19 @@ def load_voyager_index_for_querying(force_reload=False):
                 return
 
         # Reassemble binary and pick id_map_json from first non-empty segment (prefer part 1)
-        index_binary_data = b"".join([p[1] for p in parts])
-        if not index_binary_data:
-            logger.error(f"Reassembled Voyager index binary is empty. Aborting load.")
-            voyager_index, id_map, reverse_id_map = None, None, None
-            return
+        index_stream = tempfile.TemporaryFile()
+        for _, part_data, _, _ in parts:
+            index_stream.write(part_data)
+        index_stream.seek(0)
 
         if not id_map_json_candidate:
             logger.error("No non-empty id_map_json found in segmented Voyager index rows. Aborting load.")
             voyager_index, id_map, reverse_id_map = None, None, None
+            index_stream.close()
             return
 
         # Final validation: try loading Voyager and ensure element count matches id_map length
         try:
-            index_stream = io.BytesIO(index_binary_data)
             loaded_index = voyager.Index.load(index_stream)
             loaded_index.ef = VOYAGER_QUERY_EF
             # Validate element counts if voyager exposes num_elements
@@ -281,6 +280,11 @@ def load_voyager_index_for_querying(force_reload=False):
             logger.error(f"Failed to load reassembled Voyager index: {load_error}", exc_info=True)
             voyager_index, id_map, reverse_id_map = None, None, None
             return
+        finally:
+            try:
+                index_stream.close()
+            except Exception as close_error:
+                logger.warning("Failed to close Voyager index stream: %s", close_error, exc_info=True)
 
     except Exception as e:
         logger.error("Failed to load Voyager index from database: %s", e, exc_info=True)

--- a/tests/unit/test_clap_text_search.py
+++ b/tests/unit/test_clap_text_search.py
@@ -8,6 +8,36 @@ import numpy as np
 from unittest.mock import Mock, patch, MagicMock
 
 
+class DummyVoyagerIndex:
+    """Simple fake Voyager index for unit tests."""
+    def __init__(self, embeddings: np.ndarray):
+        self.embeddings = embeddings
+
+    def __len__(self):
+        return len(self.embeddings)
+
+    def query(self, query_vector: np.ndarray, k: int):
+        similarities = self.embeddings @ query_vector
+        order = np.argsort(similarities)[::-1]
+        top = order[:k]
+        distances = (1.0 - similarities[top]).astype(np.float32)
+        return list(top), distances
+
+
+def setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, embeddings, item_ids):
+    _CLAP_INDEX_CACHE['loaded'] = True
+    _CLAP_INDEX_CACHE['index'] = DummyVoyagerIndex(embeddings)
+    _CLAP_INDEX_CACHE['id_map'] = {i: item_ids[i] for i in range(len(item_ids))}
+    _CLAP_INDEX_CACHE['reverse_id_map'] = {item_ids[i]: i for i in range(len(item_ids))}
+
+
+def teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE):
+    _CLAP_INDEX_CACHE['loaded'] = False
+    _CLAP_INDEX_CACHE['index'] = None
+    _CLAP_INDEX_CACHE['id_map'] = None
+    _CLAP_INDEX_CACHE['reverse_id_map'] = None
+
+
 class TestCacheStatsCalculation:
     """Tests for CLAP cache statistics calculation"""
 
@@ -106,7 +136,7 @@ class TestSimilarityCalculationLogic:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_similarity_ranking_order(self, mock_get_embedding):
         """Test that search results are ranked by similarity (highest first)"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         # Setup cache with known embeddings
         _CLAP_CACHE['loaded'] = True
@@ -130,6 +160,7 @@ class TestSimilarityCalculationLogic:
             for i in range(5)
         ]
         _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(5)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         # Query embedding similar to first embedding
         query_embedding = np.array([1.0, 0.0, 0.0], dtype=np.float32)
@@ -156,7 +187,7 @@ class TestSimilarityCalculationLogic:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_respects_limit_parameter(self, mock_get_embedding):
         """Test that search returns at most 'limit' results"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         # Setup cache with 20 songs
         _CLAP_CACHE['loaded'] = True
@@ -171,6 +202,7 @@ class TestSimilarityCalculationLogic:
             for i in range(20)
         ]
         _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(20)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
@@ -187,6 +219,7 @@ class TestSimilarityCalculationLogic:
         assert len(results) == 15
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None
@@ -196,7 +229,7 @@ class TestSimilarityCalculationLogic:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_limit_larger_than_cache(self, mock_get_embedding):
         """Test search when limit exceeds available songs"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         # Setup cache with only 5 songs
         _CLAP_CACHE['loaded'] = True
@@ -210,6 +243,7 @@ class TestSimilarityCalculationLogic:
             for i in range(5)
         ]
         _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(5)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
@@ -222,6 +256,7 @@ class TestSimilarityCalculationLogic:
         assert len(results) == 5
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None
@@ -235,7 +270,7 @@ class TestSearchResultStructure:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_result_contains_required_fields(self, mock_get_embedding):
         """Test that each result contains all required fields"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         _CLAP_CACHE['loaded'] = True
         _CLAP_CACHE['embeddings'] = np.random.rand(3, 512).astype(np.float32)
@@ -249,6 +284,7 @@ class TestSearchResultStructure:
             {'item_id': 'song3', 'title': 'Third Song', 'author': 'Third Artist'},
         ]
         _CLAP_CACHE['item_ids'] = ['song1', 'song2', 'song3']
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
@@ -273,6 +309,7 @@ class TestSearchResultStructure:
             assert -1.0 <= result['similarity'] <= 1.0
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None
@@ -282,7 +319,7 @@ class TestSearchResultStructure:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_preserves_metadata_accurately(self, mock_get_embedding):
         """Test that search results preserve original metadata"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         _CLAP_CACHE['loaded'] = True
         _CLAP_CACHE['embeddings'] = np.random.rand(2, 512).astype(np.float32)
@@ -296,6 +333,7 @@ class TestSearchResultStructure:
             {'item_id': 'xyz789', 'title': 'Stairway to Heaven', 'author': 'Led Zeppelin'},
         ]
         _CLAP_CACHE['item_ids'] = ['abc123', 'xyz789']
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
@@ -316,6 +354,7 @@ class TestSearchResultStructure:
         assert song2['author'] == 'Led Zeppelin'
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None
@@ -349,14 +388,16 @@ class TestSearchEdgeCases:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_handles_failed_text_embedding(self, mock_get_embedding):
         """Test that search handles text embedding failure gracefully"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         _CLAP_CACHE['loaded'] = True
         _CLAP_CACHE['embeddings'] = np.random.rand(5, 512).astype(np.float32)
         _CLAP_CACHE['metadata'] = [{'item_id': f'song{i}', 'title': f'Song {i}', 'author': f'Artist {i}'} for i in range(5)]
+        _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(5)]
         
         # Simulate embedding failure
         mock_get_embedding.return_value = None
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         results = search_by_text("test query", limit=10)
         
@@ -364,6 +405,7 @@ class TestSearchEdgeCases:
         assert results == []
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None
@@ -372,7 +414,7 @@ class TestSearchEdgeCases:
     @patch('tasks.clap_analyzer.get_text_embedding')
     def test_search_with_zero_limit(self, mock_get_embedding):
         """Test search with limit of 0"""
-        from tasks.clap_text_search import search_by_text, _CLAP_CACHE
+        from tasks.clap_text_search import search_by_text, _CLAP_CACHE, _CLAP_INDEX_CACHE
         
         _CLAP_CACHE['loaded'] = True
         _CLAP_CACHE['embeddings'] = np.random.rand(10, 512).astype(np.float32)
@@ -382,6 +424,7 @@ class TestSearchEdgeCases:
         
         _CLAP_CACHE['metadata'] = [{'item_id': f'song{i}', 'title': f'Song {i}', 'author': f'Artist {i}'} for i in range(10)]
         _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(10)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, _CLAP_CACHE['embeddings'], _CLAP_CACHE['item_ids'])
         
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
@@ -393,6 +436,7 @@ class TestSearchEdgeCases:
         assert results == []
         
         # Cleanup
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
         _CLAP_CACHE['loaded'] = False
         _CLAP_CACHE['embeddings'] = None
         _CLAP_CACHE['metadata'] = None

--- a/tests/unit/test_clap_text_search.py
+++ b/tests/unit/test_clap_text_search.py
@@ -329,9 +329,14 @@ class TestSearchResultStructure:
         query_embedding = np.random.rand(512).astype(np.float32)
         query_embedding /= np.linalg.norm(query_embedding)
         mock_get_embedding.return_value = query_embedding
-        
-        results = search_by_text("rock classics", limit=2)
-        
+
+        with patch('app_helper.get_score_data_by_ids') as mock_get_score_data:
+            mock_get_score_data.return_value = [
+                {'item_id': 'abc123', 'title': 'Bohemian Rhapsody', 'author': 'Queen'},
+                {'item_id': 'xyz789', 'title': 'Stairway to Heaven', 'author': 'Led Zeppelin'},
+            ]
+            results = search_by_text("rock classics", limit=2)
+
         # Find each song in results
         song1 = next((r for r in results if r['item_id'] == 'abc123'), None)
         song2 = next((r for r in results if r['item_id'] == 'xyz789'), None)

--- a/tests/unit/test_clap_text_search.py
+++ b/tests/unit/test_clap_text_search.py
@@ -43,15 +43,14 @@ class TestCacheStatsCalculation:
 
     def test_get_cache_stats_when_not_loaded(self):
         """Test cache stats return empty structure when cache not loaded"""
-        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE
-        
+        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE, _CLAP_INDEX_CACHE
+
         # Ensure cache is not loaded
         _CLAP_CACHE['loaded'] = False
-        _CLAP_CACHE['embeddings'] = None
-        _CLAP_CACHE['metadata'] = None
-        
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
+
         stats = get_cache_stats()
-        
+
         assert stats['loaded'] is False
         assert stats['song_count'] == 0
         assert stats['embedding_dimension'] == 0
@@ -59,51 +58,43 @@ class TestCacheStatsCalculation:
 
     def test_get_cache_stats_with_loaded_cache(self):
         """Test cache stats calculation with loaded data"""
-        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE
-        
-        # Simulate loaded cache with 100 songs, 512-dim embeddings
+        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE, _CLAP_INDEX_CACHE
+
+        # Simulate loaded CLAP index with 100 songs
         _CLAP_CACHE['loaded'] = True
-        _CLAP_CACHE['embeddings'] = np.random.rand(100, 512).astype(np.float32)
-        _CLAP_CACHE['metadata'] = [
-            {'item_id': f'song{i}', 'title': f'Title {i}', 'author': f'Artist {i}'}
-            for i in range(100)
-        ]
-        _CLAP_CACHE['item_ids'] = [f'song{i}' for i in range(100)]
-        
+        embeddings = np.random.rand(100, 512).astype(np.float32)
+        item_ids = [f'song{i}' for i in range(100)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, embeddings, item_ids)
+
         stats = get_cache_stats()
-        
+
         assert stats['loaded'] is True
         assert stats['song_count'] == 100
         assert stats['embedding_dimension'] == 512
         assert stats['memory_mb'] > 0  # Should calculate memory size
-        
+
         # Cleanup
         _CLAP_CACHE['loaded'] = False
-        _CLAP_CACHE['embeddings'] = None
-        _CLAP_CACHE['metadata'] = None
-        _CLAP_CACHE['item_ids'] = None
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
 
     def test_get_cache_stats_memory_calculation_accuracy(self):
         """Test that memory calculation is reasonable"""
-        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE
-        
-        # 10 songs × 512 dimensions × 4 bytes (float32) = ~20KB
+        from tasks.clap_text_search import get_cache_stats, _CLAP_CACHE, _CLAP_INDEX_CACHE
+
+        # Simulate loaded CLAP index with 10 songs
         _CLAP_CACHE['loaded'] = True
-        _CLAP_CACHE['embeddings'] = np.random.rand(10, 512).astype(np.float32)
-        _CLAP_CACHE['metadata'] = [
-            {'item_id': f'song{i}', 'title': 'Title', 'author': 'Artist'}
-            for i in range(10)
-        ]
-        
+        embeddings = np.random.rand(10, 512).astype(np.float32)
+        item_ids = [f'song{i}' for i in range(10)]
+        setup_dummy_clap_index_cache(_CLAP_INDEX_CACHE, embeddings, item_ids)
+
         stats = get_cache_stats()
-        
-        # Should be around 0.02 MB for embeddings + small overhead for metadata
-        assert 0.01 < stats['memory_mb'] < 0.1
-        
+
+        # Should report a small non-zero memory size for the in-memory index
+        assert 0.0 < stats['memory_mb'] < 1.0
+
         # Cleanup
         _CLAP_CACHE['loaded'] = False
-        _CLAP_CACHE['embeddings'] = None
-        _CLAP_CACHE['metadata'] = None
+        teardown_dummy_clap_index_cache(_CLAP_INDEX_CACHE)
 
 
 class TestCacheStateChecking:


### PR DESCRIPTION
As-is CLAP search load the entire embbeding table on a numpy ram cache and perform search on it. Very old computer or low speed device (like noavx2 nas) seems to be slower in the load activity and the db connection go in timeout.

In this PR:
- We raise the timeout for connection to the db from 5 to 10 minutes
- We introduce a Voyager index also for clap search, load a bytea index from the database instead of the entire table should be faster
- The clap search is performed now on an index instead of on numpy. Performance change on normal computer is not noticeable (with big library it passed from around 100ms to around 40ms) but could help low power one.