### PR TITLE
Backup Restore improvement

### DIFF
--- a/app_backup.py
+++ b/app_backup.py
@@ -289,6 +289,7 @@ def restore_backup():
                     # Start restore with reassembled file
                     all_chunks_received = True
                 except Exception as e:
+                    logger.exception("Failed to reassemble uploaded backup chunks")
                     if tmp:
                         try:
                             tmp.close()
@@ -296,7 +297,7 @@ def restore_backup():
                             pass
                     if restore_file and os.path.exists(restore_file):
                         os.unlink(restore_file)
-                    return jsonify({'error': f'Failed to reassemble chunks: {str(e)}'}), 500
+                    return jsonify({'error': 'Failed to reassemble chunks due to an internal error.'}), 500
             else:
                 # Still waiting for more chunks
                 missing_chunks = [i for i in range(1, total_chunks + 1) if i not in received_chunks]

--- a/app_backup.py
+++ b/app_backup.py
@@ -180,7 +180,9 @@ def create_backup():
 def restore_backup():
     """Restore the database from an uploaded .sql dump file via psql.
 
-    Streams large files to disk in chunks to handle multi-GB backups efficiently.
+    Supports both:
+    - Full file upload (chunk_num=None)
+    - Chunked upload (chunk_num=X, total_chunks=Y) - each chunk saved, reassembled when all received
     """
     confirmation = request.form.get('confirmation', '')
     expected = "I want to restore the database from the backup. This action is not reversible"
@@ -191,73 +193,168 @@ def restore_backup():
     if not uploaded or not uploaded.filename:
         return jsonify({'error': 'No file uploaded.'}), 400
 
+    # Check if this is a chunked upload
+    chunk_num = request.form.get('chunk_num')
+    total_chunks = request.form.get('total_chunks')
+
     restore_file = None
     restore_log = None
     restore_pid = None
+
     try:
-        # Create temporary file for the backup
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
-        restore_file = tmp.name
+        if chunk_num and total_chunks:
+            # Chunked upload mode
+            try:
+                chunk_num = int(chunk_num)
+                total_chunks = int(total_chunks)
+            except ValueError:
+                return jsonify({'error': 'chunk_num and total_chunks must be integers.'}), 400
 
-        # Stream the uploaded file to disk in 8MB chunks to avoid memory issues with large files
-        chunk_size = 8 * 1024 * 1024  # 8 MB chunks
-        bytes_written = 0
-        logger.info(f"Starting to stream upload to {restore_file}")
+            if chunk_num < 1 or chunk_num > total_chunks or total_chunks < 1:
+                return jsonify({'error': f'Invalid chunk numbers: chunk_num={chunk_num}, total_chunks={total_chunks}'}), 400
 
-        try:
-            while True:
-                chunk = uploaded.stream.read(chunk_size)
-                if not chunk:
-                    break
-                tmp.write(chunk)
-                bytes_written += len(chunk)
-                # Log progress every 100MB
-                if bytes_written % (100 * 1024 * 1024) == 0 or bytes_written < chunk_size:
-                    logger.info(f"Streamed {bytes_written / (1024**3):.2f} GB to {restore_file}")
-        finally:
+            chunks_dir = os.path.join(BACKUP_DIR, 'chunks')
+            os.makedirs(chunks_dir, exist_ok=True)
+
+            chunk_file = os.path.join(chunks_dir, f'backup_{chunk_num}_of_{total_chunks}.sql')
+
+            # Check for orphaned chunks from different upload sessions
+            orphaned_chunks = set()
+            received_chunks = set()
+            for f in os.listdir(chunks_dir):
+                if f.startswith('backup_') and f.endswith('.sql'):
+                    try:
+                        parts = f.replace('backup_', '').replace('.sql', '').split('_of_')
+                        if len(parts) == 2:
+                            file_chunk_num = int(parts[0])
+                            file_total_chunks = int(parts[1])
+                            if file_total_chunks != total_chunks:
+                                orphaned_chunks.add(f)
+                            else:
+                                received_chunks.add(file_chunk_num)
+                    except (ValueError, IndexError):
+                        pass
+
+            # Warn about orphaned chunks from previous incomplete upload
+            if orphaned_chunks:
+                logger.warning(f"Found orphaned chunks from previous upload. Cleaning up: {orphaned_chunks}")
+                for orphan in orphaned_chunks:
+                    try:
+                        os.unlink(os.path.join(chunks_dir, orphan))
+                    except Exception as e:
+                        logger.warning(f"Could not delete orphan chunk {orphan}: {e}")
+
+            # Save the current chunk
+            try:
+                uploaded.save(chunk_file)
+                logger.info(f"Saved chunk {chunk_num}/{total_chunks}")
+                received_chunks.add(chunk_num)
+            except Exception as e:
+                return jsonify({'error': f'Failed to save chunk {chunk_num}: {str(e)}'}), 500
+
+            logger.info(f"Received chunks: {sorted(received_chunks)}/{total_chunks}")
+
+            # If all chunks received, reassemble
+            if len(received_chunks) == total_chunks and all(i in received_chunks for i in range(1, total_chunks + 1)):
+                logger.info(f"All {total_chunks} chunks received. Reassembling...")
+
+                tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
+                restore_file = tmp.name
+
+                try:
+                    for i in range(1, total_chunks + 1):
+                        chunk_path = os.path.join(chunks_dir, f'backup_{i}_of_{total_chunks}.sql')
+                        if not os.path.exists(chunk_path):
+                            raise Exception(f"Chunk {i} is missing during reassembly!")
+                        try:
+                            with open(chunk_path, 'rb') as chunk_f:
+                                data = chunk_f.read()
+                                if not data:
+                                    raise Exception(f"Chunk {i} is empty!")
+                                tmp.write(data)
+                        except IOError as e:
+                            raise Exception(f"Error reading chunk {i}: {str(e)}")
+
+                    tmp.close()
+                    file_size = os.path.getsize(restore_file)
+                    logger.info(f"Reassembly complete: {restore_file} ({file_size} bytes)")
+
+                    # Clean up chunk files
+                    for i in range(1, total_chunks + 1):
+                        try:
+                            os.unlink(os.path.join(chunks_dir, f'backup_{i}_of_{total_chunks}.sql'))
+                        except Exception as e:
+                            logger.warning(f"Could not delete chunk {i}: {e}")
+
+                    # Start restore with reassembled file
+                    all_chunks_received = True
+                except Exception as e:
+                    if tmp:
+                        try:
+                            tmp.close()
+                        except:
+                            pass
+                    if restore_file and os.path.exists(restore_file):
+                        os.unlink(restore_file)
+                    return jsonify({'error': f'Failed to reassemble chunks: {str(e)}'}), 500
+            else:
+                # Still waiting for more chunks
+                missing_chunks = [i for i in range(1, total_chunks + 1) if i not in received_chunks]
+                return jsonify({
+                    'success': True,
+                    'message': f'Chunk {chunk_num}/{total_chunks} received. Waiting for chunks: {missing_chunks}',
+                    'chunk_num': chunk_num,
+                    'total_chunks': total_chunks,
+                    'received_chunks': sorted(received_chunks),
+                    'missing_chunks': missing_chunks,
+                    'all_chunks_received': False,
+                })
+        else:
+            # Single file upload (non-chunked)
+            tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
+            uploaded.save(tmp)
             tmp.close()
+            restore_file = tmp.name
+            all_chunks_received = True
 
-        logger.info(f"Upload complete: {bytes_written / (1024**3):.2f} GB written to {restore_file}")
+        # Start restore only if all chunks received or single file upload
+        if restore_file and all_chunks_received:
+            stop_requested = restart_manager.publish_stop_request()
+            logger.info('Published worker stop request: %s', stop_requested)
 
-        # Publish worker stop as soon as the upload has been persisted and before
-        # starting the detached restore runner. This reduces the window between
-        # upload completion and the stop request being sent.
-        stop_requested = restart_manager.publish_stop_request()
-        logger.info('Published worker stop request before restore runner start: %s', stop_requested)
+            timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+            restore_log = os.path.join(RESTORE_LOG_DIR, f"restore_{timestamp}.log")
+            os.makedirs(RESTORE_LOG_DIR, exist_ok=True)
 
-        timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-        restore_log = os.path.join(RESTORE_LOG_DIR, f"restore_{timestamp}.log")
-        os.makedirs(RESTORE_LOG_DIR, exist_ok=True)
+            restore_cmd = [sys.executable, os.path.abspath(__file__), '--run-restore', restore_file, restore_log]
+            proc = subprocess.Popen(
+                restore_cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+                close_fds=True,
+            )
+            restore_pid = proc.pid
+            logger.info("Restore started in detached process %s", restore_pid)
 
-        restore_cmd = [sys.executable, os.path.abspath(__file__), '--run-restore', restore_file, restore_log]
-        proc = subprocess.Popen(
-            restore_cmd,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            close_fds=True,
-        )
-        restore_pid = proc.pid
-        logger.info("Restore started in detached process %s, log=%s", restore_pid, restore_log)
+            return jsonify({
+                'success': True,
+                'message': 'Database restore started.',
+                'restore_pid': restore_pid,
+                'restore_log': restore_log,
+                'all_chunks_received': True,
+            })
 
-        return jsonify({
-            'success': True,
-            'message': 'Database restore started.',
-            'restore_pid': restore_pid,
-            'restore_log': restore_log,
-        })
     except FileNotFoundError:
         logger.error("Python executable not found for restore runner")
         if restore_file and os.path.exists(restore_file):
             os.unlink(restore_file)
         return jsonify({'error': 'Python executable not found for restore runner.'}), 500
     except Exception:
-        logger.exception("Restore launch failed")
+        logger.exception("Restore failed")
         if restore_file and os.path.exists(restore_file):
             os.unlink(restore_file)
-        if restore_log and os.path.exists(restore_log):
-            os.unlink(restore_log)
-        return jsonify({'error': 'Restore launch failed. Check server logs.'}), 500
+        return jsonify({'error': 'Restore failed. Check server logs.'}), 500
 
 
 if __name__ == '__main__':

--- a/app_backup.py
+++ b/app_backup.py
@@ -6,6 +6,9 @@ import logging
 import tempfile
 from datetime import datetime
 from flask import Blueprint, render_template, jsonify, request, send_file, after_this_request
+from redis import Redis
+from redis.exceptions import RedisError
+import config
 from config import POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB
 import restart_manager
 
@@ -15,6 +18,28 @@ backup_bp = Blueprint('backup_bp', __name__)
 
 BACKUP_DIR = os.environ.get("BACKUP_DIR", "/app/backup")
 RESTORE_LOG_DIR = os.environ.get("RESTORE_LOG_DIR", BACKUP_DIR)
+
+# Cross-container restore lock. Only one restore may run at a time.
+# TTL self-releases on crash; runner releases explicitly on clean exit.
+RESTORE_LOCK_KEY = 'audiomuse:restore_lock'
+RESTORE_LOCK_TTL_SECONDS = 60 * 60  # 1 hour
+
+
+def _acquire_restore_lock():
+    """SET NX EX. Returns True if we got the lock, False if held or Redis is down."""
+    try:
+        client = Redis.from_url(config.REDIS_URL, socket_timeout=5, decode_responses=True)
+        return bool(client.set(RESTORE_LOCK_KEY, '1', nx=True, ex=RESTORE_LOCK_TTL_SECONDS))
+    except RedisError:
+        logger.exception("Redis unavailable while acquiring restore lock; failing closed.")
+        return False
+
+
+def _release_restore_lock():
+    try:
+        Redis.from_url(config.REDIS_URL, socket_timeout=5).delete(RESTORE_LOCK_KEY)
+    except RedisError:
+        logger.exception("Redis unavailable while releasing restore lock; relying on TTL.")
 
 
 def _pg_env():
@@ -125,6 +150,10 @@ def _run_restore_runner(dump_file, log_file):
             log.write(f"Could not delete temporary dump file {dump_file}: {exc}\n")
             log.flush()
 
+        _release_restore_lock()
+        log.write("Released restore lock.\n")
+        log.flush()
+
         log.write(f"Restore runner finished at {datetime.now().isoformat()}\n")
         log.flush()
 
@@ -216,6 +245,15 @@ def restore_backup():
             chunks_dir = os.path.join(BACKUP_DIR, 'chunks')
             os.makedirs(chunks_dir, exist_ok=True)
 
+            # Acquire the cross-container restore lock on the first chunk only.
+            # Subsequent chunks belong to the already-locked session.
+            if chunk_num == 1 and not _acquire_restore_lock():
+                logger.warning("Refusing chunk 1: restore lock already held.")
+                return jsonify({
+                    'error': 'A database restore is already in progress. '
+                             'Wait for it to finish, or wait up to 1 hour for the lock to auto-release.'
+                }), 409
+
             chunk_file = os.path.join(chunks_dir, f'backup_{chunk_num}_of_{total_chunks}.sql')
 
             # The first chunk marks the start of a new upload session: wipe any
@@ -299,6 +337,7 @@ def restore_backup():
                             pass
                     if restore_file and os.path.exists(restore_file):
                         os.unlink(restore_file)
+                    _release_restore_lock()
                     return jsonify({'error': 'Failed to reassemble chunks due to an internal error.'}), 500
             else:
                 # Still waiting for more chunks
@@ -314,6 +353,12 @@ def restore_backup():
                 })
         else:
             # Single file upload (non-chunked)
+            if not _acquire_restore_lock():
+                logger.warning("Refusing non-chunked restore: lock already held.")
+                return jsonify({
+                    'error': 'A database restore is already in progress. '
+                             'Wait for it to finish, or wait up to 1 hour for the lock to auto-release.'
+                }), 409
             tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
             uploaded.save(tmp)
             tmp.close()
@@ -352,11 +397,13 @@ def restore_backup():
         logger.error("Python executable not found for restore runner")
         if restore_file and os.path.exists(restore_file):
             os.unlink(restore_file)
+        _release_restore_lock()
         return jsonify({'error': 'Python executable not found for restore runner.'}), 500
     except Exception:
         logger.exception("Restore failed")
         if restore_file and os.path.exists(restore_file):
             os.unlink(restore_file)
+        _release_restore_lock()
         return jsonify({'error': 'Restore failed. Check server logs.'}), 500
 
 

--- a/app_backup.py
+++ b/app_backup.py
@@ -218,39 +218,36 @@ def restore_backup():
 
             chunk_file = os.path.join(chunks_dir, f'backup_{chunk_num}_of_{total_chunks}.sql')
 
-            # Check for orphaned chunks from different upload sessions
-            orphaned_chunks = set()
-            received_chunks = set()
-            for f in os.listdir(chunks_dir):
-                if f.startswith('backup_') and f.endswith('.sql'):
-                    try:
-                        parts = f.replace('backup_', '').replace('.sql', '').split('_of_')
-                        if len(parts) == 2:
-                            file_chunk_num = int(parts[0])
-                            file_total_chunks = int(parts[1])
-                            if file_total_chunks != total_chunks:
-                                orphaned_chunks.add(f)
-                            else:
-                                received_chunks.add(file_chunk_num)
-                    except (ValueError, IndexError):
-                        pass
-
-            # Warn about orphaned chunks from previous incomplete upload
-            if orphaned_chunks:
-                logger.warning(f"Found orphaned chunks from previous upload. Cleaning up: {orphaned_chunks}")
-                for orphan in orphaned_chunks:
-                    try:
-                        os.unlink(os.path.join(chunks_dir, orphan))
-                    except Exception as e:
-                        logger.warning(f"Could not delete orphan chunk {orphan}: {e}")
+            # The first chunk marks the start of a new upload session: wipe any
+            # leftovers so a previous failed run cannot leak stale data into the
+            # reassembled file (chunks may match total_chunks but have different
+            # contents).
+            if chunk_num == 1:
+                for f in os.listdir(chunks_dir):
+                    if f.startswith('backup_') and f.endswith('.sql'):
+                        try:
+                            os.unlink(os.path.join(chunks_dir, f))
+                        except Exception as exc:
+                            logger.warning(f"Could not delete leftover chunk {f}: {exc}")
 
             # Save the current chunk
             try:
                 uploaded.save(chunk_file)
                 logger.info(f"Saved chunk {chunk_num}/{total_chunks}")
-                received_chunks.add(chunk_num)
-            except Exception as e:
-                return jsonify({'error': f'Failed to save chunk {chunk_num}: {str(e)}'}), 500
+            except Exception:
+                logger.exception("Failed to save chunk %s", chunk_num)
+                return jsonify({'error': f'Failed to save chunk {chunk_num}.'}), 500
+
+            # Rebuild the received set from disk (only chunks belonging to this session)
+            received_chunks = set()
+            for f in os.listdir(chunks_dir):
+                if f.startswith('backup_') and f.endswith(f'_of_{total_chunks}.sql'):
+                    try:
+                        parts = f.replace('backup_', '').replace('.sql', '').split('_of_')
+                        if len(parts) == 2:
+                            received_chunks.add(int(parts[0]))
+                    except (ValueError, IndexError):
+                        pass
 
             logger.info(f"Received chunks: {sorted(received_chunks)}/{total_chunks}")
 
@@ -267,11 +264,16 @@ def restore_backup():
                         if not os.path.exists(chunk_path):
                             raise Exception(f"Chunk {i} is missing during reassembly!")
                         try:
+                            bytes_read = 0
                             with open(chunk_path, 'rb') as chunk_f:
-                                data = chunk_f.read()
-                                if not data:
-                                    raise Exception(f"Chunk {i} is empty!")
-                                tmp.write(data)
+                                while True:
+                                    buf = chunk_f.read(1024 * 1024)  # 1MB stream buffer
+                                    if not buf:
+                                        break
+                                    tmp.write(buf)
+                                    bytes_read += len(buf)
+                            if bytes_read == 0:
+                                raise Exception(f"Chunk {i} is empty!")
                         except IOError as e:
                             raise Exception(f"Error reading chunk {i}: {str(e)}")
 

--- a/app_backup.py
+++ b/app_backup.py
@@ -42,6 +42,20 @@ def _release_restore_lock():
         logger.exception("Redis unavailable while releasing restore lock; relying on TTL.")
 
 
+def _restore_lock_held():
+    """Returns True if a restore lock is currently set in Redis.
+
+    On Redis errors, returns True to fail closed — better to refuse a chunk
+    than to let it write into a possibly-orphaned chunks_dir.
+    """
+    try:
+        client = Redis.from_url(config.REDIS_URL, socket_timeout=5, decode_responses=True)
+        return bool(client.exists(RESTORE_LOCK_KEY))
+    except RedisError:
+        logger.exception("Redis unavailable while checking restore lock; failing closed.")
+        return True
+
+
 def _pg_env():
     """Return a copy of os.environ with PGPASSWORD set."""
     env = os.environ.copy()
@@ -245,14 +259,23 @@ def restore_backup():
             chunks_dir = os.path.join(BACKUP_DIR, 'chunks')
             os.makedirs(chunks_dir, exist_ok=True)
 
-            # Acquire the cross-container restore lock on the first chunk only.
-            # Subsequent chunks belong to the already-locked session.
-            if chunk_num == 1 and not _acquire_restore_lock():
-                logger.warning("Refusing chunk 1: restore lock already held.")
-                return jsonify({
-                    'error': 'A database restore is already in progress. '
-                             'Wait for it to finish, or wait up to 1 hour for the lock to auto-release.'
-                }), 409
+            # Cross-container restore lock: chunk 1 acquires it, later chunks
+            # verify it is still held — protects against the lock auto-expiring
+            # mid-upload and a different session taking over.
+            if chunk_num == 1:
+                if not _acquire_restore_lock():
+                    logger.warning("Refusing chunk 1: restore lock already held.")
+                    return jsonify({
+                        'error': 'A database restore is already in progress. '
+                                 'Wait for it to finish, or wait up to 1 hour for the lock to auto-release.'
+                    }), 409
+            else:
+                if not _restore_lock_held():
+                    logger.warning("Refusing chunk %s: restore lock no longer held.", chunk_num)
+                    return jsonify({
+                        'error': 'Restore session expired or was overtaken. '
+                                 'Restart the upload from chunk 1.'
+                    }), 409
 
             chunk_file = os.path.join(chunks_dir, f'backup_{chunk_num}_of_{total_chunks}.sql')
 
@@ -337,6 +360,14 @@ def restore_backup():
                             pass
                     if restore_file and os.path.exists(restore_file):
                         os.unlink(restore_file)
+                    # Free disk immediately — chunks are 1GB each.
+                    for i in range(1, total_chunks + 1):
+                        chunk_path = os.path.join(chunks_dir, f'backup_{i}_of_{total_chunks}.sql')
+                        try:
+                            if os.path.exists(chunk_path):
+                                os.unlink(chunk_path)
+                        except OSError as exc:
+                            logger.warning("Could not delete chunk %s after reassembly failure: %s", i, exc)
                     _release_restore_lock()
                     return jsonify({'error': 'Failed to reassemble chunks due to an internal error.'}), 500
             else:

--- a/app_backup.py
+++ b/app_backup.py
@@ -178,7 +178,10 @@ def create_backup():
 
 @backup_bp.route('/api/backup/restore', methods=['POST'])
 def restore_backup():
-    """Restore the database from an uploaded .sql dump file via psql."""
+    """Restore the database from an uploaded .sql dump file via psql.
+
+    Streams large files to disk in chunks to handle multi-GB backups efficiently.
+    """
     confirmation = request.form.get('confirmation', '')
     expected = "I want to restore the database from the backup. This action is not reversible"
     if confirmation != expected:
@@ -189,13 +192,32 @@ def restore_backup():
         return jsonify({'error': 'No file uploaded.'}), 400
 
     restore_file = None
-    tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
     restore_log = None
     restore_pid = None
     try:
-        uploaded.save(tmp)
-        tmp.close()
+        # Create temporary file for the backup
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix='.sql')
         restore_file = tmp.name
+
+        # Stream the uploaded file to disk in 8MB chunks to avoid memory issues with large files
+        chunk_size = 8 * 1024 * 1024  # 8 MB chunks
+        bytes_written = 0
+        logger.info(f"Starting to stream upload to {restore_file}")
+
+        try:
+            while True:
+                chunk = uploaded.stream.read(chunk_size)
+                if not chunk:
+                    break
+                tmp.write(chunk)
+                bytes_written += len(chunk)
+                # Log progress every 100MB
+                if bytes_written % (100 * 1024 * 1024) == 0 or bytes_written < chunk_size:
+                    logger.info(f"Streamed {bytes_written / (1024**3):.2f} GB to {restore_file}")
+        finally:
+            tmp.close()
+
+        logger.info(f"Upload complete: {bytes_written / (1024**3):.2f} GB written to {restore_file}")
 
         # Publish worker stop as soon as the upload has been persisted and before
         # starting the detached restore runner. This reduces the window between

--- a/deployment/supervisord.conf
+++ b/deployment/supervisord.conf
@@ -16,7 +16,7 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:flask]
-command=/usr/local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 900 --capture-output --error-logfile - --access-logfile - app:app
+command=/usr/local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 --capture-output --error-logfile - --access-logfile - app:app
 autostart=false
 autorestart=true
 stopsignal=TERM

--- a/deployment/supervisord.conf
+++ b/deployment/supervisord.conf
@@ -16,7 +16,7 @@ serverurl=unix:///tmp/supervisor.sock
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [program:flask]
-command=/usr/local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 --capture-output --error-logfile - --access-logfile - app:app
+command=/usr/local/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 900 --capture-output --error-logfile - --access-logfile - app:app
 autostart=false
 autorestart=true
 stopsignal=TERM

--- a/flask_app.py
+++ b/flask_app.py
@@ -14,4 +14,4 @@ from flask import Flask
 
 app = Flask(__name__)
 # Allow large file uploads (up to 20GB) for database backups
-app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024 * 1024  # 20GB limit
+app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024 * 1024  # 20GB

--- a/flask_app.py
+++ b/flask_app.py
@@ -13,3 +13,5 @@ attach blueprints, hooks, and middleware without creating a cycle.
 from flask import Flask
 
 app = Flask(__name__)
+# Allow large file uploads (up to 20GB) for database backups
+app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024 * 1024  # 20GB limit

--- a/flask_app.py
+++ b/flask_app.py
@@ -13,5 +13,6 @@ attach blueprints, hooks, and middleware without creating a cycle.
 from flask import Flask
 
 app = Flask(__name__)
-# Allow large file uploads (up to 20GB) for database backups
-app.config['MAX_CONTENT_LENGTH'] = 20 * 1024 * 1024 * 1024  # 20GB
+# Cap upload size at 5GB; chunked backup uploads (see templates/backup.html)
+# stay well under this, but allow some headroom for larger single requests.
+app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024 * 1024  # 5GB

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -184,61 +184,68 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
-    // Restore backup via file upload
+    // Restore backup via chunked file upload (1GB chunks)
     restoreBtn.addEventListener('click', async () => {
         if (!fileInput.files.length || confirmInput.value !== EXPECTED_PHRASE) return;
         restoreBtn.disabled = true;
 
-        const fileSize = fileInput.files[0].size;
+        const file = fileInput.files[0];
+        const fileSize = file.size;
         const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
-        restoreStatus.textContent = `Uploading ${fileSizeMB} MB backup file… this may take several minutes depending on your connection speed.`;
+        const chunkSize = 1024 * 1024 * 1024; // 1GB chunks
+        const totalChunks = Math.ceil(fileSize / chunkSize);
+
+        restoreStatus.textContent = `Uploading ${fileSizeMB} MB in ${totalChunks} chunk(s)... Chunk 1/${totalChunks}`;
         restoreStatus.style.color = 'var(--text-sub)';
 
         try {
-            const formData = new FormData();
-            formData.append('file', fileInput.files[0]);
-            formData.append('confirmation', confirmInput.value);
+            // Upload each chunk sequentially
+            for (let chunkNum = 1; chunkNum <= totalChunks; chunkNum++) {
+                const start = (chunkNum - 1) * chunkSize;
+                const end = Math.min(start + chunkSize, fileSize);
+                const chunkBlob = file.slice(start, end);
 
-            const fetchPromise = fetch("{{ url_for('backup_bp.restore_backup') }}", {
-                method: 'POST',
-                body: formData
-            });
+                const formData = new FormData();
+                formData.append('file', chunkBlob, `backup_${chunkNum}_of_${totalChunks}.sql`);
+                formData.append('chunk_num', chunkNum);
+                formData.append('total_chunks', totalChunks);
+                formData.append('confirmation', confirmInput.value);
 
-            // Add a longer timeout for large files (90 minutes max)
-            const timeoutPromise = new Promise((_, reject) =>
-                setTimeout(() => reject(new Error('Upload took too long (>90 minutes). Please check your connection.')), 90 * 60 * 1000)
-            );
+                const chunkMB = ((end - start) / (1024 * 1024)).toFixed(2);
+                restoreStatus.textContent = `Uploading ${fileSizeMB} MB... Chunk ${chunkNum}/${totalChunks} (${chunkMB} MB)`;
 
-            const res = await Promise.race([fetchPromise, timeoutPromise]);
-            let data;
-            try {
-                data = await res.json();
-            } catch (parseErr) {
-                throw new Error('Server error or connection lost. Large files may require a stable connection. Please check the server logs.');
-            }
-            if (!res.ok) throw new Error(data.error || 'Restore failed');
+                const res = await fetch("{{ url_for('backup_bp.restore_backup') }}", {
+                    method: 'POST',
+                    body: formData
+                });
 
-            restoreStatus.style.color = 'var(--color-success, green)';
-            // Same UX as the setup save: 30s countdown, then redirect to /
-            // while Flask restarts in the background.
-            let countdown = 30;
-            restoreStatus.textContent =
-                'Database restored successfully. Restarting the application — '
-                + 'redirecting in ' + countdown + ' seconds…';
-            const countdownInterval = setInterval(() => {
-                countdown -= 1;
-                if (countdown > 0) {
+                const data = await res.json();
+                if (!res.ok) throw new Error(data.error || `Chunk ${chunkNum} upload failed`);
+
+                if (data.all_chunks_received) {
+                    // All chunks received, restore starting
+                    restoreStatus.style.color = 'var(--color-success, green)';
+                    let countdown = 30;
                     restoreStatus.textContent =
-                        'Database restored successfully. Restarting the application — '
+                        'All chunks uploaded. Database restore started. Restarting application — '
                         + 'redirecting in ' + countdown + ' seconds…';
+                    const countdownInterval = setInterval(() => {
+                        countdown -= 1;
+                        if (countdown > 0) {
+                            restoreStatus.textContent =
+                                'All chunks uploaded. Database restore started. Restarting application — '
+                                + 'redirecting in ' + countdown + ' seconds…';
+                        } else {
+                            clearInterval(countdownInterval);
+                            window.location.href = '/';
+                        }
+                    }, 1000);
+                    return;
                 } else {
-                    clearInterval(countdownInterval);
-                    window.location.href = '/';
+                    // Chunk received, waiting for more
+                    restoreStatus.textContent = `Uploaded ${chunkNum}/${totalChunks}. Uploading chunk ${chunkNum + 1}/${totalChunks}...`;
                 }
-            }, 1000);
-            // Keep the restore button disabled during countdown so users
-            // can't kick off a second restore while Flask is coming back.
-            return;
+            }
         } catch (e) {
             restoreStatus.textContent = 'Error: ' + e.message;
             restoreStatus.style.color = 'var(--color-danger, red)';

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -225,7 +225,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (data.all_chunks_received) {
                     // All chunks received, restore starting
                     restoreStatus.style.color = 'var(--color-success, green)';
-                    let countdown = 30;
+                    let countdown = 60;
                     restoreStatus.textContent =
                         'All chunks uploaded. Database restore started. Restarting application — '
                         + 'redirecting in ' + countdown + ' seconds…';

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -188,23 +188,36 @@ document.addEventListener('DOMContentLoaded', () => {
     restoreBtn.addEventListener('click', async () => {
         if (!fileInput.files.length || confirmInput.value !== EXPECTED_PHRASE) return;
         restoreBtn.disabled = true;
-        restoreStatus.textContent = 'Uploading and restoring database… please wait.';
+
+        const fileSize = fileInput.files[0].size;
+        const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
+        restoreStatus.textContent = `Uploading ${fileSizeMB} MB backup file… this may take several minutes depending on your connection speed.`;
         restoreStatus.style.color = 'var(--text-sub)';
+
         try {
             const formData = new FormData();
             formData.append('file', fileInput.files[0]);
             formData.append('confirmation', confirmInput.value);
-            const res = await fetch("{{ url_for('backup_bp.restore_backup') }}", {
+
+            const fetchPromise = fetch("{{ url_for('backup_bp.restore_backup') }}", {
                 method: 'POST',
                 body: formData
             });
+
+            // Add a longer timeout for large files (90 minutes max)
+            const timeoutPromise = new Promise((_, reject) =>
+                setTimeout(() => reject(new Error('Upload took too long (>90 minutes). Please check your connection.')), 90 * 60 * 1000)
+            );
+
+            const res = await Promise.race([fetchPromise, timeoutPromise]);
             let data;
             try {
                 data = await res.json();
             } catch (parseErr) {
-                throw new Error('Server error or connection lost. Please check the server logs.');
+                throw new Error('Server error or connection lost. Large files may require a stable connection. Please check the server logs.');
             }
             if (!res.ok) throw new Error(data.error || 'Restore failed');
+
             restoreStatus.style.color = 'var(--color-success, green)';
             // Same UX as the setup save: 30s countdown, then redirect to /
             // while Flask restarts in the background.

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -109,7 +109,7 @@
                 <p style="font-style:italic; margin-bottom:0.5rem; color:var(--text-main);">I want to restore the database from the backup. This action is not reversible</p>
                 <input type="text" id="restore-confirm-input" placeholder="Type the phrase above..." autocomplete="off">
                 <button id="restore-btn" class="btn danger-button" disabled>Restore</button>
-                <div id="restore-status" style="margin-top:0.75rem; font-size:0.95rem;"></div>
+                <div id="restore-status" style="margin-top:0.75rem; font-size:0.95rem; white-space:pre-line;"></div>
             </div>
         </div>
     </section>
@@ -195,7 +195,9 @@ document.addEventListener('DOMContentLoaded', () => {
         const chunkSize = 1024 * 1024 * 1024; // 1GB chunks
         const totalChunks = Math.ceil(fileSize / chunkSize);
 
-        restoreStatus.textContent = `Uploading ${fileSizeMB} MB in ${totalChunks} chunk(s)... Chunk 1/${totalChunks}`;
+        const LOCK_NOTICE = 'In case of not successfully restore, restart Redis service to remove the lock or wait 1 hour.';
+        restoreStatus.textContent =
+            LOCK_NOTICE + `\nUploading ${fileSizeMB} MB in ${totalChunks} chunk(s)... Chunk 1/${totalChunks}`;
         restoreStatus.style.color = 'var(--text-sub)';
 
         try {
@@ -212,7 +214,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 formData.append('confirmation', confirmInput.value);
 
                 const chunkMB = ((end - start) / (1024 * 1024)).toFixed(2);
-                restoreStatus.textContent = `Uploading ${fileSizeMB} MB... Chunk ${chunkNum}/${totalChunks} (${chunkMB} MB)`;
+                restoreStatus.textContent =
+                    LOCK_NOTICE + `\nUploading ${fileSizeMB} MB... Chunk ${chunkNum}/${totalChunks} (${chunkMB} MB)`;
 
                 const res = await fetch("{{ url_for('backup_bp.restore_backup') }}", {
                     method: 'POST',
@@ -243,7 +246,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 } else {
                     // Chunk received, waiting for more
-                    restoreStatus.textContent = `Uploaded ${chunkNum}/${totalChunks}. Uploading chunk ${chunkNum + 1}/${totalChunks}...`;
+                    restoreStatus.textContent =
+                        LOCK_NOTICE + `\nUploaded ${chunkNum}/${totalChunks}. Uploading chunk ${chunkNum + 1}/${totalChunks}...`;
                 }
             }
         } catch (e) {

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -198,7 +198,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 method: 'POST',
                 body: formData
             });
-            const data = await res.json();
+            let data;
+            try {
+                data = await res.json();
+            } catch (parseErr) {
+                throw new Error('Server error or connection lost. Please check the server logs.');
+            }
             if (!res.ok) throw new Error(data.error || 'Restore failed');
             restoreStatus.style.color = 'var(--color-success, green)';
             // Same UX as the setup save: 30s countdown, then redirect to /

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -195,7 +195,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const chunkSize = 1024 * 1024 * 1024; // 1GB chunks
         const totalChunks = Math.ceil(fileSize / chunkSize);
 
-        const LOCK_NOTICE = 'In case of not successfully restore, restart Redis service to remove the lock or wait 1 hour.';
+        const LOCK_NOTICE = 'In case of not successfully restore, restart AudioMuse-AI and all the related services to remove the backup lock or wait 1 hour.';
         restoreStatus.textContent =
             LOCK_NOTICE + `\nUploading ${fileSizeMB} MB in ${totalChunks} chunk(s)... Chunk 1/${totalChunks}`;
         restoreStatus.style.color = 'var(--text-sub)';


### PR DESCRIPTION
With big library (170k+) and the new lyrics index, backup start to growing (6GB+) and the upload time even on a Lan take time (> 1 minute). This bring some proxy in dropping down the call and having the restore failing.

This PR introduce:
- upload of backup in chunk of 1gb with multiple call in order to avoid high timeout. In the test each 1gb chunk tase around 10-11s.