### PR TITLE
backup restore functionality: added improved db cleanup before restore

### DIFF
--- a/app_backup.py
+++ b/app_backup.py
@@ -69,7 +69,7 @@ def _run_restore_runner(dump_file, log_file):
             '-d', POSTGRES_DB,
             '-v', 'ON_ERROR_STOP=1',
             '--single-transaction',
-            '-c', 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO public;',
+            '-c', 'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;',
             '-f', dump_file
         )
         log.write(f"Running restore command: {' '.join(restore_cmd)}\n")

--- a/app_backup.py
+++ b/app_backup.py
@@ -64,7 +64,14 @@ def _run_restore_runner(dump_file, log_file):
             log.write("Continuing restore despite local Flask stop failure.\n")
             log.flush()
 
-        restore_cmd = _pg_cmd('psql', '-d', POSTGRES_DB, '-v', 'ON_ERROR_STOP=1', '-f', dump_file)
+        restore_cmd = _pg_cmd(
+            'psql',
+            '-d', POSTGRES_DB,
+            '-v', 'ON_ERROR_STOP=1',
+            '--single-transaction',
+            '-c', 'DROP SCHEMA public CASCADE; CREATE SCHEMA public; GRANT ALL ON SCHEMA public TO public;',
+            '-f', dump_file
+        )
         log.write(f"Running restore command: {' '.join(restore_cmd)}\n")
         log.flush()
 


### PR DESCRIPTION
Before the restore functionality GET the table from the backup, IF exist that same table it drop from the actual database, FINALLY it restore the backup table.

With this PR it DROP all the table and restore exactly the database form the backup.

In this way you avoid to have hanging table from a previous installation and maybe not used anymore.