### PR TITLE
Add NixOS support: packaging and service module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,5 @@ student_clap/models/FMA_SONGS_2247_LICENSE.md
 
 # Testing suite
 testing_suite/
+
+/result

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ MUSIC_LIBRARIES = os.environ.get("MUSIC_LIBRARIES", "")
 # Maximum number of items to fetch during the connection probe.
 # Set to 0 to scan all top-played items, or a small positive integer to keep the probe fast.
 PROBE_TOP_PLAYED_LIMIT = int(os.environ.get("PROBE_TOP_PLAYED_LIMIT", "1"))
-TEMP_DIR = "/app/temp_audio"  # Always use /app/temp_audio
+TEMP_DIR = os.environ.get("TEMP_DIR", "/app/temp_audio")
 
 
 def _compute_headers():

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,40 @@
+{
+  "nodes": {
+    "flake-schemas": {
+      "locked": {
+        "lastModified": 1775244557,
+        "narHash": "sha256-iYXRXIX9eafJmwJFAhqT3YxvvpNRuPFSLRCSpvGh8Ic=",
+        "rev": "15edbeeaf77e42216dbcba8bfd907fdeabb75a2b",
+        "revCount": 132,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/DeterminateSystems/flake-schemas/0.4.2/019d5cf2-ee3c-7313-964e-f3f83c35d509/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/DeterminateSystems/flake-schemas/%2A"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776877367,
+        "narHash": "sha256-EHq1/OX139R1RvBzOJ0aMRT3xnWyqtHBRUBuO1gFzjI=",
+        "rev": "0726a0ecb6d4e08f6adced58726b95db924cef57",
+        "revCount": 985613,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.1.985613%2Brev-0726a0ecb6d4e08f6adced58726b95db924cef57/019dc33e-a3ef-7cf1-936a-cf64d10f6c63/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.1.%2A"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-schemas": "flake-schemas",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,90 @@
+{
+  description = "AudioMuse-AI — AI-powered music analysis and playlist generation";
+
+  inputs = {
+    flake-schemas.url = "https://flakehub.com/f/DeterminateSystems/flake-schemas/*";
+    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.1.*";
+  };
+
+  outputs =
+    {
+      self,
+      flake-schemas,
+      nixpkgs,
+    }:
+    let
+      # Packages are Linux-only (native ML libs + systemd services)
+      supportedSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forEachSupportedSystem =
+        f:
+        nixpkgs.lib.genAttrs supportedSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+
+      # Dev shells support more platforms
+      devShellSystems = [
+        "x86_64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+        "aarch64-linux"
+      ];
+      forEachDevSystem =
+        f:
+        nixpkgs.lib.genAttrs devShellSystems (
+          system:
+          f {
+            pkgs = import nixpkgs { inherit system; };
+          }
+        );
+    in
+    {
+      schemas = flake-schemas.schemas;
+
+      # Packages (Linux only)
+      packages = forEachSupportedSystem (
+        { pkgs }:
+        let
+          models = pkgs.callPackage ./nix/models.nix { };
+        in
+        {
+          audiomuse-ai-models = models;
+          default = pkgs.callPackage ./nix/package.nix { inherit models; };
+        }
+      );
+
+      # NixOS module
+      nixosModules.default =
+        {
+          config,
+          lib,
+          pkgs,
+          ...
+        }:
+        {
+          imports = [ ./nix/module.nix ];
+
+          config = lib.mkIf config.services.audiomuse-ai.enable {
+            services.audiomuse-ai.package = lib.mkDefault self.packages.${pkgs.system}.default;
+          };
+        };
+
+      # Development environments (all platforms)
+      devShells = forEachDevSystem (
+        { pkgs }:
+        {
+          default = pkgs.mkShell {
+            packages = with pkgs; [
+              mkdocs
+              nil
+            ];
+          };
+        }
+      );
+    };
+}

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -15,27 +15,27 @@ stdenvNoCC.mkDerivation {
   srcs = [
     (fetchurl {
       url = "${baseUrl}/musicnn_embedding.onnx";
-      hash = lib.fakeHash;
+      hash = "sha256-pIrYh5UKVXrvu03N31itSAIhP/X8b7Ue2jUHzXl7ubA=";
       name = "musicnn_embedding.onnx";
     })
     (fetchurl {
       url = "${baseUrl}/musicnn_prediction.onnx";
-      hash = lib.fakeHash;
+      hash = "sha256-DU543UPGEK7IjAmeQfSolpeX2lrCYS6myiH6qeGkKPM=";
       name = "musicnn_prediction.onnx";
     })
     (fetchurl {
       url = "${dclapUrl}/model_epoch_36.onnx";
-      hash = lib.fakeHash;
+      hash = "sha256-F4YEA/j8kK/4rAYyoHQeteWNjAsK0vzlztlnJ0sOqXE=";
       name = "model_epoch_36.onnx";
     })
     (fetchurl {
       url = "${dclapUrl}/model_epoch_36.onnx.data";
-      hash = lib.fakeHash;
+      hash = "sha256-KnNbI8Kq17Etn/yFM0zrzGWcB2ltL/YOLjeNoott9lc=";
       name = "model_epoch_36.onnx.data";
     })
     (fetchurl {
       url = "${baseUrl}/clap_text_model.onnx";
-      hash = lib.fakeHash;
+      hash = "sha256-IA1I85Bf8fJyr1AG3ZhR+UBxp93k6v2cB7wJxaxlpxQ=";
       name = "clap_text_model.onnx";
     })
   ];

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -68,7 +68,7 @@ stdenvNoCC.mkDerivation {
   meta = with lib; {
     description = "Pre-trained ML models for AudioMuse-AI";
     homepage = "https://github.com/NeptuneHub/AudioMuse-AI";
-    license = licenses.unfree;
+    license = licenses.free;
     platforms = platforms.all;
   };
 }

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -1,0 +1,74 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchurl,
+}:
+
+let
+  baseUrl = "https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v4.0.0-model";
+  dclapUrl = "https://github.com/NeptuneHub/AudioMuse-AI-DCLAP/releases/download/v1";
+in
+stdenvNoCC.mkDerivation {
+  pname = "audiomuse-ai-models";
+  version = "4.0.0";
+
+  srcs = [
+    (fetchurl {
+      url = "${baseUrl}/musicnn_embedding.onnx";
+      hash = lib.fakeHash;
+      name = "musicnn_embedding.onnx";
+    })
+    (fetchurl {
+      url = "${baseUrl}/musicnn_prediction.onnx";
+      hash = lib.fakeHash;
+      name = "musicnn_prediction.onnx";
+    })
+    (fetchurl {
+      url = "${dclapUrl}/model_epoch_36.onnx";
+      hash = lib.fakeHash;
+      name = "model_epoch_36.onnx";
+    })
+    (fetchurl {
+      url = "${dclapUrl}/model_epoch_36.onnx.data";
+      hash = lib.fakeHash;
+      name = "model_epoch_36.onnx.data";
+    })
+    (fetchurl {
+      url = "${baseUrl}/clap_text_model.onnx";
+      hash = lib.fakeHash;
+      name = "clap_text_model.onnx";
+    })
+  ];
+
+  huggingfaceModels = fetchurl {
+    url = "${baseUrl}/huggingface_models.tar.gz";
+    hash = lib.fakeHash;
+    name = "huggingface_models.tar.gz";
+  };
+
+  dontUnpack = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p $out/model $out/cache/huggingface
+
+    for src in $srcs; do
+      # Strip the hash prefix from the filename
+      local fname=$(basename "$src")
+      fname=''${fname#*-}
+      cp "$src" "$out/model/$fname"
+    done
+
+    tar -xzf "$huggingfaceModels" -C $out/cache/huggingface
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "Pre-trained ML models for AudioMuse-AI";
+    homepage = "https://github.com/NeptuneHub/AudioMuse-AI";
+    license = licenses.unfree;
+    platforms = platforms.all;
+  };
+}

--- a/nix/models.nix
+++ b/nix/models.nix
@@ -42,7 +42,7 @@ stdenvNoCC.mkDerivation {
 
   huggingfaceModels = fetchurl {
     url = "${baseUrl}/huggingface_models.tar.gz";
-    hash = lib.fakeHash;
+    hash = "sha256-AqeNbkI0BMcnEWj3QPF+Q9vBCUf3Rt/EIFZwinRsyz0=";
     name = "huggingface_models.tar.gz";
   };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -211,6 +211,33 @@ in
       };
     };
 
+    # --- Gunicorn ---
+    gunicorn = {
+      workers = mkOption {
+        type = types.ints.positive;
+        default = 1;
+        description = "Number of gunicorn worker processes.";
+      };
+
+      threads = mkOption {
+        type = types.ints.positive;
+        default = 4;
+        description = "Number of threads per gunicorn worker.";
+      };
+
+      timeout = mkOption {
+        type = types.ints.positive;
+        default = 300;
+        description = "Gunicorn worker timeout in seconds.";
+      };
+
+      extraArgs = mkOption {
+        type = types.str;
+        default = "";
+        description = "Extra command-line arguments for gunicorn.";
+      };
+    };
+
     # --- Temp directory ---
     tempDir = mkOption {
       type = types.str;
@@ -297,7 +324,16 @@ in
         };
 
         serviceConfig = commonServiceConfig // {
-          ExecStart = "${cfg.package}/bin/audiomuse-ai-flask --bind 0.0.0.0:${toString cfg.port}";
+          ExecStart = builtins.concatStringsSep " " [
+            "${cfg.package}/bin/audiomuse-ai-flask"
+            "--bind 0.0.0.0:${toString cfg.port}"
+            "--workers ${toString cfg.gunicorn.workers}"
+            "--threads ${toString cfg.gunicorn.threads}"
+            "--worker-class gthread"
+            "--keep-alive 5"
+            "--timeout ${toString cfg.gunicorn.timeout}"
+            cfg.gunicorn.extraArgs
+          ];
         };
       };
 

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -260,23 +260,6 @@ in
       ];
     };
 
-    # Grant database ownership after PostgreSQL starts
-    systemd.services.audiomuse-ai-db-setup = mkIf cfg.postgresql.createLocally {
-      description = "AudioMuse-AI database ownership setup";
-      after = [ "postgresql.service" ];
-      requires = [ "postgresql.service" ];
-      wantedBy = [ "multi-user.target" ];
-      serviceConfig = {
-        Type = "oneshot";
-        RemainAfterExit = true;
-        User = "postgres";
-        ExecStart = let
-          psql = config.services.postgresql.package + "/bin/psql";
-        in
-          "${psql} -c \"ALTER DATABASE \\\"${cfg.postgresql.database}\\\" OWNER TO \\\"${cfg.postgresql.user}\\\"\"";
-      };
-    };
-
     # --- Redis (local) ---
     services.redis.servers.audiomuse-ai = mkIf cfg.redis.createLocally {
       enable = true;
@@ -285,6 +268,23 @@ in
 
     # --- All systemd services ---
     systemd.services = {
+      # --- Database ownership setup ---
+      audiomuse-ai-db-setup = mkIf cfg.postgresql.createLocally {
+        description = "AudioMuse-AI database ownership setup";
+        after = [ "postgresql.service" ];
+        requires = [ "postgresql.service" ];
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          User = "postgres";
+          ExecStart = let
+            psql = config.services.postgresql.package + "/bin/psql";
+          in
+            "${psql} -c \"ALTER DATABASE \\\"${cfg.postgresql.database}\\\" OWNER TO \\\"${cfg.postgresql.user}\\\"\"";
+        };
+      };
+
       # --- Flask web server ---
       audiomuse-ai-flask = {
         description = "AudioMuse-AI Flask Web Server";

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -61,7 +61,7 @@ let
 
   # Service dependencies
   serviceDeps =
-    optional cfg.postgresql.createLocally "postgresql.service"
+    optional cfg.postgresql.createLocally "audiomuse-ai-db-setup.service"
     ++ optional cfg.redis.createLocally "redis-audiomuse-ai.service";
 
 in
@@ -256,9 +256,25 @@ in
       ensureUsers = [
         {
           name = cfg.postgresql.user;
-          ensureDBOwnership = true;
         }
       ];
+    };
+
+    # Grant database ownership after PostgreSQL starts
+    systemd.services.audiomuse-ai-db-setup = mkIf cfg.postgresql.createLocally {
+      description = "AudioMuse-AI database ownership setup";
+      after = [ "postgresql.service" ];
+      requires = [ "postgresql.service" ];
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "oneshot";
+        RemainAfterExit = true;
+        User = "postgres";
+        ExecStart = let
+          psql = config.services.postgresql.package + "/bin/psql";
+        in
+          "${psql} -c \"ALTER DATABASE \\\"${cfg.postgresql.database}\\\" OWNER TO \\\"${cfg.postgresql.user}\\\"\"";
+      };
     };
 
     # --- Redis (local) ---

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,345 @@
+{
+  config,
+  lib,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkEnableOption
+    mkOption
+    mkIf
+    mkDefault
+    types
+    optional
+    literalExpression
+    ;
+  cfg = config.services.audiomuse-ai;
+
+  # Build the common environment variables shared by all services
+  commonEnv = {
+    POSTGRES_HOST = cfg.postgresql.host;
+    POSTGRES_PORT = toString cfg.postgresql.port;
+    POSTGRES_USER = cfg.postgresql.user;
+    POSTGRES_DB = cfg.postgresql.database;
+    REDIS_URL = "redis://${cfg.redis.host}:${toString cfg.redis.port}/0";
+    TEMP_DIR = cfg.tempDir;
+    MEDIASERVER_TYPE = cfg.mediaServer.type;
+    AI_MODEL_PROVIDER = cfg.aiModelProvider;
+    PYTHONUNBUFFERED = "1";
+  }
+  // lib.optionalAttrs (cfg.mediaServer.url != "") {
+    "${lib.toUpper cfg.mediaServer.type}_URL" = cfg.mediaServer.url;
+  }
+  // lib.optionalAttrs cfg.gpu.enable {
+    USE_GPU_CLUSTERING = "true";
+  }
+  // cfg.extraEnvironment;
+
+  # Common systemd service configuration
+  commonServiceConfig = {
+    User = "audiomuse-ai";
+    Group = "audiomuse-ai";
+    StateDirectory = "audiomuse-ai";
+    WorkingDirectory = "${cfg.package}/lib/audiomuse-ai";
+    Restart = "always";
+    RestartSec = 5;
+
+    # Hardening
+    NoNewPrivileges = true;
+    ProtectSystem = "strict";
+    ProtectHome = true;
+    PrivateTmp = true;
+    ReadWritePaths = [
+      cfg.tempDir
+      "/var/lib/audiomuse-ai"
+    ];
+  }
+  // lib.optionalAttrs (cfg.environmentFile != null) {
+    EnvironmentFile = cfg.environmentFile;
+  };
+
+  # Service dependencies
+  serviceDeps =
+    optional cfg.postgresql.createLocally "postgresql.service"
+    ++ optional cfg.redis.createLocally "redis-audiomuse-ai.service";
+
+in
+{
+  options.services.audiomuse-ai = {
+    enable = mkEnableOption "AudioMuse-AI music analysis service";
+
+    package = mkOption {
+      type = types.package;
+      description = "The AudioMuse-AI package to use.";
+    };
+
+    port = mkOption {
+      type = types.port;
+      default = 8000;
+      description = "Port for the Flask web server.";
+    };
+
+    # --- PostgreSQL ---
+    postgresql = {
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "PostgreSQL host.";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 5432;
+        description = "PostgreSQL port.";
+      };
+
+      user = mkOption {
+        type = types.str;
+        default = "audiomuse";
+        description = "PostgreSQL user.";
+      };
+
+      database = mkOption {
+        type = types.str;
+        default = "audiomusedb";
+        description = "PostgreSQL database name.";
+      };
+
+      createLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to create the PostgreSQL database and user locally.";
+      };
+    };
+
+    # --- Redis ---
+    redis = {
+      host = mkOption {
+        type = types.str;
+        default = "localhost";
+        description = "Redis host.";
+      };
+
+      port = mkOption {
+        type = types.port;
+        default = 6379;
+        description = "Redis port.";
+      };
+
+      createLocally = mkOption {
+        type = types.bool;
+        default = true;
+        description = "Whether to create a local Redis instance.";
+      };
+    };
+
+    # --- Secrets ---
+    environmentFile = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = ''
+        Path to an environment file containing secrets.
+        This file is loaded by all AudioMuse-AI systemd services via EnvironmentFile=.
+        It should contain lines like:
+          POSTGRES_PASSWORD=mysecretpassword
+          JELLYFIN_TOKEN=mytoken
+          JWT_SECRET=myjwtsecret
+          AUDIOMUSE_USER=admin
+          AUDIOMUSE_PASSWORD=adminpass
+          API_TOKEN=myapitoken
+          OPENAI_API_KEY=sk-...
+          GEMINI_API_KEY=AIza...
+          MISTRAL_API_KEY=...
+          NAVIDROME_PASSWORD=...
+      '';
+    };
+
+    # --- Media Server ---
+    mediaServer = {
+      type = mkOption {
+        type = types.enum [
+          "jellyfin"
+          "navidrome"
+          "lyrion"
+          "mpd"
+          "emby"
+        ];
+        default = "jellyfin";
+        description = "Type of media server to connect to.";
+      };
+
+      url = mkOption {
+        type = types.str;
+        default = "";
+        description = "URL of the media server. Secrets (tokens, passwords) should go in environmentFile.";
+      };
+    };
+
+    # --- AI ---
+    aiModelProvider = mkOption {
+      type = types.enum [
+        "NONE"
+        "OLLAMA"
+        "OPENAI"
+        "GEMINI"
+        "MISTRAL"
+      ];
+      default = "NONE";
+      description = "AI model provider for playlist naming.";
+    };
+
+    # --- GPU ---
+    gpu.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Enable GPU acceleration (requires NVIDIA GPU and CUDA).";
+    };
+
+    # --- Workers ---
+    workers = {
+      default = mkOption {
+        type = types.ints.positive;
+        default = 1;
+        description = "Number of default queue workers (song analysis).";
+      };
+
+      highPriority = mkOption {
+        type = types.ints.positive;
+        default = 1;
+        description = "Number of high priority queue workers.";
+      };
+    };
+
+    # --- Temp directory ---
+    tempDir = mkOption {
+      type = types.str;
+      default = "/var/lib/audiomuse-ai/temp_audio";
+      description = "Directory for temporary audio files.";
+    };
+
+    # --- Extra environment ---
+    extraEnvironment = mkOption {
+      type = types.attrsOf types.str;
+      default = { };
+      description = "Additional environment variables for all AudioMuse-AI services.";
+      example = literalExpression ''
+        {
+          TZ = "Europe/Berlin";
+          CLUSTER_ALGORITHM = "kmeans";
+        }
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # --- System user ---
+    users.users.audiomuse-ai = {
+      isSystemUser = true;
+      group = "audiomuse-ai";
+      home = "/var/lib/audiomuse-ai";
+      createHome = true;
+      description = "AudioMuse-AI service user";
+    };
+
+    users.groups.audiomuse-ai = { };
+
+    # --- Temp directory ---
+    systemd.tmpfiles.rules = [
+      "d ${cfg.tempDir} 0750 audiomuse-ai audiomuse-ai -"
+    ];
+
+    # --- PostgreSQL (local) ---
+    services.postgresql = mkIf cfg.postgresql.createLocally {
+      enable = mkDefault true;
+      ensureDatabases = [ cfg.postgresql.database ];
+      ensureUsers = [
+        {
+          name = cfg.postgresql.user;
+          ensureDBOwnership = true;
+        }
+      ];
+    };
+
+    # --- Redis (local) ---
+    services.redis.servers.audiomuse-ai = mkIf cfg.redis.createLocally {
+      enable = true;
+      port = cfg.redis.port;
+    };
+
+    # --- All systemd services ---
+    systemd.services = {
+      # --- Flask web server ---
+      audiomuse-ai-flask = {
+        description = "AudioMuse-AI Flask Web Server";
+        after = [ "network.target" ] ++ serviceDeps;
+        requires = serviceDeps;
+        wantedBy = [ "multi-user.target" ];
+
+        environment = commonEnv // {
+          SERVICE_TYPE = "flask";
+        };
+
+        serviceConfig = commonServiceConfig // {
+          ExecStart = "${cfg.package}/bin/audiomuse-ai-flask --bind 0.0.0.0:${toString cfg.port}";
+        };
+      };
+
+      # --- Janitor ---
+      audiomuse-ai-janitor = {
+        description = "AudioMuse-AI RQ Janitor";
+        after = [ "network.target" ] ++ serviceDeps;
+        requires = serviceDeps;
+        wantedBy = [ "multi-user.target" ];
+
+        environment = commonEnv // {
+          SERVICE_TYPE = "worker";
+        };
+
+        serviceConfig = commonServiceConfig // {
+          ExecStart = "${cfg.package}/bin/audiomuse-ai-janitor";
+        };
+      };
+    }
+    // lib.listToAttrs (
+      # --- Default queue workers ---
+      map (i: {
+        name = "audiomuse-ai-worker-default-${toString i}";
+        value = {
+          description = "AudioMuse-AI Default Queue Worker ${toString i}";
+          after = [ "network.target" ] ++ serviceDeps;
+          requires = serviceDeps;
+          wantedBy = [ "multi-user.target" ];
+
+          environment = commonEnv // {
+            SERVICE_TYPE = "worker";
+          };
+
+          serviceConfig = commonServiceConfig // {
+            ExecStart = "${cfg.package}/bin/audiomuse-ai-worker-default";
+          };
+        };
+      }) (lib.range 1 cfg.workers.default)
+    )
+    // lib.listToAttrs (
+      # --- High priority queue workers ---
+      map (i: {
+        name = "audiomuse-ai-worker-high-${toString i}";
+        value = {
+          description = "AudioMuse-AI High Priority Queue Worker ${toString i}";
+          after = [ "network.target" ] ++ serviceDeps;
+          requires = serviceDeps;
+          wantedBy = [ "multi-user.target" ];
+
+          environment = commonEnv // {
+            SERVICE_TYPE = "worker";
+          };
+
+          serviceConfig = commonServiceConfig // {
+            ExecStart = "${cfg.package}/bin/audiomuse-ai-worker-high";
+          };
+        };
+      }) (lib.range 1 cfg.workers.highPriority)
+    );
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -38,7 +38,6 @@ let
       flasgger
       sqlglot
       google-genai
-      mistralai
       pydub
       psutil
       onnx
@@ -78,6 +77,12 @@ let
     hash = "sha256-VFECT7lWOm94GUVkgVHSNChFwOBu+5MExKngiuVxEgk=";
   };
 
+  # nixpkgs mistralai is v2.x but project needs <2.0.0
+  mistralai-wheel = fetchurl {
+    url = "https://files.pythonhosted.org/packages/f9/26/71cca7ceb9d5956511a560c98ba48562bf45ab6dd4dc0a026d2298ee60cf/mistralai-1.11.1-py3-none-any.whl";
+    hash = "sha256-w2LM2IQESL89unyI69loPQdvAogpjdh6UeTL3ubq+sE=";
+  };
+
   # pozalabs-pydub is a fork of pydub fixing a Python 3.12 SyntaxWarning.
   # nixpkgs pydub (already in pythonEnv) works fine — the warning is cosmetic.
 
@@ -104,6 +109,7 @@ let
       cp ${python-mpd2-wheel} wheels/python_mpd2-3.1.1-py2.py3-none-any.whl
       cp ${voyager-wheel} wheels/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       cp ${laion-clap-wheel} wheels/laion_clap-1.1.7-py3-none-any.whl
+      cp ${mistralai-wheel} wheels/mistralai-1.11.1-py3-none-any.whl
 
       # Install from local wheel directory (no network needed)
       ${python}/bin/python -m pip install \
@@ -114,7 +120,8 @@ let
         --no-cache-dir \
         python-mpd2 \
         voyager==2.1.0 \
-        laion-clap
+        laion-clap \
+        mistralai==1.11.1
     '';
 
     installPhase = "true";

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -58,6 +58,8 @@ let
       gunicorn
       zstandard
       umap-learn
+      opentelemetry-api
+      opentelemetry-sdk
     ]
   );
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,211 @@
+{
+  lib,
+  stdenvNoCC,
+  python312,
+  python312Packages,
+  makeWrapper,
+  models,
+  ffmpeg,
+  fftw,
+  libsndfile,
+  libsamplerate,
+  openblas,
+  lapack,
+  postgresql,
+}:
+
+let
+  python = python312;
+
+  pythonEnv = python.withPackages (
+    ps: with ps; [
+      numpy
+      scipy
+      numba
+      soundfile
+      flask
+      flask-cors
+      redis
+      requests
+      scikit-learn
+      rq
+      pyyaml
+      six
+      rapidfuzz
+      psycopg2
+      ftfy
+      flasgger
+      sqlglot
+      google-genai
+      mistralai
+      pydub
+      psutil
+      onnx
+      onnxruntime
+      resampy
+      librosa
+      mutagen
+      flatbuffers
+      packaging
+      protobuf
+      sympy
+      mcp
+      httpx
+      transformers
+      sentencepiece
+      pyjwt
+      argon2-cffi
+      gunicorn
+      zstandard
+      umap-learn
+    ]
+  );
+
+  # Packages not in nixpkgs — installed via pip into a vendor directory
+  pipVendor = stdenvNoCC.mkDerivation {
+    pname = "audiomuse-ai-pip-vendor";
+    version = "0.1.0";
+
+    dontUnpack = true;
+
+    nativeBuildInputs = [
+      python
+      python312Packages.pip
+      python312Packages.setuptools
+      python312Packages.wheel
+    ];
+
+    buildPhase = ''
+      export HOME=$TMPDIR
+
+      # Install packages not available in nixpkgs
+      ${python}/bin/python -m pip install \
+        --no-deps \
+        --target $out/lib/${python.libPrefix}/site-packages \
+        --no-cache-dir \
+        python-mpd2 \
+        pozalabs-pydub==0.37.0 \
+        voyager==2.1.0 \
+        laion-clap
+    '';
+
+    installPhase = "true";
+
+    meta.description = "Pip-vendored Python packages for AudioMuse-AI";
+  };
+
+  appSrc = lib.cleanSourceWith {
+    src = ./..;
+    filter =
+      path: type:
+      let
+        baseName = baseNameOf path;
+        relPath = lib.removePrefix (toString ./..) path;
+      in
+      # Include Python files at root
+      (type == "regular" && lib.hasSuffix ".py" baseName && !lib.hasPrefix "/nix" relPath)
+      # Include key directories
+      || (
+        type == "directory"
+        && builtins.elem baseName [
+          "templates"
+          "static"
+          "tasks"
+          "query"
+          "student_clap"
+          "requirements"
+        ]
+      )
+      # Include everything inside included directories
+      || (
+        lib.hasPrefix "/templates" relPath
+        || lib.hasPrefix "/static" relPath
+        || lib.hasPrefix "/tasks" relPath
+        || lib.hasPrefix "/query" relPath
+        || lib.hasPrefix "/student_clap" relPath
+      )
+      # Include JSON data file
+      || (type == "regular" && baseName == "mood_centroids_real_080_clap.json");
+  };
+
+in
+stdenvNoCC.mkDerivation {
+  pname = "audiomuse-ai";
+  version = "1.0.4";
+
+  src = appSrc;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  buildInputs = [
+    ffmpeg
+    fftw
+    libsndfile
+    libsamplerate
+    openblas
+    lapack
+    postgresql.lib
+  ];
+
+  installPhase = ''
+    runHook preInstall
+
+    # Copy application source
+    mkdir -p $out/lib/audiomuse-ai
+    cp -r . $out/lib/audiomuse-ai/
+
+    # Create wrapper scripts
+    mkdir -p $out/bin
+
+    local commonArgs=(
+      --prefix PYTHONPATH : "${pythonEnv}/${python.sitePackages}"
+      --prefix PYTHONPATH : "${pipVendor}/lib/${python.libPrefix}/site-packages"
+      --prefix PYTHONPATH : "$out/lib/audiomuse-ai"
+      --prefix PATH : "${lib.makeBinPath [ ffmpeg ]}"
+      --set EMBEDDING_MODEL_PATH "${models}/model/musicnn_embedding.onnx"
+      --set PREDICTION_MODEL_PATH "${models}/model/musicnn_prediction.onnx"
+      --set CLAP_AUDIO_MODEL_PATH "${models}/model/model_epoch_36.onnx"
+      --set CLAP_TEXT_MODEL_PATH "${models}/model/clap_text_model.onnx"
+      --set HF_HOME "${models}/cache/huggingface"
+      --set HF_HUB_OFFLINE "1"
+      --set TRANSFORMERS_OFFLINE "1"
+    )
+
+    # Flask web server (port passed at runtime via --bind)
+    makeWrapper ${pythonEnv}/bin/gunicorn $out/bin/audiomuse-ai-flask \
+      "''${commonArgs[@]}" \
+      --chdir "$out/lib/audiomuse-ai" \
+      --add-flags "--workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 app:app"
+
+    # Default queue worker
+    makeWrapper ${pythonEnv}/bin/python $out/bin/audiomuse-ai-worker-default \
+      "''${commonArgs[@]}" \
+      --set AUDIOMUSE_ROLE "worker" \
+      --chdir "$out/lib/audiomuse-ai" \
+      --add-flags "$out/lib/audiomuse-ai/rq_worker.py"
+
+    # High priority queue worker
+    makeWrapper ${pythonEnv}/bin/python $out/bin/audiomuse-ai-worker-high \
+      "''${commonArgs[@]}" \
+      --set AUDIOMUSE_ROLE "worker" \
+      --chdir "$out/lib/audiomuse-ai" \
+      --add-flags "$out/lib/audiomuse-ai/rq_worker_high_priority.py"
+
+    # Janitor
+    makeWrapper ${pythonEnv}/bin/python $out/bin/audiomuse-ai-janitor \
+      "''${commonArgs[@]}" \
+      --set AUDIOMUSE_ROLE "worker" \
+      --chdir "$out/lib/audiomuse-ai" \
+      --add-flags "$out/lib/audiomuse-ai/rq_janitor.py"
+
+    runHook postInstall
+  '';
+
+  meta = with lib; {
+    description = "AI-powered music analysis and playlist generation";
+    homepage = "https://github.com/NeptuneHub/AudioMuse-AI";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+    mainProgram = "audiomuse-ai-flask";
+  };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,6 +1,7 @@
 {
   lib,
   stdenvNoCC,
+  fetchurl,
   python312,
   python312Packages,
   makeWrapper,
@@ -61,7 +62,26 @@ let
     ]
   );
 
-  # Packages not in nixpkgs — installed via pip into a vendor directory
+  # Pre-fetched wheels for packages not in nixpkgs
+  python-mpd2-wheel = fetchurl {
+    url = "https://files.pythonhosted.org/packages/8e/6d/1b9e1c203057c9a7fa6971db3605188a8ef1120ca305e4878c960ab6e2d3/python_mpd2-3.1.1-py2.py3-none-any.whl";
+    hash = "sha256-hr8RAKCxNZWddKmnpYzwUVvzC7VOslrm+44XXlAwD8M=";
+  };
+
+  voyager-wheel = fetchurl {
+    url = "https://files.pythonhosted.org/packages/b7/13/a772a9a2d4cc427f6b4ae2aca65e50ec99f7bb6037c346cc22a07bc4a326/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+    hash = "sha256-lBW5ySO6xJPVxo1VrlXEKJFTwj+fR4Qik03mGsuvTAE=";
+  };
+
+  laion-clap-wheel = fetchurl {
+    url = "https://files.pythonhosted.org/packages/ab/ea/6fb3d90bc1d85e6039506c248009e7f195456b81efa0a7aa413b3e13eb04/laion_clap-1.1.7-py3-none-any.whl";
+    hash = "sha256-VFECT7lWOm94GUVkgVHSNChFwOBu+5MExKngiuVxEgk=";
+  };
+
+  # pozalabs-pydub is a fork of pydub fixing a Python 3.12 SyntaxWarning.
+  # nixpkgs pydub (already in pythonEnv) works fine — the warning is cosmetic.
+
+  # Packages not in nixpkgs — installed from pre-fetched wheels
   pipVendor = stdenvNoCC.mkDerivation {
     pname = "audiomuse-ai-pip-vendor";
     version = "0.1.0";
@@ -77,14 +97,22 @@ let
 
     buildPhase = ''
       export HOME=$TMPDIR
+      mkdir -p $out/lib/${python.libPrefix}/site-packages
 
-      # Install packages not available in nixpkgs
+      # Create a directory with properly-named wheels (strip Nix store hash prefix)
+      mkdir -p wheels
+      cp ${python-mpd2-wheel} wheels/python_mpd2-3.1.1-py2.py3-none-any.whl
+      cp ${voyager-wheel} wheels/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+      cp ${laion-clap-wheel} wheels/laion_clap-1.1.7-py3-none-any.whl
+
+      # Install from local wheel directory (no network needed)
       ${python}/bin/python -m pip install \
         --no-deps \
+        --no-index \
+        --find-links wheels/ \
         --target $out/lib/${python.libPrefix}/site-packages \
         --no-cache-dir \
         python-mpd2 \
-        pozalabs-pydub==0.37.0 \
         voyager==2.1.0 \
         laion-clap
     '';

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -69,10 +69,21 @@ let
     hash = "sha256-hr8RAKCxNZWddKmnpYzwUVvzC7VOslrm+44XXlAwD8M=";
   };
 
-  voyager-wheel = fetchurl {
-    url = "https://files.pythonhosted.org/packages/b7/13/a772a9a2d4cc427f6b4ae2aca65e50ec99f7bb6037c346cc22a07bc4a326/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
-    hash = "sha256-lBW5ySO6xJPVxo1VrlXEKJFTwj+fR4Qik03mGsuvTAE=";
-  };
+  voyager-wheel =
+    let
+      wheels = {
+        "x86_64-linux" = {
+          url = "https://files.pythonhosted.org/packages/b7/13/a772a9a2d4cc427f6b4ae2aca65e50ec99f7bb6037c346cc22a07bc4a326/voyager-2.1.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl";
+          hash = "sha256-lBW5ySO6xJPVxo1VrlXEKJFTwj+fR4Qik03mGsuvTAE=";
+        };
+        "aarch64-linux" = {
+          url = "https://files.pythonhosted.org/packages/91/87/f3ed4ebeeff371b0b759c277025379dbcb5dbf00083df6c03f5c9727b6cd/voyager-2.1.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl";
+          hash = "sha256-zd9TWdioi9X8EvxxwOf9My5NodltrIrkRbATiHHNKLI=";
+        };
+      };
+      system = stdenvNoCC.hostPlatform.system;
+    in
+    fetchurl (wheels.${system} or (throw "Unsupported system for voyager wheel: ${system}"));
 
   laion-clap-wheel = fetchurl {
     url = "https://files.pythonhosted.org/packages/ab/ea/6fb3d90bc1d85e6039506c248009e7f195456b81efa0a7aa413b3e13eb04/laion_clap-1.1.7-py3-none-any.whl";
@@ -208,11 +219,11 @@ stdenvNoCC.mkDerivation {
       --set TRANSFORMERS_OFFLINE "1"
     )
 
-    # Flask web server (port passed at runtime via --bind)
+    # Flask web server (all gunicorn args passed at runtime by NixOS module)
     makeWrapper ${pythonEnv}/bin/gunicorn $out/bin/audiomuse-ai-flask \
       "''${commonArgs[@]}" \
       --chdir "$out/lib/audiomuse-ai" \
-      --add-flags "--workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 app:app"
+      --add-flags "app:app"
 
     # Default queue worker
     makeWrapper ${pythonEnv}/bin/python $out/bin/audiomuse-ai-worker-default \


### PR DESCRIPTION
## Summary

- Package the application as a Nix derivation with all Python dependencies, wrapper scripts for Flask/workers/janitor, and ML model downloads as fixed-output derivations
- Add a NixOS module (services.audiomuse-ai) with declarative configuration for PostgreSQL, Redis, media server, AI provider, GPU, workers, and secrets via environmentFile
- Patch TEMP_DIR to be configurable via environment variable

## Details

New files:
- `nix/models.nix`   fetches all ONNX + HuggingFace models (hashes need populating on first build)
- `nix/package.nix`   Python app package with pip vendor for deps not in nixpkgs (voyager, laion-clap, python-mpd2, pozalabs-pydub)
- `nix/module.nix`   NixOS module with systemd services, local PostgreSQL/Redis provisioning, hardening
- `flake.nix`   extended with packages and nixosModules outputs

### Usage

```nix
{
    imports = [ audiomuse-ai.nixosModules.default ];

    services.audiomuse-ai = {
        enable = true;
        port = 8000;
        environmentFile = "/run/secrets/audiomuse-ai.env";
        mediaServer.type = "jellyfin";
        mediaServer.url = "http://jellyfin:8096";
        aiModelProvider = "GEMINI";
    };
}
```

## Test plan

- nix flake check passes
- nix build .#audiomuse-ai-models succeeds
- nix build produces package with wrapper scripts in result/bin/
- NixOS VM test: enable service with createLocally = true, verify Flask responds on port 8000
