### PR TITLE
Add _FILE support for Docker secrets

### DIFF
--- a/app_auth.py
+++ b/app_auth.py
@@ -18,6 +18,7 @@ all other schema objects) so a cold start only calls one init routine.
 import datetime
 import logging
 import os
+from env_utils import get_env
 import secrets
 
 from flask import (
@@ -365,8 +366,8 @@ def seed_admin_from_env():
 
     # 3. Fall back to real process environment variables.
     if not (user and password):
-        user = os.environ.get('AUDIOMUSE_USER', '') or ''
-        password = os.environ.get('AUDIOMUSE_PASSWORD', '') or ''
+        user = get_env('AUDIOMUSE_USER', '') or ''
+        password = get_env('AUDIOMUSE_PASSWORD', '') or ''
         source = 'env'
 
     if not (isinstance(user, str) and user.strip() and isinstance(password, str) and password):

--- a/config.py
+++ b/config.py
@@ -1,5 +1,6 @@
 #AudioMuse-AI/config.py
 import os
+from env_utils import get_env
 
 # --- Media Server Type ---
 MEDIASERVER_TYPE = os.environ.get("MEDIASERVER_TYPE", "jellyfin").lower() # Possible values: jellyfin, navidrome, lyrion, mpd, emby
@@ -8,13 +9,13 @@ MEDIASERVER_TYPE = os.environ.get("MEDIASERVER_TYPE", "jellyfin").lower() # Poss
 
 # JELLYFIN_USER_ID and JELLYFIN_TOKEN come from a Kubernetes Secret
 JELLYFIN_URL = os.environ.get("JELLYFIN_URL", "") # Replace with your default URL
-JELLYFIN_USER_ID = os.environ.get("JELLYFIN_USER_ID", "")  # Replace with a suitable default or handle missing case
-JELLYFIN_TOKEN = os.environ.get("JELLYFIN_TOKEN", "")  # Replace with a suitable default or handle missing case
+JELLYFIN_USER_ID = get_env("JELLYFIN_USER_ID", "")  # Replace with a suitable default or handle missing case
+JELLYFIN_TOKEN = get_env("JELLYFIN_TOKEN", "")  # Replace with a suitable default or handle missing case
 
 # EMBY_USER_ID and JELLYFIN_TOKEN come from a Kubernetes Secret
 EMBY_URL = os.environ.get("EMBY_URL", "") # Replace with your default URL
-EMBY_USER_ID = os.environ.get("EMBY_USER_ID", "")  # Replace with a suitable default or handle missing case
-EMBY_TOKEN = os.environ.get("EMBY_TOKEN", "")  # Replace with a suitable default or handle missing case
+EMBY_USER_ID = get_env("EMBY_USER_ID", "")  # Replace with a suitable default or handle missing case
+EMBY_TOKEN = get_env("EMBY_TOKEN", "")  # Replace with a suitable default or handle missing case
 
 
 # NEW: Allow specifying music libraries/folders for analysis across all media servers.
@@ -40,8 +41,8 @@ HEADERS = _compute_headers()
 # --- Navidrome (Subsonic API) Constants ---
 # These are used only if MEDIASERVER_TYPE is "navidrome".
 NAVIDROME_URL = os.environ.get("NAVIDROME_URL", "")
-NAVIDROME_USER = os.environ.get("NAVIDROME_USER", "")
-NAVIDROME_PASSWORD = os.environ.get("NAVIDROME_PASSWORD", "") # Use the password directly
+NAVIDROME_USER = get_env("NAVIDROME_USER", "")
+NAVIDROME_PASSWORD = get_env("NAVIDROME_PASSWORD", "") # Use the password directly
 
 # --- Lyrion (LMS) Constants ---
 # These are used only if MEDIASERVER_TYPE is "lyrion".
@@ -85,7 +86,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 # These are used only if MEDIASERVER_TYPE is "mpd".
 MPD_HOST = os.environ.get("MPD_HOST", "localhost")
 MPD_PORT = int(os.environ.get("MPD_PORT", "6600"))
-MPD_PASSWORD = os.environ.get("MPD_PASSWORD", "")  # Optional password, leave empty if none
+MPD_PASSWORD = get_env("MPD_PASSWORD", "")  # Optional password, leave empty if none
 MPD_MUSIC_DIRECTORY = os.environ.get("MPD_MUSIC_DIRECTORY", "/var/lib/mpd/music")  # Path to MPD's music directory for file access
 
 
@@ -249,12 +250,12 @@ MAX_SONGS_IN_AI_PROMPT = int(os.environ.get("MAX_SONGS_IN_AI_PROMPT", "25"))
 # OpenAI API (also used for OpenRouter) - uses same API standard as Ollama
 OPENAI_SERVER_URL = os.environ.get("OPENAI_SERVER_URL", os.environ.get("OLLAMA_SERVER_URL", "http://192.168.3.211:11434/api/generate"))
 OPENAI_MODEL_NAME = os.environ.get("OPENAI_MODEL_NAME", os.environ.get("OLLAMA_MODEL_NAME", "llama3.1:8b"))
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "no-key-needed") # Set to "no-key-needed" for Ollama, or your actual API key for OpenAI/OpenRouter
+OPENAI_API_KEY = get_env("OPENAI_API_KEY", "no-key-needed") # Set to "no-key-needed" for Ollama, or your actual API key for OpenAI/OpenRouter
 
-GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "") # Default API key
+GEMINI_API_KEY = get_env("GEMINI_API_KEY", "") # Default API key
 GEMINI_MODEL_NAME = os.environ.get("GEMINI_MODEL_NAME", "gemini-2.5-pro") # Default Gemini model gemini-2.5-pro, alternative gemini-2.5-flash
 
-MISTRAL_API_KEY = os.environ.get("MISTRAL_API_KEY", "")
+MISTRAL_API_KEY = get_env("MISTRAL_API_KEY", "")
 MISTRAL_MODEL_NAME = os.environ.get("MISTRAL_MODEL_NAME", "ministral-3b-latest")
 
 # AI Request Timeout Configuration
@@ -263,10 +264,11 @@ MISTRAL_MODEL_NAME = os.environ.get("MISTRAL_MODEL_NAME", "ministral-3b-latest")
 # Default: 120 seconds for Ollama (tool calling/instant playlist), 60 seconds for OpenAI/Mistral
 AI_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("AI_REQUEST_TIMEOUT_SECONDS", "300"))
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+REDIS_URL = get_env('REDIS_URL', REDIS_URL)
 
 # Construct DATABASE_URL from individual components for better security in K8s
-POSTGRES_USER = os.environ.get("POSTGRES_USER", "audiomuse")
-POSTGRES_PASSWORD = os.environ.get("POSTGRES_PASSWORD", "audiomusepassword")
+POSTGRES_USER = get_env("POSTGRES_USER", "audiomuse")
+POSTGRES_PASSWORD = get_env("POSTGRES_PASSWORD", "audiomusepassword")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "postgres-service.playlist") # Default for K8s
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
 POSTGRES_DB = os.environ.get("POSTGRES_DB", "audiomusedb")
@@ -279,14 +281,14 @@ _pg_user_esc = quote(POSTGRES_USER, safe='')
 _pg_pass_esc = quote(POSTGRES_PASSWORD, safe='')
 
 # If DATABASE_URL is set in the environment, prefer it; otherwise build one using the escaped credentials
-DATABASE_URL = os.environ.get(
+DATABASE_URL = get_env(
     "DATABASE_URL",
     f"postgresql://{_pg_user_esc}:{_pg_pass_esc}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
 )
 
 # --- AI User for Chat SQL Execution ---
 AI_CHAT_DB_USER_NAME = os.environ.get("AI_CHAT_DB_USER_NAME", "ai_user")
-AI_CHAT_DB_USER_PASSWORD = os.environ.get("AI_CHAT_DB_USER_PASSWORD", "ChangeThisSecurePassword123!") # IMPORTANT: Change this default and use environment variables
+AI_CHAT_DB_USER_PASSWORD = get_env("AI_CHAT_DB_USER_PASSWORD", "ChangeThisSecurePassword123!") # IMPORTANT: Change this default and use environment variables
 
 # --- Classifier Constant ---
 MOOD_LABELS = [
@@ -513,13 +515,13 @@ MAX_SONGS_PER_ARTIST_PLAYLIST = int(os.environ.get("MAX_SONGS_PER_ARTIST_PLAYLIS
 PLAYLIST_ENERGY_ARC = os.environ.get("PLAYLIST_ENERGY_ARC", "False").lower() == "true"
 # --- Authentication ---
 # Set all three to enable authentication. Leave any blank to disable (legacy mode).
-AUDIOMUSE_USER = os.environ.get("AUDIOMUSE_USER", "")
-AUDIOMUSE_PASSWORD = os.environ.get("AUDIOMUSE_PASSWORD", "")
-API_TOKEN = os.environ.get("API_TOKEN", "")
+AUDIOMUSE_USER = get_env("AUDIOMUSE_USER", "")
+AUDIOMUSE_PASSWORD = get_env("AUDIOMUSE_PASSWORD", "")
+API_TOKEN = get_env("API_TOKEN", "")
 
 # JWT secret for signing session tokens. Auto-generated if not set (sessions lost on restart).
 # Note: the warning for missing JWT_SECRET is emitted in app.py after logging is configured
-JWT_SECRET = os.environ.get("JWT_SECRET", "")
+JWT_SECRET = get_env("JWT_SECRET", "")
 
 # Enable or disable authentication independently of whether credentials are set.
 # Default is True to preserve the current secure behavior.

--- a/config.py
+++ b/config.py
@@ -271,7 +271,7 @@ POSTGRES_USER = get_env("POSTGRES_USER", "audiomuse")
 POSTGRES_PASSWORD = get_env("POSTGRES_PASSWORD", "audiomusepassword")
 POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "postgres-service.playlist") # Default for K8s
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
-POSTGRES_DB = os.environ.get("POSTGRES_DB", "audiomusedb")
+POSTGRES_DB = get_env("POSTGRES_DB", "audiomusedb")
 
 # Allow an explicit DATABASE_URL to override construction (useful for docker-compose or direct env override)
 from urllib.parse import quote

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -11,11 +11,17 @@
 # --- Shared backend configuration ---
 POSTGRES_USER=audiomuse
 POSTGRES_PASSWORD=audiomusepassword
+# Optional alternative to POSTGRES_PASSWORD for Docker secrets:
+# POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
 POSTGRES_DB=audiomusedb
 POSTGRES_PORT=5432
 POSTGRES_HOST=postgres
 
 REDIS_URL=redis://redis:6379/0 # /!\ change port adress if you change REDIS_PORT below
+# Optional alternative to REDIS_URL for Docker secrets:
+# REDIS_URL_FILE=/run/secrets/redis_url
+# Optional full database DSN override via Docker secrets:
+# DATABASE_URL_FILE=/run/secrets/database_url
 REDIS_PORT=6379
 FRONTEND_PORT=8000
 WORKER_PORT=8029

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -10,10 +10,14 @@
 
 # --- Shared backend configuration ---
 POSTGRES_USER=audiomuse
+# Optional alternative to POSTGRES_USER for Docker secrets:
+# POSTGRES_USER_FILE=/run/secrets/postgres_user
 POSTGRES_PASSWORD=audiomusepassword
 # Optional alternative to POSTGRES_PASSWORD for Docker secrets:
 # POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
 POSTGRES_DB=audiomusedb
+# Optional alternative to POSTGRES_DB for Docker secrets:
+# POSTGRES_DB_FILE=/run/secrets/postgres_db
 POSTGRES_PORT=5432
 POSTGRES_HOST=postgres
 

--- a/deployment/docker-compose-nvidia.yaml
+++ b/deployment/docker-compose-nvidia.yaml
@@ -17,6 +17,7 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
       - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
@@ -36,10 +37,14 @@ services:
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
+      REDIS_URL_FILE: "${REDIS_URL_FILE:-}"
+      DATABASE_URL: "${DATABASE_URL:-}"
+      DATABASE_URL_FILE: "${DATABASE_URL_FILE:-}"
       TEMP_DIR: "/app/temp_audio"
     volumes:
       - temp-audio-flask:/app/temp_audio # Volume for temporary audio files
@@ -65,10 +70,14 @@ services:
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
+      REDIS_URL_FILE: "${REDIS_URL_FILE:-}"
+      DATABASE_URL: "${DATABASE_URL:-}"
+      DATABASE_URL_FILE: "${DATABASE_URL_FILE:-}"
       NVIDIA_VISIBLE_DEVICES: "0"
       NVIDIA_DRIVER_CAPABILITIES: "compute,utility"
       USE_GPU_CLUSTERING: "${USE_GPU_CLUSTERING:-true}"

--- a/deployment/docker-compose-nvidia.yaml
+++ b/deployment/docker-compose-nvidia.yaml
@@ -16,9 +16,11 @@ services:
     container_name: audiomuse-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
     ports:
       - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
@@ -36,9 +38,11 @@ services:
       TZ: "${TZ:-UTC}"
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
@@ -69,9 +73,11 @@ services:
       TZ: "${TZ:-UTC}"
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -16,9 +16,11 @@ services:
     container_name: audiomuse-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
     ports:
       - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
     volumes:
@@ -36,9 +38,11 @@ services:
       TZ: "${TZ:-UTC}"
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
@@ -62,9 +66,11 @@ services:
       TZ: "${TZ:-UTC}"
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_USER_FILE: ${POSTGRES_USER_FILE:-}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
       POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
+      POSTGRES_DB_FILE: ${POSTGRES_DB_FILE:-}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service

--- a/deployment/docker-compose.yaml
+++ b/deployment/docker-compose.yaml
@@ -17,6 +17,7 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
     ports:
       - "${POSTGRES_PORT:-5432}:5432" # Expose PostgreSQL port to the host
@@ -36,10 +37,14 @@ services:
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
+      REDIS_URL_FILE: "${REDIS_URL_FILE:-}"
+      DATABASE_URL: "${DATABASE_URL:-}"
+      DATABASE_URL_FILE: "${DATABASE_URL_FILE:-}"
       TEMP_DIR: "/app/temp_audio"
     volumes:
       - temp-audio-flask:/app/temp_audio # Volume for temporary audio files
@@ -58,10 +63,14 @@ services:
       # DATABASE_URL is now constructed by config.py from the following:
       POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_PASSWORD_FILE: ${POSTGRES_PASSWORD_FILE:-}
       POSTGRES_DB: ${POSTGRES_DB:-audiomusedb}
       POSTGRES_HOST: "postgres" # Service name of the postgres container
       POSTGRES_PORT: "${POSTGRES_PORT:-5432}"
       REDIS_URL: "${REDIS_URL:-redis://redis:6379/0}" # Connects to the 'redis' service
+      REDIS_URL_FILE: "${REDIS_URL_FILE:-}"
+      DATABASE_URL: "${DATABASE_URL:-}"
+      DATABASE_URL_FILE: "${DATABASE_URL_FILE:-}"
       TEMP_DIR: "/app/temp_audio"
     volumes:
       - temp-audio-worker:/app/temp_audio # Volume for temporary audio files

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -2,6 +2,8 @@
 
 These are the parameters accepted for this script. From `v1.0.0`, only PostgreSQL, Redis, and `TZ` configuration must still be configured via environment variables. All other configuration values are managed through the browser setup wizard and persisted in the database. For compatibility with legacy installations, environment variables are imported into the database automatically on first startup. The Setup Wizard is shown on clean installation as lending page and is also available later from the menu under Administration > Setup Wizard.
 
+Sensitive values also support the standard Docker secrets convention: set `YOUR_KEY_FILE=/run/secrets/your_key` instead of `YOUR_KEY`. When both are present, `*_FILE` takes precedence.
+
 How to find jellyfin **userid**:
 * Log into Jellyfin from your browser as an admin
 * Go to Dashboard > “admin panel” > Users.

--- a/env_utils.py
+++ b/env_utils.py
@@ -1,0 +1,17 @@
+import os
+import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def get_env(key, default=""):
+    """Read an environment variable, preferring KEY_FILE when present."""
+    file_path = os.environ.get(f"{key}_FILE")
+    if file_path:
+        try:
+            with open(file_path, encoding="utf-8") as file_handle:
+                return file_handle.read().strip()
+        except OSError as exc:
+            logger.warning("Failed to read %s_FILE from %s: %s", key, file_path, exc)
+    return os.environ.get(key, default)

--- a/tasks/setup_manager.py
+++ b/tasks/setup_manager.py
@@ -5,6 +5,7 @@ import psycopg2
 from argon2 import PasswordHasher
 from argon2 import exceptions as argon2_exceptions
 import config
+from env_utils import get_env
 from psycopg2.extras import RealDictCursor
 from urllib.parse import quote
 
@@ -36,12 +37,12 @@ class SetupManager:
         self._password_hasher = PasswordHasher()
 
     def _get_database_url(self):
-        env_url = os.environ.get("DATABASE_URL")
+        env_url = get_env("DATABASE_URL")
         if env_url:
             return env_url
 
-        user = os.environ.get("POSTGRES_USER", "audiomuse")
-        password = os.environ.get("POSTGRES_PASSWORD", "audiomusepassword")
+        user = get_env("POSTGRES_USER", "audiomuse")
+        password = get_env("POSTGRES_PASSWORD", "audiomusepassword")
         host = os.environ.get("POSTGRES_HOST", "postgres-service.playlist")
         port = os.environ.get("POSTGRES_PORT", "5432")
         db = os.environ.get("POSTGRES_DB", "audiomusedb")

--- a/tasks/setup_manager.py
+++ b/tasks/setup_manager.py
@@ -45,7 +45,7 @@ class SetupManager:
         password = get_env("POSTGRES_PASSWORD", "audiomusepassword")
         host = os.environ.get("POSTGRES_HOST", "postgres-service.playlist")
         port = os.environ.get("POSTGRES_PORT", "5432")
-        db = os.environ.get("POSTGRES_DB", "audiomusedb")
+        db = get_env("POSTGRES_DB", "audiomusedb")
         user_escaped = quote(user, safe='')
         password_escaped = quote(password, safe='')
         return f"postgresql://{user_escaped}:{password_escaped}@{host}:{port}/{db}"

--- a/tests/unit/test_env_utils.py
+++ b/tests/unit/test_env_utils.py
@@ -1,0 +1,94 @@
+import importlib
+import sys
+import types
+
+from env_utils import get_env
+
+
+def test_get_env_prefers_file_value(tmp_path, monkeypatch):
+    secret_file = tmp_path / "openai_api_key"
+    secret_file.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", str(secret_file))
+
+    assert get_env("OPENAI_API_KEY", "") == "from-file"
+
+
+def test_get_env_falls_back_to_env_when_file_missing(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", "/does/not/exist")
+
+    assert get_env("OPENAI_API_KEY", "") == "from-env"
+
+
+def test_get_env_logs_warning_when_file_read_fails(monkeypatch, caplog):
+    monkeypatch.setenv("OPENAI_API_KEY", "from-env")
+    monkeypatch.setenv("OPENAI_API_KEY_FILE", "/does/not/exist")
+
+    with caplog.at_level("WARNING"):
+        assert get_env("OPENAI_API_KEY", "") == "from-env"
+
+    assert "Failed to read OPENAI_API_KEY_FILE" in caplog.text
+
+
+def test_config_reads_secret_values_from_file(monkeypatch, tmp_path):
+    jwt_secret_file = tmp_path / "jwt_secret"
+    jwt_secret_file.write_text("jwt-from-file\n", encoding="utf-8")
+    pg_password_file = tmp_path / "postgres_password"
+    pg_password_file.write_text("postgres-from-file\n", encoding="utf-8")
+    pg_user_file = tmp_path / "postgres_user"
+    pg_user_file.write_text("postgres-user-from-file\n", encoding="utf-8")
+    jellyfin_user_id_file = tmp_path / "jellyfin_user_id"
+    jellyfin_user_id_file.write_text("jellyfin-user-from-file\n", encoding="utf-8")
+    audiomuse_user_file = tmp_path / "audiomuse_user"
+    audiomuse_user_file.write_text("admin-from-file\n", encoding="utf-8")
+
+    monkeypatch.setenv("JWT_SECRET_FILE", str(jwt_secret_file))
+    monkeypatch.setenv("POSTGRES_USER_FILE", str(pg_user_file))
+    monkeypatch.setenv("POSTGRES_PASSWORD_FILE", str(pg_password_file))
+    monkeypatch.setenv("JELLYFIN_USER_ID_FILE", str(jellyfin_user_id_file))
+    monkeypatch.setenv("AUDIOMUSE_USER_FILE", str(audiomuse_user_file))
+    monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("POSTGRES_USER", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    monkeypatch.delenv("JELLYFIN_USER_ID", raising=False)
+    monkeypatch.delenv("AUDIOMUSE_USER", raising=False)
+
+    fake_setup_manager = types.ModuleType("tasks.setup_manager")
+
+    class DummySetupManager:
+        def ensure_table(self):
+            return None
+
+        def get_raw_overrides(self, ensure_table=True):
+            return {}
+
+        def cast_value(self, current_value, new_value):
+            return new_value
+
+        def config_table_exists(self):
+            return False
+
+    fake_setup_manager.SetupManager = DummySetupManager
+    original_config = sys.modules.get("config")
+    original_setup_manager = sys.modules.get("tasks.setup_manager")
+    monkeypatch.setitem(sys.modules, "tasks.setup_manager", fake_setup_manager)
+    sys.modules.pop("config", None)
+
+    try:
+        config = importlib.import_module("config")
+
+        assert config.JWT_SECRET == "jwt-from-file"
+        assert config.POSTGRES_USER == "postgres-user-from-file"
+        assert config.POSTGRES_PASSWORD == "postgres-from-file"
+        assert config.JELLYFIN_USER_ID == "jellyfin-user-from-file"
+        assert config.AUDIOMUSE_USER == "admin-from-file"
+        assert "postgres-from-file" in config.DATABASE_URL
+    finally:
+        sys.modules.pop("config", None)
+        if original_config is not None:
+            sys.modules["config"] = original_config
+        if original_setup_manager is not None:
+            sys.modules["tasks.setup_manager"] = original_setup_manager
+        else:
+            sys.modules.pop("tasks.setup_manager", None)

--- a/tests/unit/test_env_utils.py
+++ b/tests/unit/test_env_utils.py
@@ -36,6 +36,8 @@ def test_config_reads_secret_values_from_file(monkeypatch, tmp_path):
     jwt_secret_file.write_text("jwt-from-file\n", encoding="utf-8")
     pg_password_file = tmp_path / "postgres_password"
     pg_password_file.write_text("postgres-from-file\n", encoding="utf-8")
+    pg_db_file = tmp_path / "postgres_db"
+    pg_db_file.write_text("postgres-db-from-file\n", encoding="utf-8")
     pg_user_file = tmp_path / "postgres_user"
     pg_user_file.write_text("postgres-user-from-file\n", encoding="utf-8")
     jellyfin_user_id_file = tmp_path / "jellyfin_user_id"
@@ -44,11 +46,13 @@ def test_config_reads_secret_values_from_file(monkeypatch, tmp_path):
     audiomuse_user_file.write_text("admin-from-file\n", encoding="utf-8")
 
     monkeypatch.setenv("JWT_SECRET_FILE", str(jwt_secret_file))
+    monkeypatch.setenv("POSTGRES_DB_FILE", str(pg_db_file))
     monkeypatch.setenv("POSTGRES_USER_FILE", str(pg_user_file))
     monkeypatch.setenv("POSTGRES_PASSWORD_FILE", str(pg_password_file))
     monkeypatch.setenv("JELLYFIN_USER_ID_FILE", str(jellyfin_user_id_file))
     monkeypatch.setenv("AUDIOMUSE_USER_FILE", str(audiomuse_user_file))
     monkeypatch.delenv("JWT_SECRET", raising=False)
+    monkeypatch.delenv("POSTGRES_DB", raising=False)
     monkeypatch.delenv("POSTGRES_USER", raising=False)
     monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
     monkeypatch.delenv("JELLYFIN_USER_ID", raising=False)
@@ -79,6 +83,7 @@ def test_config_reads_secret_values_from_file(monkeypatch, tmp_path):
         config = importlib.import_module("config")
 
         assert config.JWT_SECRET == "jwt-from-file"
+        assert config.POSTGRES_DB == "postgres-db-from-file"
         assert config.POSTGRES_USER == "postgres-user-from-file"
         assert config.POSTGRES_PASSWORD == "postgres-from-file"
         assert config.JELLYFIN_USER_ID == "jellyfin-user-from-file"


### PR DESCRIPTION
  ## Summary

  Add support for the standard `*_FILE` environment variable convention so sensitive values can be read from Docker secret files instead of plain environment variables.

  This keeps the existing env-based behavior unchanged, but allows deployments to use patterns like:

  - `POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password`
  - `OPENAI_API_KEY_FILE=/run/secrets/openai_api_key`
  - `JWT_SECRET_FILE=/run/secrets/jwt_secret`

  ## Changes

  - add a small shared `get_env()` helper that prefers `KEY_FILE` over `KEY`
  - use it for sensitive config values in `config.py`
  - use it in `tasks/setup_manager.py` for `DATABASE_URL` / `POSTGRES_PASSWORD`
  - use it in `app_auth.py` for legacy admin password bootstrap
  - expose `*_FILE` pass-through variables in the official Docker Compose files
  - document the convention in `.env.example` and `docs/PARAMETERS.md`
  - add unit tests for `_FILE` precedence, fallback behavior, and config loading

  ## Verification

  Tested locally with:

  - full unit test suite: `894 passed`
  - focused new tests for `_FILE` handling
  - isolated Docker Compose smoke test with real secret files mounted under `/run/secrets`

  The Docker smoke test confirmed that file-backed values are used instead of the plain environment values.