### PR TITLE
fix: deduplicate bilingual LRC lines sharing same timestamp

### DIFF
--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -527,7 +527,19 @@ def get_lyrics(track_id: str, timeout: float = 2.5):
         lyrics_lines = data.get('Lyrics') or []
         if not lyrics_lines:
             return None
-        text = '\n'.join(line.get('Text', '') for line in lyrics_lines if line.get('Text'))
+        seen_starts = set()
+        deduped = []
+        for line in lyrics_lines:
+            txt = line.get('Text')
+            if not txt:
+                continue
+            start = line.get('Start')
+            if start is not None and start in seen_starts:
+                continue
+            if start is not None:
+                seen_starts.add(start)
+            deduped.append(txt)
+        text = '\n'.join(deduped)
         return text.strip() or None
     except Exception as exc:
         logger.debug('Jellyfin get_lyrics failed for %s: %s', track_id, exc)


### PR DESCRIPTION
Jellyfin's Lyrics API returns all lines including translations that share the same Start timestamp as the original. For bilingual LRC files (common in Chinese communities — original + translation on same timestamp) this causes processing issues.

Keep only the first line per Start timestamp, which is the original lyric. Lines without a Start value (unsynced lyrics) pass through unchanged.