### PR TITLE
Fix provider migration FK violation on lyrics_embedding

### DIFF
--- a/tasks/provider_migration_tasks.py
+++ b/tasks/provider_migration_tasks.py
@@ -226,6 +226,9 @@ def execute_provider_migration(session_id):
         # 4. Reflect FK names and check for optional tables before opening tx
         fk_embedding      = find_fk(cur, 'embedding', 'item_id')
         fk_clap_embedding = find_fk(cur, 'clap_embedding', 'item_id')
+        cur.execute("SELECT to_regclass('public.lyrics_embedding') IS NOT NULL")
+        lyrics_exists = bool(cur.fetchone()[0])
+        fk_lyrics_embedding = find_fk(cur, 'lyrics_embedding', 'item_id') if lyrics_exists else None
         cur.execute("SELECT to_regclass('public.mulan_embedding') IS NOT NULL")
         mulan_exists = bool(cur.fetchone()[0])
         fk_mulan_embedding = find_fk(cur, 'mulan_embedding', 'item_id') if mulan_exists else None
@@ -238,6 +241,8 @@ def execute_provider_migration(session_id):
                 new_meta=new_meta,
                 fk_embedding=fk_embedding,
                 fk_clap_embedding=fk_clap_embedding,
+                fk_lyrics_embedding=fk_lyrics_embedding,
+                lyrics_exists=lyrics_exists,
                 fk_mulan_embedding=fk_mulan_embedding,
                 mulan_exists=mulan_exists,
                 target_type=target_type,
@@ -380,8 +385,10 @@ def _merge_mapping(state):
 
 
 def _run_migration_transaction(cur, mapping, new_meta,
-                               fk_embedding, fk_clap_embedding, fk_mulan_embedding,
-                               mulan_exists, target_type, target_creds, session_id,
+                               fk_embedding, fk_clap_embedding,
+                               fk_lyrics_embedding, lyrics_exists,
+                               fk_mulan_embedding, mulan_exists,
+                               target_type, target_creds, session_id,
                                selected_libraries=None):
     """Execute every SQL statement for the migration transaction.
 
@@ -421,6 +428,8 @@ def _run_migration_transaction(cur, mapping, new_meta,
         cur.execute(f"ALTER TABLE embedding DROP CONSTRAINT {fk_embedding}")
     if fk_clap_embedding:
         cur.execute(f"ALTER TABLE clap_embedding DROP CONSTRAINT {fk_clap_embedding}")
+    if lyrics_exists and fk_lyrics_embedding:
+        cur.execute(f"ALTER TABLE lyrics_embedding DROP CONSTRAINT {fk_lyrics_embedding}")
     if mulan_exists and fk_mulan_embedding:
         cur.execute(f"ALTER TABLE mulan_embedding DROP CONSTRAINT {fk_mulan_embedding}")
 
@@ -456,6 +465,18 @@ def _run_migration_transaction(cur, mapping, new_meta,
             f"WHERE {alias}.item_id = %s || m.new_id",
             (prefix,),
         )
+    if lyrics_exists:
+        cur.execute(
+            "UPDATE lyrics_embedding e SET item_id = %s || m.new_id "
+            "FROM item_id_migration_map m WHERE e.item_id = m.old_id",
+            (prefix,),
+        )
+        cur.execute(
+            "UPDATE lyrics_embedding e SET item_id = m.new_id "
+            "FROM item_id_migration_map m "
+            "WHERE e.item_id = %s || m.new_id",
+            (prefix,),
+        )
     if mulan_exists:
         cur.execute(
             "UPDATE mulan_embedding e SET item_id = %s || m.new_id "
@@ -478,6 +499,11 @@ def _run_migration_transaction(cur, mapping, new_meta,
     if fk_clap_embedding:
         cur.execute(
             f"ALTER TABLE clap_embedding ADD CONSTRAINT {fk_clap_embedding} "
+            f"FOREIGN KEY (item_id) REFERENCES score(item_id) ON DELETE CASCADE"
+        )
+    if lyrics_exists and fk_lyrics_embedding:
+        cur.execute(
+            f"ALTER TABLE lyrics_embedding ADD CONSTRAINT {fk_lyrics_embedding} "
             f"FOREIGN KEY (item_id) REFERENCES score(item_id) ON DELETE CASCADE"
         )
     if mulan_exists and fk_mulan_embedding:

--- a/tests/unit/test_provider_migration_execute.py
+++ b/tests/unit/test_provider_migration_execute.py
@@ -151,7 +151,7 @@ def _make_session_row(session_id=1, target='navidrome',
 
 
 def _install_fake_psycopg2(mig, session_row, voyager_rows=None, mproj_rows=None,
-                           authors=None, mulan_exists=False):
+                           authors=None, mulan_exists=False, lyrics_exists=False):
     """Install a fake psycopg2 connection on the module + mock out redis, probe, etc.
 
     Returns (mock_conn, mock_cursor, executed_sql) for assertions.
@@ -166,6 +166,8 @@ def _install_fake_psycopg2(mig, session_row, voyager_rows=None, mproj_rows=None,
         up = sql_str.upper()
         if 'INFORMATION_SCHEMA' in up and 'FOREIGN KEY' in up:
             mock_cur.fetchone.return_value = ('{}_item_id_fkey'.format(params[0] if params else 'embedding'),)
+        elif 'TO_REGCLASS' in up and 'LYRICS_EMBEDDING' in up:
+            mock_cur.fetchone.return_value = (lyrics_exists,)
         elif 'TO_REGCLASS' in up and 'MULAN_EMBEDDING' in up:
             mock_cur.fetchone.return_value = (mulan_exists,)
         elif 'FROM MIGRATION_SESSION' in up and 'SELECT' in up:


### PR DESCRIPTION
Provider migration was raising a foreign-key violation on the `lyrics_embedding` table when re-keying score rows from the source provider's IDs to the target provider's IDs. Updates to `score.item_id` were happening before the cascading update to dependent tables that reference it, so the FK check fired first.

This was discovered while preparing to test #336 — switching providers to validate the new cron upsert path on different backends ran straight into the FK error.

Tested migrating Jellyfin -> Navidrome -> Lyrion -> Emby