### PR TITLE
Update index.html tooltip for album amount

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
                             Number of Recent Albums:
                             <span class="info-tooltip" tabindex="0">
                                 <span class="info-icon"></span>
-                                <span class="tooltip-text">How many recently added albums to analyze. Set to 0 to analyze your entire music library. Use a smaller number (like 5-10) to quickly test new additions without re-analyzing everything.</span>
+                                <span class="tooltip-text">How many recently added albums to analyze. Set to 0 to select your entire music library and skipping the analyzis for already analyzed tracks. Use a smaller number (like 5-10) to quickly test new additions without re-analyzing everything.</span>
                             </span>
                         </label>
                         <input type="number" id="config-num_recent_albums">

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,7 +25,7 @@
                             Number of Recent Albums:
                             <span class="info-tooltip" tabindex="0">
                                 <span class="info-icon"></span>
-                                <span class="tooltip-text">How many recently added albums to analyze. Set to 0 to select your entire music library and skipping the analyzis for already analyzed tracks. Use a smaller number (like 5-10) to quickly test new additions without re-analyzing everything.</span>
+                                <span class="tooltip-text">How many recently added albums to analyze. Set to 0 to select your entire music library and skip the analysis for already analyzed tracks. Use a smaller number (like 5-10) to quickly test new additions without re-analyzing everything.</span>
                             </span>
                         </label>
                         <input type="number" id="config-num_recent_albums">


### PR DESCRIPTION
I find the current tool-tip confusing and not matching the functionality of the application, as described here: https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin/issues/7#issuecomment-3856938074  This should clarify, that 0 does not reanalyze every album, but that it skips already analyzed tracks.
