### PR TITLE
Feature #336: cron Sonic Fingerprint reuses one stable playlist

### DIFF
--- a/app_cron.py
+++ b/app_cron.py
@@ -184,21 +184,41 @@ def run_due_cron_jobs():
                     rq_queue_high.enqueue('tasks.clustering.run_clustering_task', kwargs=clustering_kwargs, job_id=job_id, description='Cron Clustering', job_timeout=-1)
                     logger.info(f"Cron: enqueued clustering job {job_id}")
                 elif task_type == 'sonic_fingerprint':
-                    # Run synchronously, not via queue, and create playlist on media server
+                    # Run synchronously, not via queue. Upsert a stably-named playlist on the
+                    # media server so client-side "online first" sync (e.g. Symfonium on Navidrome)
+                    # keeps tracking the same server playlist across runs (issue #336).
                     from tasks.sonic_fingerprint_manager import generate_sonic_fingerprint
+                    from tasks.mediaserver import create_or_replace_playlist
                     from tasks.voyager_manager import create_playlist_from_ids
+                    from config import SONIC_FINGERPRINT_CRON_PLAYLIST_NAME
                     try:
                         fingerprint_results = generate_sonic_fingerprint()
                         if not fingerprint_results:
-                            logger.warning(f"Cron: sonic fingerprint found no results (job_id={job_id})")
+                            logger.warning(
+                                f"Cron: sonic fingerprint found no results — preserving previous playlist (job_id={job_id})"
+                            )
                         else:
                             track_ids = [r['item_id'] for r in fingerprint_results if 'item_id' in r]
-                            playlist_name = f"Sonic Fingerprint (Cron {time.strftime('%Y-%m-%d')})"
                             try:
-                                playlist_id = create_playlist_from_ids(playlist_name, track_ids)
-                                logger.info(f"Cron: created sonic fingerprint playlist '{playlist_name}' (playlist_id={playlist_id}, job_id={job_id})")
+                                try:
+                                    upserted = create_or_replace_playlist(
+                                        SONIC_FINGERPRINT_CRON_PLAYLIST_NAME, track_ids
+                                    )
+                                    playlist_id = upserted.get('Id') if upserted else None
+                                    logger.info(
+                                        f"Cron: upserted '{SONIC_FINGERPRINT_CRON_PLAYLIST_NAME}' "
+                                        f"(playlist_id={playlist_id}, tracks={len(track_ids)}, job_id={job_id})"
+                                    )
+                                except NotImplementedError:
+                                    # MPD or unsupported backend: keep the legacy date-suffixed behavior.
+                                    legacy_name = f"Sonic Fingerprint (Cron {time.strftime('%Y-%m-%d')})"
+                                    playlist_id = create_playlist_from_ids(legacy_name, track_ids)
+                                    logger.info(
+                                        f"Cron: created sonic fingerprint playlist '{legacy_name}' "
+                                        f"(playlist_id={playlist_id}, job_id={job_id})"
+                                    )
                             except Exception as e:
-                                logger.error(f"Cron: error creating playlist for sonic fingerprint: {e}")
+                                logger.error(f"Cron: error creating/updating playlist for sonic fingerprint: {e}")
                         logger.info(f"Cron: ran sonic fingerprint synchronously (job_id={job_id})")
                     except Exception as e:
                         logger.error(f"Cron: error running sonic fingerprint: {e}")

--- a/config.py
+++ b/config.py
@@ -549,6 +549,10 @@ CLAP_OTHER_FEATURES_REDIS_KEY = os.environ.get("CLAP_OTHER_FEATURES_REDIS_KEY", 
 # --- Sonic Fingerprint Constants ---
 SONIC_FINGERPRINT_TOP_N_SONGS = int(os.environ.get("SONIC_FINGERPRINT_TOP_N_SONGS", "20"))
 SONIC_FINGERPRINT_NEIGHBORS = int(os.environ.get("SONIC_FINGERPRINT_NEIGHBORS", "100"))
+SONIC_FINGERPRINT_CRON_PLAYLIST_NAME = os.environ.get(
+    "SONIC_FINGERPRINT_CRON_PLAYLIST_NAME",
+    "Sonic Fingerprint by AudioMuse-AI",
+)
 
 # --- Database Cleaning Safety ---
 CLEANING_SAFETY_LIMIT = int(os.environ.get("CLEANING_SAFETY_LIMIT", "100"))  # Max orphaned albums to delete in one run

--- a/tasks/mediaserver.py
+++ b/tasks/mediaserver.py
@@ -352,8 +352,9 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     """Cron-only upsert: create the playlist if missing, or replace its contents in place.
 
     Used by the scheduled sonic_fingerprint task so the same server-side playlist (and ID,
-    where the backend allows) gets reused across runs. Raises NotImplementedError for MPD —
-    the cron handler catches that and falls back to legacy date-suffixed playlist creation.
+    where the backend allows) gets reused across runs. Raises NotImplementedError for MPD
+    and any other unsupported backend — the cron handler catches that and falls back to
+    legacy date-suffixed playlist creation.
     """
     if not playlist_name:
         raise ValueError("Playlist name is required.")
@@ -368,8 +369,6 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         return emby_create_or_replace_playlist(playlist_name, item_ids, user_creds)
     if config.MEDIASERVER_TYPE == 'lyrion':
         return lyrion_create_or_replace_playlist(playlist_name, item_ids, user_creds)
-    if config.MEDIASERVER_TYPE == 'mpd':
-        raise NotImplementedError("create_or_replace_playlist is not implemented for MPD")
     raise NotImplementedError(
         f"create_or_replace_playlist not supported for MEDIASERVER_TYPE={config.MEDIASERVER_TYPE!r}"
     )

--- a/tasks/mediaserver.py
+++ b/tasks/mediaserver.py
@@ -19,6 +19,7 @@ from tasks.mediaserver_jellyfin import (
     get_playlist_by_name as jellyfin_get_playlist_by_name,
     create_playlist as jellyfin_create_playlist,
     create_instant_playlist as jellyfin_create_instant_playlist,
+    create_or_replace_playlist as jellyfin_create_or_replace_playlist,
     get_top_played_songs as jellyfin_get_top_played_songs,
     get_last_played_time as jellyfin_get_last_played_time,
     list_libraries as _jellyfin_list_libraries,
@@ -36,6 +37,7 @@ from tasks.mediaserver_navidrome import (
     get_playlist_by_name as navidrome_get_playlist_by_name,
     create_playlist as navidrome_create_playlist,
     create_instant_playlist as navidrome_create_instant_playlist,
+    create_or_replace_playlist as navidrome_create_or_replace_playlist,
     get_top_played_songs as navidrome_get_top_played_songs,
     get_last_played_time as navidrome_get_last_played_time,
     list_libraries as _navidrome_list_libraries,
@@ -53,6 +55,7 @@ from tasks.mediaserver_lyrion import (
     get_playlist_by_name as lyrion_get_playlist_by_name,
     create_playlist as lyrion_create_playlist,
     create_instant_playlist as lyrion_create_instant_playlist,
+    create_or_replace_playlist as lyrion_create_or_replace_playlist,
     get_top_played_songs as lyrion_get_top_played_songs,
     get_last_played_time as lyrion_get_last_played_time,
     list_libraries as _lyrion_list_libraries,
@@ -85,6 +88,7 @@ from tasks.mediaserver_emby import (
     get_playlist_by_name as emby_get_playlist_by_name,
     create_playlist as emby_create_playlist,
     create_instant_playlist as emby_create_instant_playlist,
+    create_or_replace_playlist as emby_create_or_replace_playlist,
     get_top_played_songs as emby_get_top_played_songs,
     get_last_played_time as emby_get_last_played_time,
     list_libraries as _emby_list_libraries,
@@ -330,7 +334,7 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
     """Creates an instant playlist. Uses user_creds if provided, otherwise admin."""
     if not playlist_name: raise ValueError("Playlist name is required.")
     if not item_ids: raise ValueError("Track IDs are required.")
-    
+
     if config.MEDIASERVER_TYPE == 'jellyfin':
         return jellyfin_create_instant_playlist(playlist_name, item_ids, user_creds)
     if config.MEDIASERVER_TYPE == 'navidrome':
@@ -342,6 +346,33 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
     if config.MEDIASERVER_TYPE == 'emby':
         return emby_create_instant_playlist(playlist_name, item_ids, user_creds)
     return None
+
+
+def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
+    """Cron-only upsert: create the playlist if missing, or replace its contents in place.
+
+    Used by the scheduled sonic_fingerprint task so the same server-side playlist (and ID,
+    where the backend allows) gets reused across runs. Raises NotImplementedError for MPD —
+    the cron handler catches that and falls back to legacy date-suffixed playlist creation.
+    """
+    if not playlist_name:
+        raise ValueError("Playlist name is required.")
+    if not item_ids:
+        raise ValueError("Track IDs are required.")
+
+    if config.MEDIASERVER_TYPE == 'jellyfin':
+        return jellyfin_create_or_replace_playlist(playlist_name, item_ids, user_creds)
+    if config.MEDIASERVER_TYPE == 'navidrome':
+        return navidrome_create_or_replace_playlist(playlist_name, item_ids, user_creds)
+    if config.MEDIASERVER_TYPE == 'emby':
+        return emby_create_or_replace_playlist(playlist_name, item_ids, user_creds)
+    if config.MEDIASERVER_TYPE == 'lyrion':
+        return lyrion_create_or_replace_playlist(playlist_name, item_ids, user_creds)
+    if config.MEDIASERVER_TYPE == 'mpd':
+        raise NotImplementedError("create_or_replace_playlist is not implemented for MPD")
+    raise NotImplementedError(
+        f"create_or_replace_playlist not supported for MEDIASERVER_TYPE={config.MEDIASERVER_TYPE!r}"
+    )
 
 def get_top_played_songs(limit, user_creds=None):
     """Fetches top played songs. Uses user_creds if provided, otherwise admin."""

--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -1033,7 +1033,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         logger.info(f"✅ Emby: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
         return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
 
-    playlist_id = existing.get("Id") or existing.get("id")
+    playlist_id = existing.get("Id")
     if not playlist_id:
         logger.error(f"Emby create_or_replace_playlist: existing playlist '{playlist_name}' has no Id")
         return None
@@ -1046,7 +1046,9 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         return None
 
     if not _add_items_to_playlist(playlist_id, item_ids, user_id, headers):
+        # Items were already cleared above; signal failure so the cron handler doesn't log success.
         logger.error(f"Emby create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
+        return None
 
     logger.info(f"✅ Emby: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
     return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}

--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -10,6 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
+EMBY_PLAYLIST_BATCH_SIZE = 100
 
 # ##############################################################################
 # EMBY IMPLEMENTATION
@@ -920,4 +921,133 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
             playlist_name, user_id, e, exc_info=True
         )
         return None
+
+
+def _get_playlist_entry_ids(playlist_id, user_id, headers):
+    """Fetches every PlaylistItemId for an existing Emby playlist.
+
+    Emby returns playlist contents at GET /emby/Playlists/{Id}/Items?UserId=... with each item
+    carrying a PlaylistItemId distinct from the audio Item's Id. Removal needs PlaylistItemId.
+    """
+    url = f"{config.EMBY_URL}/emby/Playlists/{playlist_id}/Items"
+    params = {"UserId": user_id}
+    try:
+        r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
+        r.raise_for_status()
+        items = r.json().get("Items", [])
+        entry_ids = [it.get("PlaylistItemId") for it in items if it.get("PlaylistItemId")]
+        if len(entry_ids) != len(items):
+            logger.warning(
+                f"Emby _get_playlist_entry_ids: playlist {playlist_id} had "
+                f"{len(items) - len(entry_ids)} items missing PlaylistItemId — they will not be removed"
+            )
+        return entry_ids
+    except Exception as e:
+        logger.error(f"Emby _get_playlist_entry_ids failed for {playlist_id}: {e}", exc_info=True)
+        return None
+
+
+def _remove_playlist_entries(playlist_id, entry_ids, headers):
+    """DELETEs entries from an Emby playlist in batches. Returns True on full success."""
+    if not entry_ids:
+        return True
+    url = f"{config.EMBY_URL}/emby/Playlists/{playlist_id}/Items"
+    for i in range(0, len(entry_ids), EMBY_PLAYLIST_BATCH_SIZE):
+        batch = entry_ids[i:i + EMBY_PLAYLIST_BATCH_SIZE]
+        params = {"EntryIds": ",".join(batch)}
+        try:
+            r = requests.delete(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+        except Exception as e:
+            logger.error(
+                f"Emby _remove_playlist_entries: batch starting at {i} failed for playlist {playlist_id}: {e}",
+                exc_info=True,
+            )
+            return False
+    return True
+
+
+def _add_items_to_playlist(playlist_id, item_ids, user_id, headers):
+    """POSTs items to an Emby playlist in batches. Returns True on full success."""
+    if not item_ids:
+        return True
+    url = f"{config.EMBY_URL}/emby/Playlists/{playlist_id}/Items"
+    for i in range(0, len(item_ids), EMBY_PLAYLIST_BATCH_SIZE):
+        batch = item_ids[i:i + EMBY_PLAYLIST_BATCH_SIZE]
+        params = {"Ids": ",".join(batch), "UserId": user_id}
+        try:
+            r = requests.post(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+        except Exception as e:
+            logger.error(
+                f"Emby _add_items_to_playlist: batch starting at {i} failed for playlist {playlist_id}: {e}",
+                exc_info=True,
+            )
+            return False
+    return True
+
+
+def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
+    """Cron-only upsert: create the playlist if missing, or replace its contents preserving the ID.
+
+    Uses admin credentials by default. Returns the playlist dict (with 'Id'/'Name') or None.
+    """
+    if not item_ids:
+        return None
+
+    user_id = user_creds.get('user_id') if user_creds else config.EMBY_USER_ID
+    token = (user_creds.get('token') if user_creds else None) or config.EMBY_TOKEN
+    if not token or not user_id:
+        logger.error("Emby create_or_replace_playlist: token or user_id missing")
+        return None
+    headers = {"X-Emby-Token": token}
+
+    existing = get_playlist_by_name(playlist_name, user_creds=user_creds)
+    if not existing:
+        first_batch = item_ids[:EMBY_PLAYLIST_BATCH_SIZE]
+        rest = item_ids[EMBY_PLAYLIST_BATCH_SIZE:]
+        ids_param = ",".join(first_batch)
+        url = (
+            f"{config.EMBY_URL}/emby/Playlists"
+            f"?Name={requests.utils.quote(playlist_name)}"
+            f"&Ids={requests.utils.quote(ids_param)}"
+            f"&UserId={user_id}"
+            f"&MediaType=Audio"
+        )
+        try:
+            r = requests.post(url, headers=headers, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+            created = r.json()
+        except Exception as e:
+            logger.error(f"Emby create_or_replace_playlist: create failed for '{playlist_name}': {e}", exc_info=True)
+            return None
+
+        new_id = created.get("Id")
+        if not new_id:
+            logger.error(f"Emby create_or_replace_playlist: created '{playlist_name}' but response had no Id")
+            return None
+
+        if rest and not _add_items_to_playlist(new_id, rest, user_id, headers):
+            logger.error(f"Emby create_or_replace_playlist: created '{playlist_name}' but failed to add overflow tracks")
+
+        logger.info(f"✅ Emby: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
+        return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
+
+    playlist_id = existing.get("Id") or existing.get("id")
+    if not playlist_id:
+        logger.error(f"Emby create_or_replace_playlist: existing playlist '{playlist_name}' has no Id")
+        return None
+
+    entry_ids = _get_playlist_entry_ids(playlist_id, user_id, headers)
+    if entry_ids is None:
+        return None
+
+    if not _remove_playlist_entries(playlist_id, entry_ids, headers):
+        return None
+
+    if not _add_items_to_playlist(playlist_id, item_ids, user_id, headers):
+        logger.error(f"Emby create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
+
+    logger.info(f"✅ Emby: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
+    return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}
 

--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -10,7 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
-EMBY_PLAYLIST_BATCH_SIZE = 50
+EMBY_PLAYLIST_BATCH_SIZE = 100
 
 # ##############################################################################
 # EMBY IMPLEMENTATION
@@ -947,19 +947,14 @@ def _get_playlist_entry_ids(playlist_id, user_id, headers):
         return None
 
 
-def _remove_playlist_entries(playlist_id, entry_ids, user_id, headers):
-    """DELETEs entries from an Emby playlist in batches. Returns True on full success.
-
-    ``UserId`` is passed as a query param to mirror ``_add_items_to_playlist`` and avoid
-    the Jellyfin-style auth quirk where the DELETE handler can't resolve a user from a
-    bare API token. See parallel fix in tasks/mediaserver_jellyfin.py.
-    """
+def _remove_playlist_entries(playlist_id, entry_ids, headers):
+    """DELETEs entries from an Emby playlist in batches. Returns True on full success."""
     if not entry_ids:
         return True
     url = f"{config.EMBY_URL}/emby/Playlists/{playlist_id}/Items"
     for i in range(0, len(entry_ids), EMBY_PLAYLIST_BATCH_SIZE):
         batch = entry_ids[i:i + EMBY_PLAYLIST_BATCH_SIZE]
-        params = {"EntryIds": ",".join(batch), "UserId": user_id}
+        params = {"EntryIds": ",".join(batch)}
         try:
             r = requests.delete(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
             r.raise_for_status()
@@ -1047,7 +1042,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     if entry_ids is None:
         return None
 
-    if not _remove_playlist_entries(playlist_id, entry_ids, user_id, headers):
+    if not _remove_playlist_entries(playlist_id, entry_ids, headers):
         return None
 
     if not _add_items_to_playlist(playlist_id, item_ids, user_id, headers):

--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -10,7 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
-EMBY_PLAYLIST_BATCH_SIZE = 100
+EMBY_PLAYLIST_BATCH_SIZE = 50
 
 # ##############################################################################
 # EMBY IMPLEMENTATION
@@ -947,14 +947,19 @@ def _get_playlist_entry_ids(playlist_id, user_id, headers):
         return None
 
 
-def _remove_playlist_entries(playlist_id, entry_ids, headers):
-    """DELETEs entries from an Emby playlist in batches. Returns True on full success."""
+def _remove_playlist_entries(playlist_id, entry_ids, user_id, headers):
+    """DELETEs entries from an Emby playlist in batches. Returns True on full success.
+
+    ``UserId`` is passed as a query param to mirror ``_add_items_to_playlist`` and avoid
+    the Jellyfin-style auth quirk where the DELETE handler can't resolve a user from a
+    bare API token. See parallel fix in tasks/mediaserver_jellyfin.py.
+    """
     if not entry_ids:
         return True
     url = f"{config.EMBY_URL}/emby/Playlists/{playlist_id}/Items"
     for i in range(0, len(entry_ids), EMBY_PLAYLIST_BATCH_SIZE):
         batch = entry_ids[i:i + EMBY_PLAYLIST_BATCH_SIZE]
-        params = {"EntryIds": ",".join(batch)}
+        params = {"EntryIds": ",".join(batch), "UserId": user_id}
         try:
             r = requests.delete(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
             r.raise_for_status()
@@ -1042,7 +1047,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     if entry_ids is None:
         return None
 
-    if not _remove_playlist_entries(playlist_id, entry_ids, headers):
+    if not _remove_playlist_entries(playlist_id, entry_ids, user_id, headers):
         return None
 
     if not _add_items_to_playlist(playlist_id, item_ids, user_id, headers):

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -10,7 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
-JELLYFIN_PLAYLIST_BATCH_SIZE = 50
+JELLYFIN_PLAYLIST_BATCH_SIZE = 100
 
 # ##############################################################################
 # JELLYFIN IMPLEMENTATION
@@ -591,18 +591,13 @@ def _get_playlist_entry_ids(playlist_id):
 
 
 def _remove_playlist_entries(playlist_id, entry_ids):
-    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success.
-
-    ``userId`` must be passed as a query param: Jellyfin's DELETE handler can't resolve
-    a user from an API token alone and otherwise 400s with "Guid can't be empty".
-    See jellyfin/jellyfin#12999, #13476, #14910.
-    """
+    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success."""
     if not entry_ids:
         return True
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     for i in range(0, len(entry_ids), JELLYFIN_PLAYLIST_BATCH_SIZE):
         batch = entry_ids[i:i + JELLYFIN_PLAYLIST_BATCH_SIZE]
-        params = {"entryIds": ",".join(batch), "userId": config.JELLYFIN_USER_ID}
+        params = {"entryIds": ",".join(batch)}
         try:
             r = requests.delete(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
             r.raise_for_status()

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -657,7 +657,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         logger.info(f"✅ Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
         return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
 
-    playlist_id = existing.get("Id") or existing.get("id")
+    playlist_id = existing.get("Id")
     if not playlist_id:
         logger.error(f"Jellyfin create_or_replace_playlist: existing playlist '{playlist_name}' has no Id")
         return None
@@ -670,7 +670,9 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         return None
 
     if not _add_items_to_playlist(playlist_id, item_ids):
+        # Items were already cleared above; signal failure so the cron handler doesn't log success.
         logger.error(f"Jellyfin create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
+        return None
 
     logger.info(f"✅ Jellyfin: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
     return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -10,7 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
-JELLYFIN_PLAYLIST_BATCH_SIZE = 100
+JELLYFIN_PLAYLIST_BATCH_SIZE = 50
 
 # ##############################################################################
 # JELLYFIN IMPLEMENTATION
@@ -591,13 +591,18 @@ def _get_playlist_entry_ids(playlist_id):
 
 
 def _remove_playlist_entries(playlist_id, entry_ids):
-    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success."""
+    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success.
+
+    ``userId`` must be passed as a query param: Jellyfin's DELETE handler can't resolve
+    a user from an API token alone and otherwise 400s with "Guid can't be empty".
+    See jellyfin/jellyfin#12999, #13476, #14910.
+    """
     if not entry_ids:
         return True
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     for i in range(0, len(entry_ids), JELLYFIN_PLAYLIST_BATCH_SIZE):
         batch = entry_ids[i:i + JELLYFIN_PLAYLIST_BATCH_SIZE]
-        params = {"entryIds": ",".join(batch)}
+        params = {"entryIds": ",".join(batch), "userId": config.JELLYFIN_USER_ID}
         try:
             r = requests.delete(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
             r.raise_for_status()

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -591,23 +591,17 @@ def _get_playlist_entry_ids(playlist_id):
 
 
 def _remove_playlist_entries(playlist_id, entry_ids):
-    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success."""
+    """DELETEs entries from a Jellyfin playlist in batches. Raises on HTTP failure;
+    callers must wrap in try/except if they want to handle the failure (e.g. fall
+    back to delete-and-recreate on Jellyfin < 10.11)."""
     if not entry_ids:
-        return True
+        return
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     for i in range(0, len(entry_ids), JELLYFIN_PLAYLIST_BATCH_SIZE):
         batch = entry_ids[i:i + JELLYFIN_PLAYLIST_BATCH_SIZE]
         params = {"entryIds": ",".join(batch)}
-        try:
-            r = requests.delete(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
-            r.raise_for_status()
-        except Exception as e:
-            logger.error(
-                f"Jellyfin _remove_playlist_entries: batch starting at {i} failed for playlist {playlist_id}: {e}",
-                exc_info=True,
-            )
-            return False
-    return True
+        r = requests.delete(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
+        r.raise_for_status()
 
 
 def _add_items_to_playlist(playlist_id, item_ids):
@@ -685,12 +679,11 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     if entry_ids is None:
         return None
 
-    if not _remove_playlist_entries(playlist_id, entry_ids):
-        logger.warning(
-            f"Jellyfin: reuse of existing playlist '{playlist_name}' (Id={playlist_id}) didn't work — "
-            f"in-place item removal failed (likely Jellyfin < 10.11 with API-token bug). "
-            f"Deleting and recreating; playlist Id will change. "
-            f"Upgrade Jellyfin to 10.11+ to keep stable playlist Ids."
+    try:
+        _remove_playlist_entries(playlist_id, entry_ids)
+    except Exception:
+        logger.info(
+            f"Reuse of existing playlist '{playlist_name}' not supported from the Music Server, going to create a new one."
         )
         if not delete_playlist(playlist_id):
             logger.error(

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -630,8 +630,40 @@ def _add_items_to_playlist(playlist_id, item_ids):
     return True
 
 
+def _create_fresh_playlist(playlist_name, item_ids):
+    """POST a new Jellyfin playlist with ``item_ids``. Returns the playlist dict or None."""
+    url = f"{config.JELLYFIN_URL}/Playlists"
+    first_batch = item_ids[:JELLYFIN_PLAYLIST_BATCH_SIZE]
+    rest = item_ids[JELLYFIN_PLAYLIST_BATCH_SIZE:]
+    body = {"Name": playlist_name, "Ids": first_batch, "UserId": config.JELLYFIN_USER_ID}
+    try:
+        r = requests.post(url, headers=config.HEADERS, json=body, timeout=REQUESTS_TIMEOUT)
+        r.raise_for_status()
+        created = r.json()
+    except Exception as e:
+        logger.error(f"Jellyfin _create_fresh_playlist: create failed for '{playlist_name}': {e}", exc_info=True)
+        return None
+
+    new_id = created.get("Id")
+    if not new_id:
+        logger.error(f"Jellyfin _create_fresh_playlist: created '{playlist_name}' but response had no Id")
+        return None
+
+    if rest and not _add_items_to_playlist(new_id, rest):
+        logger.error(f"Jellyfin _create_fresh_playlist: created '{playlist_name}' but failed to add overflow tracks")
+
+    logger.info(f"✅ Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
+    return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
+
+
 def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
-    """Cron-only upsert: create the playlist if missing, or replace its contents preserving the ID.
+    """Cron-only upsert: create the playlist if missing, or replace its contents.
+
+    Tries to preserve the playlist Id by clearing then repopulating in place. Falls back
+    to deleting the whole playlist and recreating it when the in-place clear fails — this
+    is the case on Jellyfin < 10.11 with API-token auth (jellyfin/jellyfin#13476, server
+    fix shipped in 10.11.0). The fallback yields a new Id every cron tick; upgrade
+    Jellyfin to 10.11+ to keep stable Ids.
 
     Uses admin credentials. ``user_creds`` is accepted for dispatcher signature parity but
     not currently used (cron always runs as admin). Returns the playlist dict (with 'Id'/'Name')
@@ -642,28 +674,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
 
     existing = get_playlist_by_name(playlist_name)
     if not existing:
-        url = f"{config.JELLYFIN_URL}/Playlists"
-        first_batch = item_ids[:JELLYFIN_PLAYLIST_BATCH_SIZE]
-        rest = item_ids[JELLYFIN_PLAYLIST_BATCH_SIZE:]
-        body = {"Name": playlist_name, "Ids": first_batch, "UserId": config.JELLYFIN_USER_ID}
-        try:
-            r = requests.post(url, headers=config.HEADERS, json=body, timeout=REQUESTS_TIMEOUT)
-            r.raise_for_status()
-            created = r.json()
-        except Exception as e:
-            logger.error(f"Jellyfin create_or_replace_playlist: create failed for '{playlist_name}': {e}", exc_info=True)
-            return None
-
-        new_id = created.get("Id")
-        if not new_id:
-            logger.error(f"Jellyfin create_or_replace_playlist: created '{playlist_name}' but response had no Id")
-            return None
-
-        if rest and not _add_items_to_playlist(new_id, rest):
-            logger.error(f"Jellyfin create_or_replace_playlist: created '{playlist_name}' but failed to add overflow tracks")
-
-        logger.info(f"✅ Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
-        return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
+        return _create_fresh_playlist(playlist_name, item_ids)
 
     playlist_id = existing.get("Id")
     if not playlist_id:
@@ -675,7 +686,18 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         return None
 
     if not _remove_playlist_entries(playlist_id, entry_ids):
-        return None
+        logger.warning(
+            f"Jellyfin: reuse of existing playlist '{playlist_name}' (Id={playlist_id}) didn't work — "
+            f"in-place item removal failed (likely Jellyfin < 10.11 with API-token bug). "
+            f"Deleting and recreating; playlist Id will change. "
+            f"Upgrade Jellyfin to 10.11+ to keep stable playlist Ids."
+        )
+        if not delete_playlist(playlist_id):
+            logger.error(
+                f"Jellyfin: failed to delete playlist '{playlist_name}' (Id={playlist_id}) for fallback recreate"
+            )
+            return None
+        return _create_fresh_playlist(playlist_name, item_ids)
 
     if not _add_items_to_playlist(playlist_id, item_ids):
         # Items were already cleared above; signal failure so the cron handler doesn't log success.

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -10,6 +10,7 @@ from tasks.mediaserver_helper import detect_path_format
 logger = logging.getLogger(__name__)
 
 REQUESTS_TIMEOUT = 300
+JELLYFIN_PLAYLIST_BATCH_SIZE = 100
 
 # ##############################################################################
 # JELLYFIN IMPLEMENTATION
@@ -554,4 +555,123 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
     except Exception as e:
         logger.error("Exception creating Jellyfin instant playlist '%s' for user %s: %s", playlist_name, user_id, e, exc_info=True)
         return None
+
+
+def _get_playlist_entry_ids(playlist_id):
+    """Fetches every PlaylistItemId for an existing Jellyfin playlist (admin creds).
+
+    Each playlist *entry* has both the underlying audio item's ``Id`` and a separate
+    ``PlaylistItemId``. Removal via ``DELETE /Playlists/{Id}/Items?entryIds=…`` requires
+    the latter — passing the audio Id will silently no-op.
+    """
+    url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
+    params = {"UserId": config.JELLYFIN_USER_ID}
+    try:
+        r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
+        r.raise_for_status()
+        items = r.json().get("Items", [])
+        entry_ids = [it.get("PlaylistItemId") for it in items if it.get("PlaylistItemId")]
+        if len(entry_ids) != len(items):
+            logger.warning(
+                f"Jellyfin _get_playlist_entry_ids: playlist {playlist_id} had "
+                f"{len(items) - len(entry_ids)} items missing PlaylistItemId — they will not be removed"
+            )
+        return entry_ids
+    except Exception as e:
+        logger.error(f"Jellyfin _get_playlist_entry_ids failed for {playlist_id}: {e}", exc_info=True)
+        return None
+
+
+def _remove_playlist_entries(playlist_id, entry_ids):
+    """DELETEs entries from a Jellyfin playlist in batches. Returns True on full success."""
+    if not entry_ids:
+        return True
+    url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
+    for i in range(0, len(entry_ids), JELLYFIN_PLAYLIST_BATCH_SIZE):
+        batch = entry_ids[i:i + JELLYFIN_PLAYLIST_BATCH_SIZE]
+        params = {"entryIds": ",".join(batch)}
+        try:
+            r = requests.delete(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+        except Exception as e:
+            logger.error(
+                f"Jellyfin _remove_playlist_entries: batch starting at {i} failed for playlist {playlist_id}: {e}",
+                exc_info=True,
+            )
+            return False
+    return True
+
+
+def _add_items_to_playlist(playlist_id, item_ids):
+    """POSTs items to a Jellyfin playlist in batches (admin creds). Returns True on full success."""
+    if not item_ids:
+        return True
+    url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
+    for i in range(0, len(item_ids), JELLYFIN_PLAYLIST_BATCH_SIZE):
+        batch = item_ids[i:i + JELLYFIN_PLAYLIST_BATCH_SIZE]
+        params = {"ids": ",".join(batch), "userId": config.JELLYFIN_USER_ID}
+        try:
+            r = requests.post(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+        except Exception as e:
+            logger.error(
+                f"Jellyfin _add_items_to_playlist: batch starting at {i} failed for playlist {playlist_id}: {e}",
+                exc_info=True,
+            )
+            return False
+    return True
+
+
+def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
+    """Cron-only upsert: create the playlist if missing, or replace its contents preserving the ID.
+
+    Uses admin credentials. ``user_creds`` is accepted for dispatcher signature parity but
+    not currently used (cron always runs as admin). Returns the playlist dict (with 'Id'/'Name')
+    or None on failure.
+    """
+    if not item_ids:
+        return None
+
+    existing = get_playlist_by_name(playlist_name)
+    if not existing:
+        url = f"{config.JELLYFIN_URL}/Playlists"
+        first_batch = item_ids[:JELLYFIN_PLAYLIST_BATCH_SIZE]
+        rest = item_ids[JELLYFIN_PLAYLIST_BATCH_SIZE:]
+        body = {"Name": playlist_name, "Ids": first_batch, "UserId": config.JELLYFIN_USER_ID}
+        try:
+            r = requests.post(url, headers=config.HEADERS, json=body, timeout=REQUESTS_TIMEOUT)
+            r.raise_for_status()
+            created = r.json()
+        except Exception as e:
+            logger.error(f"Jellyfin create_or_replace_playlist: create failed for '{playlist_name}': {e}", exc_info=True)
+            return None
+
+        new_id = created.get("Id")
+        if not new_id:
+            logger.error(f"Jellyfin create_or_replace_playlist: created '{playlist_name}' but response had no Id")
+            return None
+
+        if rest and not _add_items_to_playlist(new_id, rest):
+            logger.error(f"Jellyfin create_or_replace_playlist: created '{playlist_name}' but failed to add overflow tracks")
+
+        logger.info(f"✅ Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
+        return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
+
+    playlist_id = existing.get("Id") or existing.get("id")
+    if not playlist_id:
+        logger.error(f"Jellyfin create_or_replace_playlist: existing playlist '{playlist_name}' has no Id")
+        return None
+
+    entry_ids = _get_playlist_entry_ids(playlist_id)
+    if entry_ids is None:
+        return None
+
+    if not _remove_playlist_entries(playlist_id, entry_ids):
+        return None
+
+    if not _add_items_to_playlist(playlist_id, item_ids):
+        logger.error(f"Jellyfin create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
+
+    logger.info(f"✅ Jellyfin: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
+    return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}
 

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -412,14 +412,22 @@ def test_connection(user_creds=None):
 
 
 def get_playlist_by_name(playlist_name):
-    """Finds a Jellyfin playlist by its exact name using admin credentials."""
+    """Finds a Jellyfin playlist by its exact name using admin credentials.
+
+    Jellyfin's /Users/{userId}/Items endpoint silently ignores the Name query
+    parameter and returns every playlist regardless of value, so we have to
+    filter client-side by exact match (mirrors the Emby version).
+    """
     url = f"{config.JELLYFIN_URL}/Users/{config.JELLYFIN_USER_ID}/Items"
-    params = {"IncludeItemTypes": "Playlist", "Recursive": True, "Name": playlist_name}
+    params = {"IncludeItemTypes": "Playlist", "Recursive": True}
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
         playlists = r.json().get("Items", [])
-        return playlists[0] if playlists else None
+        for playlist in playlists:
+            if playlist.get("Name") == playlist_name:
+                return playlist
+        return None
     except Exception as e:
         logger.error(f"Jellyfin get_playlist_by_name failed for '{playlist_name}': {e}", exc_info=True)
         return None

--- a/tasks/mediaserver_lyrion.py
+++ b/tasks/mediaserver_lyrion.py
@@ -1346,18 +1346,23 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     """Cron-only upsert for Lyrion.
 
     Lyrion's `_add_to_playlist` is destructive — it deletes-and-resaves under the original
-    name, and may assign a new numeric id (see lines 1062-1068). True ID preservation isn't
-    possible with the current primitives, so when the playlist exists we delete it and
-    recreate with the same name. End-state matches `_add_to_playlist`'s observed behavior.
-    Lyrion clients track playlists by name, so the unstable numeric id rarely matters.
+    name and may assign a new numeric id. True ID preservation isn't possible with the
+    current primitives, so when the playlist exists we delete it and recreate with the
+    same name. Lyrion clients track playlists by name, so the unstable numeric id rarely
+    matters; the important invariant is that we don't end up with two playlists sharing
+    a name (which is why we bail when delete fails instead of forging ahead).
     """
     if not item_ids:
         return None
 
     existing = get_playlist_by_name(playlist_name)
     if existing:
-        old_id = existing.get('Id') or existing.get('id')
-        if old_id:
-            delete_playlist(old_id)
+        old_id = existing.get('Id')
+        if old_id and not delete_playlist(old_id):
+            logger.error(
+                f"Lyrion create_or_replace_playlist: failed to delete existing '{playlist_name}' "
+                f"(id={old_id}); aborting to avoid creating a duplicate"
+            )
+            return None
 
     return _create_playlist_batched(playlist_name, item_ids)

--- a/tasks/mediaserver_lyrion.py
+++ b/tasks/mediaserver_lyrion.py
@@ -1135,8 +1135,12 @@ def get_all_playlists():
 def delete_playlist(playlist_id):
     """Deletes a playlist on Lyrion using JSON-RPC."""
     # The correct command is 'playlists delete'.
+    # LMS returns an empty dict ({}) on success; `_jsonrpc_request` raises on
+    # transport/protocol errors. So the only way to reach here with `response`
+    # set is server success — including the empty-dict case, which `if response:`
+    # used to mis-treat as failure.
     response = _jsonrpc_request("playlists", ["delete", f"playlist_id:{playlist_id}"])
-    if response:
+    if response is not None:
         logger.info(f"🗑️ Deleted Lyrion playlist ID: {playlist_id}")
         return True
     logger.error(f"Failed to delete playlist ID '{playlist_id}' on Lyrion")

--- a/tasks/mediaserver_lyrion.py
+++ b/tasks/mediaserver_lyrion.py
@@ -1340,3 +1340,24 @@ def create_instant_playlist(playlist_name, item_ids):
     """Creates a new instant playlist on Lyrion for a specific user, with batching."""
     final_playlist_name = f"{playlist_name.strip()}_instant"
     return _create_playlist_batched(final_playlist_name, item_ids)
+
+
+def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
+    """Cron-only upsert for Lyrion.
+
+    Lyrion's `_add_to_playlist` is destructive — it deletes-and-resaves under the original
+    name, and may assign a new numeric id (see lines 1062-1068). True ID preservation isn't
+    possible with the current primitives, so when the playlist exists we delete it and
+    recreate with the same name. End-state matches `_add_to_playlist`'s observed behavior.
+    Lyrion clients track playlists by name, so the unstable numeric id rarely matters.
+    """
+    if not item_ids:
+        return None
+
+    existing = get_playlist_by_name(playlist_name)
+    if existing:
+        old_id = existing.get('Id') or existing.get('id')
+        if old_id:
+            delete_playlist(old_id)
+
+    return _create_playlist_batched(playlist_name, item_ids)

--- a/tasks/mediaserver_navidrome.py
+++ b/tasks/mediaserver_navidrome.py
@@ -687,3 +687,68 @@ def create_instant_playlist(playlist_name, item_ids, user_creds):
     """Creates a new instant playlist on Navidrome for a specific user, with batching."""
     final_playlist_name = f"{playlist_name.strip()}_instant"
     return _create_playlist_batched(final_playlist_name, item_ids, user_creds)
+
+
+def _clear_playlist_items(playlist_id, user_creds=None):
+    """Removes every track from an existing Navidrome playlist while keeping the playlist itself.
+
+    Reads the current ``songCount`` via ``getPlaylist`` and issues batched ``updatePlaylist``
+    calls with ``songIndexToRemove`` in **descending** order so earlier indices stay valid as
+    higher ones are removed. Returns True on success, False on any failed batch.
+    """
+    detail = _navidrome_request("getPlaylist", {"id": playlist_id}, user_creds=user_creds)
+    if not (detail and "playlist" in detail):
+        logger.error(f"Navidrome _clear_playlist_items: failed to fetch playlist {playlist_id}")
+        return False
+
+    song_count = int(detail["playlist"].get("songCount") or 0)
+    if song_count == 0:
+        return True
+
+    indices = list(range(song_count - 1, -1, -1))
+    for i in range(0, len(indices), NAVIDROME_API_BATCH_SIZE):
+        batch = indices[i:i + NAVIDROME_API_BATCH_SIZE]
+        params = {
+            "playlistId": playlist_id,
+            "songIndexToRemove": batch,
+        }
+        response = _navidrome_request("updatePlaylist", params, method='post', user_creds=user_creds)
+        if not (response and response.get("status") == "ok"):
+            logger.error(
+                f"Navidrome _clear_playlist_items: failed to remove batch starting at index {batch[0]}"
+            )
+            return False
+    return True
+
+
+def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
+    """Cron-only upsert: create the playlist if missing, or replace its contents preserving the ID.
+
+    Always batches both removals and additions at NAVIDROME_API_BATCH_SIZE. Returns the playlist
+    dict (with 'Id'/'Name' keys, matching `_create_playlist_batched`) or None on failure.
+    """
+    if not item_ids:
+        return None
+
+    existing = get_playlist_by_name(playlist_name, user_creds=user_creds)
+    if not existing:
+        return _create_playlist_batched(playlist_name, item_ids, user_creds=user_creds)
+
+    playlist_id = existing.get("id") or existing.get("Id")
+    if not playlist_id:
+        logger.error(f"Navidrome create_or_replace_playlist: existing playlist '{playlist_name}' has no id")
+        return None
+
+    if not _clear_playlist_items(playlist_id, user_creds=user_creds):
+        return None
+
+    if not _add_to_playlist(playlist_id, item_ids, user_creds=user_creds):
+        logger.error(
+            f"Navidrome create_or_replace_playlist: failed to add tracks to playlist {playlist_id}"
+        )
+
+    return {
+        **existing,
+        'Id': playlist_id,
+        'Name': existing.get('name') or existing.get('Name') or playlist_name,
+    }

--- a/tasks/mediaserver_navidrome.py
+++ b/tasks/mediaserver_navidrome.py
@@ -734,7 +734,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
     if not existing:
         return _create_playlist_batched(playlist_name, item_ids, user_creds=user_creds)
 
-    playlist_id = existing.get("id") or existing.get("Id")
+    playlist_id = existing.get("id")
     if not playlist_id:
         logger.error(f"Navidrome create_or_replace_playlist: existing playlist '{playlist_name}' has no id")
         return None
@@ -743,12 +743,16 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         return None
 
     if not _add_to_playlist(playlist_id, item_ids, user_creds=user_creds):
+        # Playlist was cleared above. Returning None signals the cron handler not to log success;
+        # the playlist will remain empty until the next run, which is preferable to silently
+        # reporting a populated playlist when it isn't.
         logger.error(
             f"Navidrome create_or_replace_playlist: failed to add tracks to playlist {playlist_id}"
         )
+        return None
 
     return {
         **existing,
         'Id': playlist_id,
-        'Name': existing.get('name') or existing.get('Name') or playlist_name,
+        'Name': existing.get('name') or playlist_name,
     }

--- a/tests/unit/test_app_cron.py
+++ b/tests/unit/test_app_cron.py
@@ -1,0 +1,92 @@
+"""Tests for app_cron.py — sonic_fingerprint cron branch (issue #336).
+
+Verifies:
+- Empty fingerprint results → previous playlist is preserved (no upsert call)
+- Non-empty results → create_or_replace_playlist called with the constant name
+- Backend that raises NotImplementedError (e.g. MPD) → falls back to legacy
+  date-suffixed create_playlist_from_ids path
+"""
+from unittest.mock import MagicMock, patch
+
+
+def _make_cron_row(task_type='sonic_fingerprint'):
+    """Build a row dict matching the DictCursor shape used by run_due_cron_jobs."""
+    return {
+        'id': 1,
+        'name': 'Sonic Fingerprint',
+        'task_type': task_type,
+        'cron_expr': '* * * * *',
+        'enabled': True,
+        'last_run': 0,
+    }
+
+
+def _setup_db_mock():
+    """Mock a get_db() that returns one enabled sonic_fingerprint cron row."""
+    cur = MagicMock()
+    cur.fetchall.return_value = [_make_cron_row()]
+    db = MagicMock()
+    db.cursor.return_value = cur
+    return db, cur
+
+
+@patch('app_cron.cron_matches_now', return_value=True)
+@patch('app_cron.get_db')
+def test_sonic_fingerprint_branch_skips_on_empty_results(mock_get_db, _matches):
+    """If generate_sonic_fingerprint returns [], do NOT call create_or_replace_playlist."""
+    from app_cron import run_due_cron_jobs
+
+    db, _cur = _setup_db_mock()
+    mock_get_db.return_value = db
+
+    with patch('tasks.sonic_fingerprint_manager.generate_sonic_fingerprint', return_value=[]) as gen, \
+         patch('tasks.mediaserver.create_or_replace_playlist') as upsert, \
+         patch('tasks.voyager_manager.create_playlist_from_ids') as legacy:
+        run_due_cron_jobs()
+
+    gen.assert_called_once()
+    upsert.assert_not_called()
+    legacy.assert_not_called()
+
+
+@patch('app_cron.cron_matches_now', return_value=True)
+@patch('app_cron.get_db')
+def test_sonic_fingerprint_branch_calls_upsert_with_constant_name(mock_get_db, _matches):
+    """Non-empty results → upsert called once with SONIC_FINGERPRINT_CRON_PLAYLIST_NAME."""
+    from app_cron import run_due_cron_jobs
+    from config import SONIC_FINGERPRINT_CRON_PLAYLIST_NAME
+
+    db, _cur = _setup_db_mock()
+    mock_get_db.return_value = db
+
+    fp = [{'item_id': 'a'}, {'item_id': 'b'}, {'item_id': 'c'}]
+
+    with patch('tasks.sonic_fingerprint_manager.generate_sonic_fingerprint', return_value=fp), \
+         patch('tasks.mediaserver.create_or_replace_playlist', return_value={'Id': 'pl-x'}) as upsert, \
+         patch('tasks.voyager_manager.create_playlist_from_ids') as legacy:
+        run_due_cron_jobs()
+
+    upsert.assert_called_once_with(SONIC_FINGERPRINT_CRON_PLAYLIST_NAME, ['a', 'b', 'c'])
+    legacy.assert_not_called()
+
+
+@patch('app_cron.cron_matches_now', return_value=True)
+@patch('app_cron.get_db')
+def test_sonic_fingerprint_branch_falls_back_for_mpd(mock_get_db, _matches):
+    """Backend raising NotImplementedError → legacy create_playlist_from_ids called."""
+    from app_cron import run_due_cron_jobs
+
+    db, _cur = _setup_db_mock()
+    mock_get_db.return_value = db
+
+    fp = [{'item_id': 'a'}]
+
+    with patch('tasks.sonic_fingerprint_manager.generate_sonic_fingerprint', return_value=fp), \
+         patch('tasks.mediaserver.create_or_replace_playlist', side_effect=NotImplementedError), \
+         patch('tasks.voyager_manager.create_playlist_from_ids', return_value='legacy-id') as legacy:
+        run_due_cron_jobs()
+
+    legacy.assert_called_once()
+    legacy_name = legacy.call_args[0][0]
+    assert legacy_name.startswith('Sonic Fingerprint (Cron ')
+    assert legacy.call_args[0][1] == ['a']

--- a/tests/unit/test_mediaserver.py
+++ b/tests/unit/test_mediaserver.py
@@ -2171,3 +2171,306 @@ class TestLyrionListLibraries:
         args, kwargs = mock_rpc.call_args
         assert args[0] == 'musicfolder'
         assert kwargs.get('user_creds') == creds
+
+
+# =============================================================================
+# create_or_replace_playlist (cron sonic_fingerprint upsert) — issue #336
+# =============================================================================
+
+class TestNavidromeCreateOrReplacePlaylist:
+    """Navidrome upsert: create when missing, clear+add when existing (preserve ID)."""
+
+    @patch('tasks.mediaserver_navidrome._create_playlist_batched')
+    @patch('tasks.mediaserver_navidrome.get_playlist_by_name')
+    def test_missing_playlist_creates_via_batched(self, mock_get, mock_create):
+        from tasks.mediaserver_navidrome import create_or_replace_playlist
+
+        mock_get.return_value = None
+        mock_create.return_value = {'Id': 'new-pl-1', 'Name': 'SF', 'id': 'new-pl-1'}
+
+        result = create_or_replace_playlist('SF', ['s1', 's2'])
+
+        mock_create.assert_called_once_with('SF', ['s1', 's2'], user_creds=None)
+        assert result['Id'] == 'new-pl-1'
+
+    @patch('tasks.mediaserver_navidrome._add_to_playlist')
+    @patch('tasks.mediaserver_navidrome._navidrome_request')
+    @patch('tasks.mediaserver_navidrome.get_playlist_by_name')
+    def test_existing_playlist_preserves_id(self, mock_get, mock_request, mock_add):
+        from tasks.mediaserver_navidrome import create_or_replace_playlist
+
+        mock_get.return_value = {'id': 'pl-existing', 'name': 'SF'}
+        # 1st call: getPlaylist returns 3 songs. 2nd+: updatePlaylist returns ok.
+        mock_request.side_effect = [
+            {'playlist': {'id': 'pl-existing', 'songCount': 3}},
+            {'status': 'ok'},
+        ]
+        mock_add.return_value = True
+
+        result = create_or_replace_playlist('SF', ['new1', 'new2'])
+
+        # getPlaylist was called once
+        first = mock_request.call_args_list[0]
+        assert first[0][0] == 'getPlaylist'
+        assert first[0][1] == {'id': 'pl-existing'}
+
+        # updatePlaylist removed indices in DESCENDING order [2, 1, 0]
+        second = mock_request.call_args_list[1]
+        assert second[0][0] == 'updatePlaylist'
+        assert second[0][1]['playlistId'] == 'pl-existing'
+        assert second[0][1]['songIndexToRemove'] == [2, 1, 0]
+
+        # Adds happened on the same playlist id
+        mock_add.assert_called_once_with('pl-existing', ['new1', 'new2'], user_creds=None)
+
+        # Returned dict carries the existing ID
+        assert result['Id'] == 'pl-existing'
+
+    @patch('tasks.mediaserver_navidrome._add_to_playlist')
+    @patch('tasks.mediaserver_navidrome._navidrome_request')
+    @patch('tasks.mediaserver_navidrome.get_playlist_by_name')
+    def test_clear_batches_above_40(self, mock_get, mock_request, mock_add):
+        from tasks.mediaserver_navidrome import create_or_replace_playlist
+
+        mock_get.return_value = {'id': 'pl-100', 'name': 'SF'}
+        mock_request.side_effect = [
+            {'playlist': {'id': 'pl-100', 'songCount': 100}},
+            {'status': 'ok'}, {'status': 'ok'}, {'status': 'ok'},  # 3 update batches
+        ]
+        mock_add.return_value = True
+
+        create_or_replace_playlist('SF', ['x'])
+
+        # getPlaylist + 3 updatePlaylist batches (40+40+20)
+        assert len(mock_request.call_args_list) == 4
+        update_calls = mock_request.call_args_list[1:]
+        assert len(update_calls[0][0][1]['songIndexToRemove']) == 40
+        assert len(update_calls[1][0][1]['songIndexToRemove']) == 40
+        assert len(update_calls[2][0][1]['songIndexToRemove']) == 20
+
+    @patch('tasks.mediaserver_navidrome._navidrome_request')
+    @patch('tasks.mediaserver_navidrome.get_playlist_by_name')
+    def test_empty_item_ids_returns_none_without_calls(self, mock_get, mock_request):
+        from tasks.mediaserver_navidrome import create_or_replace_playlist
+
+        result = create_or_replace_playlist('SF', [])
+
+        assert result is None
+        mock_get.assert_not_called()
+        mock_request.assert_not_called()
+
+
+class TestJellyfinCreateOrReplacePlaylist:
+    """Jellyfin upsert via /Playlists/{Id}/Items POST/DELETE/GET."""
+
+    @patch('tasks.mediaserver_jellyfin.requests')
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    @patch('tasks.mediaserver_jellyfin.config')
+    def test_missing_playlist_creates_and_returns_id(self, mock_config, mock_get, mock_requests):
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        mock_config.JELLYFIN_URL = 'http://jf'
+        mock_config.JELLYFIN_USER_ID = 'admin-user'
+        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_get.return_value = None
+
+        post_resp = MagicMock()
+        post_resp.json.return_value = {'Id': 'new-jf-1', 'Name': 'SF'}
+        mock_requests.post.return_value = post_resp
+
+        result = create_or_replace_playlist('SF', ['s1', 's2'])
+
+        # Single POST to /Playlists with the create body
+        assert mock_requests.post.call_count == 1
+        post_call = mock_requests.post.call_args
+        assert post_call[0][0] == 'http://jf/Playlists'
+        assert post_call[1]['json'] == {'Name': 'SF', 'Ids': ['s1', 's2'], 'UserId': 'admin-user'}
+        assert result['Id'] == 'new-jf-1'
+
+    @patch('tasks.mediaserver_jellyfin.requests')
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    @patch('tasks.mediaserver_jellyfin.config')
+    def test_existing_playlist_clears_and_adds_preserving_id(self, mock_config, mock_get, mock_requests):
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        mock_config.JELLYFIN_URL = 'http://jf'
+        mock_config.JELLYFIN_USER_ID = 'admin-user'
+        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_get.return_value = {'Id': 'pl-existing', 'Name': 'SF'}
+
+        # GET items returns two entries with PlaylistItemId
+        get_resp = MagicMock()
+        get_resp.json.return_value = {'Items': [
+            {'Id': 'song1', 'PlaylistItemId': 'entry-a'},
+            {'Id': 'song2', 'PlaylistItemId': 'entry-b'},
+        ]}
+        mock_requests.get.return_value = get_resp
+        mock_requests.delete.return_value = MagicMock()
+        mock_requests.post.return_value = MagicMock()
+
+        result = create_or_replace_playlist('SF', ['new1', 'new2'])
+
+        # GET on /Playlists/pl-existing/Items
+        assert mock_requests.get.call_args[0][0] == 'http://jf/Playlists/pl-existing/Items'
+        # DELETE with entryIds
+        assert mock_requests.delete.call_count == 1
+        del_call = mock_requests.delete.call_args
+        assert del_call[0][0] == 'http://jf/Playlists/pl-existing/Items'
+        assert del_call[1]['params']['entryIds'] == 'entry-a,entry-b'
+        # POST adds new ids
+        assert mock_requests.post.call_count == 1
+        post_call = mock_requests.post.call_args
+        assert post_call[0][0] == 'http://jf/Playlists/pl-existing/Items'
+        assert post_call[1]['params']['ids'] == 'new1,new2'
+        assert post_call[1]['params']['userId'] == 'admin-user'
+        # Same ID preserved
+        assert result['Id'] == 'pl-existing'
+
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    def test_empty_item_ids_returns_none(self, mock_get):
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        result = create_or_replace_playlist('SF', [])
+
+        assert result is None
+        mock_get.assert_not_called()
+
+
+class TestEmbyCreateOrReplacePlaylist:
+    """Emby upsert under /emby/ prefix with uppercase params."""
+
+    @patch('tasks.mediaserver_emby.requests')
+    @patch('tasks.mediaserver_emby.get_playlist_by_name')
+    @patch('tasks.mediaserver_emby.config')
+    def test_existing_playlist_clears_and_adds_preserving_id(self, mock_config, mock_get, mock_requests):
+        from tasks.mediaserver_emby import create_or_replace_playlist
+
+        mock_config.EMBY_URL = 'http://emby'
+        mock_config.EMBY_USER_ID = 'admin-emby'
+        mock_config.EMBY_TOKEN = 'tok'
+        mock_get.return_value = {'Id': 'emby-pl', 'Name': 'SF'}
+
+        get_resp = MagicMock()
+        get_resp.json.return_value = {'Items': [
+            {'Id': 'song1', 'PlaylistItemId': 'e1'},
+        ]}
+        mock_requests.get.return_value = get_resp
+        mock_requests.delete.return_value = MagicMock()
+        mock_requests.post.return_value = MagicMock()
+        # quote helper used in create branch — make it a simple passthrough so
+        # other tests in this class remain compatible if they hit it
+        mock_requests.utils.quote.side_effect = lambda s: s
+
+        result = create_or_replace_playlist('SF', ['n1'])
+
+        assert mock_requests.delete.call_args[1]['params']['EntryIds'] == 'e1'
+        post_call = mock_requests.post.call_args
+        assert post_call[0][0] == 'http://emby/emby/Playlists/emby-pl/Items'
+        assert post_call[1]['params']['Ids'] == 'n1'
+        assert post_call[1]['params']['UserId'] == 'admin-emby'
+        assert result['Id'] == 'emby-pl'
+
+
+class TestLyrionCreateOrReplacePlaylist:
+    """Lyrion upsert: deletes existing then creates fresh (ID may change — known limitation)."""
+
+    @patch('tasks.mediaserver_lyrion._create_playlist_batched')
+    @patch('tasks.mediaserver_lyrion.delete_playlist')
+    @patch('tasks.mediaserver_lyrion.get_playlist_by_name')
+    def test_existing_deletes_then_creates(self, mock_get, mock_delete, mock_create):
+        from tasks.mediaserver_lyrion import create_or_replace_playlist
+
+        mock_get.return_value = {'Id': 99, 'Name': 'SF'}
+        mock_create.return_value = {'Id': 100, 'Name': 'SF'}
+
+        result = create_or_replace_playlist('SF', ['t1'])
+
+        mock_delete.assert_called_once_with(99)
+        mock_create.assert_called_once_with('SF', ['t1'])
+        assert result['Name'] == 'SF'
+
+    @patch('tasks.mediaserver_lyrion._create_playlist_batched')
+    @patch('tasks.mediaserver_lyrion.delete_playlist')
+    @patch('tasks.mediaserver_lyrion.get_playlist_by_name')
+    def test_missing_creates_without_delete(self, mock_get, mock_delete, mock_create):
+        from tasks.mediaserver_lyrion import create_or_replace_playlist
+
+        mock_get.return_value = None
+        mock_create.return_value = {'Id': 50, 'Name': 'SF'}
+
+        create_or_replace_playlist('SF', ['t1'])
+
+        mock_delete.assert_not_called()
+        mock_create.assert_called_once_with('SF', ['t1'])
+
+
+class TestDispatcherCreateOrReplacePlaylist:
+    """Validation + per-provider dispatching for create_or_replace_playlist."""
+
+    @patch('tasks.mediaserver.config')
+    def test_requires_name_and_ids(self, mock_config):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        with pytest.raises(ValueError, match="Playlist name is required"):
+            create_or_replace_playlist('', ['id1'])
+
+        with pytest.raises(ValueError, match="Track IDs are required"):
+            create_or_replace_playlist('Name', [])
+
+    @patch('tasks.mediaserver.config')
+    def test_mpd_raises_not_implemented(self, mock_config):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        mock_config.MEDIASERVER_TYPE = 'mpd'
+
+        with pytest.raises(NotImplementedError):
+            create_or_replace_playlist('SF', ['s1'])
+
+    @patch('tasks.mediaserver.navidrome_create_or_replace_playlist')
+    @patch('tasks.mediaserver.config')
+    def test_dispatches_to_navidrome(self, mock_config, mock_provider):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        mock_config.MEDIASERVER_TYPE = 'navidrome'
+        mock_provider.return_value = {'Id': 'pl-1'}
+
+        result = create_or_replace_playlist('SF', ['s1'])
+
+        mock_provider.assert_called_once_with('SF', ['s1'], None)
+        assert result['Id'] == 'pl-1'
+
+    @patch('tasks.mediaserver.jellyfin_create_or_replace_playlist')
+    @patch('tasks.mediaserver.config')
+    def test_dispatches_to_jellyfin(self, mock_config, mock_provider):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        mock_config.MEDIASERVER_TYPE = 'jellyfin'
+        mock_provider.return_value = {'Id': 'pl-2'}
+
+        create_or_replace_playlist('SF', ['s1'])
+
+        mock_provider.assert_called_once()
+
+    @patch('tasks.mediaserver.emby_create_or_replace_playlist')
+    @patch('tasks.mediaserver.config')
+    def test_dispatches_to_emby(self, mock_config, mock_provider):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        mock_config.MEDIASERVER_TYPE = 'emby'
+        mock_provider.return_value = {'Id': 'pl-3'}
+
+        create_or_replace_playlist('SF', ['s1'])
+
+        mock_provider.assert_called_once()
+
+    @patch('tasks.mediaserver.lyrion_create_or_replace_playlist')
+    @patch('tasks.mediaserver.config')
+    def test_dispatches_to_lyrion(self, mock_config, mock_provider):
+        from tasks.mediaserver import create_or_replace_playlist
+
+        mock_config.MEDIASERVER_TYPE = 'lyrion'
+        mock_provider.return_value = {'Id': 4}
+
+        create_or_replace_playlist('SF', ['s1'])
+
+        mock_provider.assert_called_once()

--- a/tests/unit/test_mediaserver.py
+++ b/tests/unit/test_mediaserver.py
@@ -2259,6 +2259,24 @@ class TestNavidromeCreateOrReplacePlaylist:
         mock_get.assert_not_called()
         mock_request.assert_not_called()
 
+    @patch('tasks.mediaserver_navidrome._add_to_playlist')
+    @patch('tasks.mediaserver_navidrome._navidrome_request')
+    @patch('tasks.mediaserver_navidrome.get_playlist_by_name')
+    def test_returns_none_when_add_fails_after_clear(self, mock_get, mock_request, mock_add):
+        """If clear succeeds but add fails, return None so the cron handler doesn't log success."""
+        from tasks.mediaserver_navidrome import create_or_replace_playlist
+
+        mock_get.return_value = {'id': 'pl-1', 'name': 'SF'}
+        mock_request.side_effect = [
+            {'playlist': {'id': 'pl-1', 'songCount': 1}},
+            {'status': 'ok'},
+        ]
+        mock_add.return_value = False
+
+        result = create_or_replace_playlist('SF', ['new1'])
+
+        assert result is None
+
 
 class TestJellyfinCreateOrReplacePlaylist:
     """Jellyfin upsert via /Playlists/{Id}/Items POST/DELETE/GET."""
@@ -2335,6 +2353,29 @@ class TestJellyfinCreateOrReplacePlaylist:
         assert result is None
         mock_get.assert_not_called()
 
+    @patch('tasks.mediaserver_jellyfin._add_items_to_playlist')
+    @patch('tasks.mediaserver_jellyfin._remove_playlist_entries')
+    @patch('tasks.mediaserver_jellyfin._get_playlist_entry_ids')
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    @patch('tasks.mediaserver_jellyfin.config')
+    def test_returns_none_when_add_fails_after_clear(
+        self, mock_config, mock_get, mock_get_entries, mock_remove, mock_add
+    ):
+        """If clear succeeds but add fails, return None instead of misreporting success."""
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        mock_config.JELLYFIN_URL = 'http://jf'
+        mock_config.JELLYFIN_USER_ID = 'admin-user'
+        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_get.return_value = {'Id': 'pl-1', 'Name': 'SF'}
+        mock_get_entries.return_value = ['e1']
+        mock_remove.return_value = True
+        mock_add.return_value = False
+
+        result = create_or_replace_playlist('SF', ['new1'])
+
+        assert result is None
+
 
 class TestEmbyCreateOrReplacePlaylist:
     """Emby upsert under /emby/ prefix with uppercase params."""
@@ -2370,6 +2411,28 @@ class TestEmbyCreateOrReplacePlaylist:
         assert post_call[1]['params']['UserId'] == 'admin-emby'
         assert result['Id'] == 'emby-pl'
 
+    @patch('tasks.mediaserver_emby._add_items_to_playlist')
+    @patch('tasks.mediaserver_emby._remove_playlist_entries')
+    @patch('tasks.mediaserver_emby._get_playlist_entry_ids')
+    @patch('tasks.mediaserver_emby.get_playlist_by_name')
+    @patch('tasks.mediaserver_emby.config')
+    def test_returns_none_when_add_fails_after_clear(
+        self, mock_config, mock_get, mock_get_entries, mock_remove, mock_add
+    ):
+        from tasks.mediaserver_emby import create_or_replace_playlist
+
+        mock_config.EMBY_URL = 'http://emby'
+        mock_config.EMBY_USER_ID = 'admin-emby'
+        mock_config.EMBY_TOKEN = 'tok'
+        mock_get.return_value = {'Id': 'emby-pl', 'Name': 'SF'}
+        mock_get_entries.return_value = ['e1']
+        mock_remove.return_value = True
+        mock_add.return_value = False
+
+        result = create_or_replace_playlist('SF', ['n1'])
+
+        assert result is None
+
 
 class TestLyrionCreateOrReplacePlaylist:
     """Lyrion upsert: deletes existing then creates fresh (ID may change — known limitation)."""
@@ -2381,6 +2444,7 @@ class TestLyrionCreateOrReplacePlaylist:
         from tasks.mediaserver_lyrion import create_or_replace_playlist
 
         mock_get.return_value = {'Id': 99, 'Name': 'SF'}
+        mock_delete.return_value = True
         mock_create.return_value = {'Id': 100, 'Name': 'SF'}
 
         result = create_or_replace_playlist('SF', ['t1'])
@@ -2402,6 +2466,21 @@ class TestLyrionCreateOrReplacePlaylist:
 
         mock_delete.assert_not_called()
         mock_create.assert_called_once_with('SF', ['t1'])
+
+    @patch('tasks.mediaserver_lyrion._create_playlist_batched')
+    @patch('tasks.mediaserver_lyrion.delete_playlist')
+    @patch('tasks.mediaserver_lyrion.get_playlist_by_name')
+    def test_aborts_when_delete_fails(self, mock_get, mock_delete, mock_create):
+        """If delete fails, return None instead of creating a duplicate playlist."""
+        from tasks.mediaserver_lyrion import create_or_replace_playlist
+
+        mock_get.return_value = {'Id': 99, 'Name': 'SF'}
+        mock_delete.return_value = False
+
+        result = create_or_replace_playlist('SF', ['t1'])
+
+        assert result is None
+        mock_create.assert_not_called()
 
 
 class TestDispatcherCreateOrReplacePlaylist:

--- a/tests/unit/test_mediaserver.py
+++ b/tests/unit/test_mediaserver.py
@@ -2376,6 +2376,59 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         assert result is None
 
+    @patch('tasks.mediaserver_jellyfin._create_fresh_playlist')
+    @patch('tasks.mediaserver_jellyfin.delete_playlist')
+    @patch('tasks.mediaserver_jellyfin._remove_playlist_entries')
+    @patch('tasks.mediaserver_jellyfin._get_playlist_entry_ids')
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    @patch('tasks.mediaserver_jellyfin.config')
+    def test_falls_back_to_recreate_when_remove_fails(
+        self, mock_config, mock_get, mock_get_entries, mock_remove, mock_delete, mock_create
+    ):
+        """Jellyfin <10.11 + API token rejects DELETE /Playlists/{Id}/Items (jellyfin#13476).
+        When that happens, delete the whole playlist and recreate. Id will change."""
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        mock_config.JELLYFIN_URL = 'http://jf'
+        mock_config.JELLYFIN_USER_ID = 'admin-user'
+        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
+        mock_get_entries.return_value = ['e1', 'e2']
+        mock_remove.return_value = False
+        mock_delete.return_value = True
+        mock_create.return_value = {'Id': 'new-pl', 'Name': 'SF'}
+
+        result = create_or_replace_playlist('SF', ['n1', 'n2'])
+
+        mock_delete.assert_called_once_with('old-pl')
+        mock_create.assert_called_once_with('SF', ['n1', 'n2'])
+        assert result['Id'] == 'new-pl'
+
+    @patch('tasks.mediaserver_jellyfin._create_fresh_playlist')
+    @patch('tasks.mediaserver_jellyfin.delete_playlist')
+    @patch('tasks.mediaserver_jellyfin._remove_playlist_entries')
+    @patch('tasks.mediaserver_jellyfin._get_playlist_entry_ids')
+    @patch('tasks.mediaserver_jellyfin.get_playlist_by_name')
+    @patch('tasks.mediaserver_jellyfin.config')
+    def test_fallback_returns_none_when_delete_playlist_fails(
+        self, mock_config, mock_get, mock_get_entries, mock_remove, mock_delete, mock_create
+    ):
+        """If the fallback delete itself fails, don't try to recreate — bail out."""
+        from tasks.mediaserver_jellyfin import create_or_replace_playlist
+
+        mock_config.JELLYFIN_URL = 'http://jf'
+        mock_config.JELLYFIN_USER_ID = 'admin-user'
+        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
+        mock_get_entries.return_value = ['e1']
+        mock_remove.return_value = False
+        mock_delete.return_value = False
+
+        result = create_or_replace_playlist('SF', ['n1'])
+
+        assert result is None
+        mock_create.assert_not_called()
+
 
 class TestEmbyCreateOrReplacePlaylist:
     """Emby upsert under /emby/ prefix with uppercase params."""

--- a/tests/unit/test_mediaserver.py
+++ b/tests/unit/test_mediaserver.py
@@ -2394,7 +2394,7 @@ class TestJellyfinCreateOrReplacePlaylist:
         mock_config.HEADERS = {'X-Emby-Token': 't'}
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1', 'e2']
-        mock_remove.return_value = False
+        mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
         mock_delete.return_value = True
         mock_create.return_value = {'Id': 'new-pl', 'Name': 'SF'}
 
@@ -2421,7 +2421,7 @@ class TestJellyfinCreateOrReplacePlaylist:
         mock_config.HEADERS = {'X-Emby-Token': 't'}
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1']
-        mock_remove.return_value = False
+        mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
         mock_delete.return_value = False
 
         result = create_or_replace_playlist('SF', ['n1'])


### PR DESCRIPTION
  ## Problem

  The scheduled `sonic_fingerprint` cron task (`app_cron.py`) called
  `create_playlist_from_ids("Sonic Fingerprint (Cron YYYY-MM-DD)", ids)`,
  which routes through `create_instant_playlist` (suffixed `_instant`) and
  creates a brand-new server-side playlist on every run.

  For "online-first" sync clients on Navidrome (Symfonium etc.) this breaks
  the user's saved sync because the server-side playlist ID changes each
  cron tick. Reported in #336; the parallel issue on Jellyfin (#150) was
  fixed inside the Jellyfin plugin, not in core, so all four core backends
  were still affected.

  ## Approach

  Per @NeptuneHub's direction in the issue thread:
  > "ad hoc playlist creation functionality only for fingerprint that then
  > need also to be reimplemented on all the music server. The logic here
  > should be to create the playlist with a specific name only if a previous
  > one doesn't exist, otherwise update the previous one."

  Add one new dispatcher function and one new helper per provider; existing
  `create_instant_playlist` / `create_playlist` / `create_playlist_from_ids`
  flows are not touched, so UI-driven and chat-driven playlist paths are
  unaffected.

  app_cron.run_due_cron_jobs (sonic_fingerprint branch only)
    └─ generate_sonic_fingerprint()
    └─ if results empty → log + skip (preserve previous playlist)
    └─ mediaserver.create_or_replace_playlist(name, track_ids)  [NEW]
     ──└─ provider_create_or_replace_playlist(name, ids)      [NEW per provider]
     ────├─ get_playlist_by_name(name)
     ────├─ exists  → clear-then-add (batched), preserve same playlist ID
     ────└─ missing → create-then-add-rest (batched)

  A new `SONIC_FINGERPRINT_CRON_PLAYLIST_NAME` config constant
  (env-overridable, default `"Sonic Fingerprint by AudioMuse-AI"`) replaces
  the date-suffixed name. MPD is intentionally out of scope; the dispatcher
  raises `NotImplementedError` for MPD and the cron handler catches it and
  falls back to the legacy date-suffixed `create_playlist_from_ids` path so
  MPD users see no regression.

  ## Per-backend implementation

  - **Navidrome**: `getPlaylist` + batched `updatePlaylist` with descending
    `songIndexToRemove` (40/batch) to clear, then `_add_to_playlist` for new
    ids. Preserves the playlist ID across runs.
  - **Jellyfin**: GET/DELETE/POST on `/Playlists/{Id}/Items` in batches of
    100, using each item's `PlaylistItemId` for `entryIds`. Preserves the
    playlist ID.
  - **Emby**: same shape under `/emby/` with capitalized params. Preserves
    the playlist ID.
  - **Lyrion**: `delete_playlist` + `_create_playlist_batched` when an
    existing playlist is found. Lyrion's underlying `_add_to_playlist`
    primitive is destructive (load → add → delete original → save), so
    the numeric playlist ID may change across runs — documented limitation.
    Lyrion clients track playlists by name, which remains stable.

  ## Commits

  1. `Fix #336: stable single playlist for cron sonic_fingerprint across providers`
     — main feature: dispatcher, four backend implementations, cron handler change, tests.
  2. `Fix #336: don't silently report success when upsert partially fails`
     — review fixes: return None when add fails after a successful clear (Navidrome /
     Jellyfin / Emby), check `delete_playlist` return value on Lyrion to avoid
     creating duplicates, drop dead Id/id fallbacks, consolidate dispatcher raises.
  3. `Fix: jellyfin get_playlist_by_name was returning the wrong playlist`
     — Jellyfin's `/Users/{userId}/Items?Name=...` silently ignores the Name filter
     and returns every playlist. The old `playlists[0]` returned a wrong/stale
     playlist (mirrors a workaround the Emby version has had since day one).
  4. `Fix: lyrion delete_playlist mis-treated empty-dict success as failure`
     — LMS returns `{}` on successful `playlists delete`; the existing `if response`
     check evaluated that as falsy and reported failure, causing the upsert to
     abort and leaving Lyrion users with disappearing playlists.

  ## Tests

  - `tests/unit/test_mediaserver.py` — new test classes for each provider
    covering missing-playlist (create), existing-playlist (replace, ID
    preserved), batching across the per-provider batch size, empty
    `item_ids` early-return, and add-failure-returns-None semantics.
  - `tests/unit/test_app_cron.py` (new) — cron sonic_fingerprint branch:
    empty-results skip, non-empty calls upsert with the constant name, MPD
    fallback to legacy `create_playlist_from_ids`.

  `python -m pytest tests/unit/test_mediaserver.py tests/unit/test_app_cron.py` →
  **125 passed**.

  ## Test plan

  - [x] Unit tests pass (125/125 in the affected files)
  - [x] Live smoke on Navidrome — first run creates, subsequent runs replace
        contents with same playlist ID; Symfonium-style ID-tracking clients
        remain stable (confirmed playlist changes)
  - [x] Live smoke on Jellyfin — same Id preserved across cron ticks (confirmed playlist changes)
  - [x] Live smoke on Emby — same Id preserved across cron ticks (confirmed playlist changes)
  - [x] Live smoke on Lyrion — upsert completes cleanly; numeric ID flaps as
        documented (name remains stable). Creates new playlist with same Name. (didn't test if it changes content because my Lyrion instant didn't report plays)
  - [x] Empty-fingerprint path preserves the previous playlist