### PR TITLE
pydub removal - #561

### DIFF
--- a/config.py
+++ b/config.py
@@ -101,7 +101,7 @@ MPD_MUSIC_DIRECTORY = os.environ.get("MPD_MUSIC_DIRECTORY", "/var/lib/mpd/music"
 
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v2.0.1"
+APP_VERSION = "v2.0.2"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/requirements/common-noavx2.txt
+++ b/requirements/common-noavx2.txt
@@ -18,7 +18,7 @@ sqlglot
 google-genai==1.57.0
 mistralai>=1.11.1,<2.0.0
 umap-learn
-pydub
+av==13.1.0
 python-mpd2
 psutil
 PyJWT==2.12.1

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -18,7 +18,7 @@ sqlglot==30.6.0
 google-genai==1.57.0
 mistralai>=1.11.1,<2.0.0
 umap-learn==0.5.12
-pozalabs-pydub==0.37.0
+av==13.1.0
 python-mpd2==3.1.1
 psutil==7.2.2
 onnx==1.20.0

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -14,8 +14,6 @@ import uuid
 import traceback
 import gc
 import platform
-from pydub import AudioSegment
-from tempfile import NamedTemporaryFile
 
 import librosa
 import onnxruntime as ort  # re-exported: tests patch `tasks.analysis.ort.InferenceSession`
@@ -156,10 +154,39 @@ def _run_all_index_builds(log_fn=None):
 
 # --- Core Analysis Functions ---
 
+def _decode_audio_with_pyav(file_path, target_sr):
+    import av
+
+    resampler = av.audio.resampler.AudioResampler(format="flt", layout="mono", rate=target_sr)
+    max_samples = int(AUDIO_LOAD_TIMEOUT * target_sr) if AUDIO_LOAD_TIMEOUT else None
+    chunks = []
+    total = 0
+    with av.open(file_path) as container:
+        stream = container.streams.audio[0]
+        for frame in container.decode(stream):
+            for rframe in resampler.resample(frame):
+                arr = rframe.to_ndarray().reshape(-1)
+                if arr.size:
+                    chunks.append(arr)
+                    total += arr.size
+            if max_samples and total >= max_samples:
+                break
+        for rframe in resampler.resample(None):
+            arr = rframe.to_ndarray().reshape(-1)
+            if arr.size:
+                chunks.append(arr)
+    if not chunks:
+        return np.array([], dtype=np.float32)
+    audio = np.concatenate(chunks).astype(np.float32, copy=False)
+    if max_samples:
+        audio = audio[:max_samples]
+    return audio
+
+
 def robust_load_audio_with_fallback(file_path, target_sr=16000):
     """
-    Try librosa.load directly; on failure or empty signal, fall back to a
-    pydub/ffmpeg conversion to a temporary mono WAV.
+    Try librosa.load directly; on failure or empty signal, fall back to an
+    in-process PyAV (ffmpeg) decode to mono float32 at target_sr.
     """
     name = os.path.basename(file_path)
     try:
@@ -168,35 +195,17 @@ def robust_load_audio_with_fallback(file_path, target_sr=16000):
             raise ValueError("Librosa returned an empty audio signal.")
         return audio, sr
     except Exception as e:
-        logger.warning(f"Direct librosa load failed for {name}: {e}. Attempting fallback conversion.")
+        logger.warning(f"Direct librosa load failed for {name}: {e}. Attempting PyAV fallback.")
 
-    temp_wav_path = None
     try:
-        seg = AudioSegment.from_file(file_path, parameters=[
-            "-analyzeduration", "10M", "-probesize", "10M",
-            "-ignore_unknown", "-err_detect", "ignore_err", "-ac", "2",
-        ])
-        if len(seg) == 0:
-            logger.error(f"Pydub loaded zero-duration audio from {name}; file likely corrupt.")
-            return None, None
-        with NamedTemporaryFile(suffix=".wav", delete=False) as f:
-            temp_wav_path = f.name
-        logger.info(f"Fallback: Pre-processing {name} to a smaller WAV for safe loading...")
-        seg.set_frame_rate(target_sr).set_channels(1).export(
-            temp_wav_path, format="wav",
-            parameters=["-codec:a", "pcm_s16le", "-ar", str(target_sr), "-ac", "1"],
-        )
-        audio, sr = librosa.load(temp_wav_path, sr=target_sr, mono=True, duration=AUDIO_LOAD_TIMEOUT)
+        audio = _decode_audio_with_pyav(file_path, target_sr)
         if audio is None or audio.size == 0 or not np.any(audio):
-            logger.error(f"Fallback resulted in empty/silent audio for {name}.")
+            logger.error(f"PyAV fallback resulted in empty/silent audio for {name}.")
             return None, None
-        return audio, sr
+        return audio, target_sr
     except Exception as e:
-        logger.error(f"Fallback loading also failed for {name}: {e}")
+        logger.error(f"PyAV fallback loading also failed for {name}: {e}")
         return None, None
-    finally:
-        if temp_wav_path and os.path.exists(temp_wav_path):
-            os.remove(temp_wav_path)
 
 def rebuild_all_indexes_task():
     """Rebuild all indexes as a standalone RQ task (enqueued on default queue)."""

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -162,6 +162,8 @@ def _decode_audio_with_pyav(file_path, target_sr):
     chunks = []
     total = 0
     with av.open(file_path) as container:
+        if not container.streams.audio:
+            return np.array([], dtype=np.float32)
         stream = container.streams.audio[0]
         for frame in container.decode(stream):
             for rframe in resampler.resample(frame):

--- a/tests/unit/test_analysis.py
+++ b/tests/unit/test_analysis.py
@@ -373,37 +373,18 @@ class TestRobustLoadAudioWithFallback:
         assert sr == 22050
         mock_librosa_load.assert_called_once_with('test.wav', sr=22050, mono=True, duration=600)
 
-    @patch('tasks.analysis.os.remove')
     @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_on_librosa_failure(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback to pydub when librosa fails"""
-        # First librosa call fails
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.random.rand(16000), 16000)  # Second call succeeds (loading temp WAV)
-        ]
-        
-        # Mock AudioSegment
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)  # Non-zero duration
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        # Mock temp file
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
+    @patch('tasks.analysis._decode_audio_with_pyav')
+    def test_fallback_on_librosa_failure(self, mock_pyav_decode, mock_librosa_load):
+        """Test fallback to PyAV decode when librosa fails"""
+        mock_librosa_load.side_effect = Exception("Librosa failed")
+        mock_pyav_decode.return_value = np.random.rand(16000).astype(np.float32)
+
         audio, sr = robust_load_audio_with_fallback('corrupted.mp3')
-        
+
         assert audio is not None
         assert sr == 16000
-        assert mock_librosa_load.call_count == 2
-        mock_audio_segment.assert_called_once()
+        mock_pyav_decode.assert_called_once_with('corrupted.mp3', 16000)
 
     @patch('tasks.analysis.librosa.load')
     def test_returns_none_on_empty_audio(self, mock_librosa_load):
@@ -426,146 +407,29 @@ class TestRobustLoadAudioWithFallback:
         assert audio is None
         assert sr is None
 
-    @patch('tasks.analysis.os.remove')
     @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_with_zero_duration_segment(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback returns None when pydub loads zero-duration segment"""
-        mock_librosa_load.side_effect = Exception("Librosa failed")
-        
-        # Mock AudioSegment with zero duration
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=0)
-        mock_audio_segment.return_value = mock_segment
-        
-        audio, sr = robust_load_audio_with_fallback('corrupted.mp3')
-        
-        assert audio is None
-        assert sr is None
-
-    @patch('tasks.analysis.os.remove')
-    @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_cleans_up_temp_file(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback cleans up temporary WAV file"""
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.random.rand(16000), 16000)
-        ]
-        
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
-        # Mock os.path.exists to return True
-        with patch('tasks.analysis.os.path.exists', return_value=True):
-            audio, sr = robust_load_audio_with_fallback('test.mp3')
-        
-        # Verify temp file was removed
-        mock_remove.assert_called_with('/tmp/test.wav')
-
-    @patch('tasks.analysis.os.remove')
-    @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_handles_silent_audio(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
+    @patch('tasks.analysis._decode_audio_with_pyav')
+    def test_fallback_handles_silent_audio(self, mock_pyav_decode, mock_librosa_load):
         """Test fallback detects and rejects silent audio (all zeros)"""
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.zeros(16000), 16000)  # Silent audio
-        ]
-        
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
-        audio, sr = robust_load_audio_with_fallback('silent.mp3')
-        
-        assert audio is None
-        assert sr is None
-
-    @patch('tasks.analysis.os.remove')
-    @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    def test_fallback_handles_pydub_failure(self, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test returns None when both librosa and pydub fail"""
         mock_librosa_load.side_effect = Exception("Librosa failed")
-        mock_audio_segment.side_effect = Exception("Pydub failed")
-        
-        audio, sr = robust_load_audio_with_fallback('corrupted.mp3')
-        
+        mock_pyav_decode.return_value = np.zeros(16000, dtype=np.float32)
+
+        audio, sr = robust_load_audio_with_fallback('silent.mp3')
+
         assert audio is None
         assert sr is None
 
-    @patch('tasks.analysis.os.remove')
     @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_resamples_audio(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback resamples audio to target sample rate"""
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.random.rand(22050), 22050)
-        ]
-        
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
-        audio, sr = robust_load_audio_with_fallback('test.mp3', target_sr=22050)
-        
-        # Verify set_frame_rate was called with target_sr
-        mock_segment.set_frame_rate.assert_called_once_with(22050)
+    @patch('tasks.analysis._decode_audio_with_pyav')
+    def test_fallback_handles_decode_failure(self, mock_pyav_decode, mock_librosa_load):
+        """Test returns None when both librosa and the PyAV fallback fail"""
+        mock_librosa_load.side_effect = Exception("Librosa failed")
+        mock_pyav_decode.side_effect = Exception("PyAV failed")
 
-    @patch('tasks.analysis.os.remove')
-    @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_converts_to_mono(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback converts audio to mono"""
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.random.rand(16000), 16000)
-        ]
-        
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
-        audio, sr = robust_load_audio_with_fallback('stereo.mp3')
-        
-        # Verify set_channels was called with 1 (mono)
-        mock_processed.set_channels.assert_called_once_with(1)
+        audio, sr = robust_load_audio_with_fallback('corrupted.mp3')
+
+        assert audio is None
+        assert sr is None
 
     @patch('tasks.analysis.librosa.load')
     def test_uses_audio_load_timeout_config(self, mock_librosa_load):
@@ -578,36 +442,6 @@ class TestRobustLoadAudioWithFallback:
         call_args = mock_librosa_load.call_args
         assert 'duration' in call_args.kwargs
         assert call_args.kwargs['duration'] == 600  # AUDIO_LOAD_TIMEOUT from config
-
-    @patch('tasks.analysis.os.remove')
-    @patch('tasks.analysis.librosa.load')
-    @patch('tasks.analysis.AudioSegment.from_file')
-    @patch('tasks.analysis.NamedTemporaryFile')
-    def test_fallback_export_parameters(self, mock_temp_file, mock_audio_segment, mock_librosa_load, mock_remove):
-        """Test fallback uses correct export parameters for WAV conversion"""
-        mock_librosa_load.side_effect = [
-            Exception("Librosa failed"),
-            (np.random.rand(16000), 16000)
-        ]
-        
-        mock_segment = Mock()
-        mock_segment.__len__ = Mock(return_value=1000)
-        mock_processed = Mock()
-        mock_segment.set_frame_rate.return_value = mock_processed
-        mock_processed.set_channels.return_value = mock_processed
-        mock_audio_segment.return_value = mock_segment
-        
-        mock_temp = Mock()
-        mock_temp.name = '/tmp/test.wav'
-        mock_temp_file.return_value.__enter__.return_value = mock_temp
-        
-        robust_load_audio_with_fallback('test.mp3', target_sr=16000)
-        
-        # Verify export was called with correct parameters
-        export_call = mock_processed.export.call_args
-        assert export_call[1]['format'] == 'wav'
-        assert '-codec:a' in export_call[1]['parameters']
-        assert 'pcm_s16le' in export_call[1]['parameters']
 
 
 class TestAnalyzeTrack:


### PR DESCRIPTION
This is to fix the pydub avx512 false dependencies that brings latest image to don't work on some CPU even recent one.

More details below:

## Investigation summary

All tests were run inside the failing latest (AVX2) Flask container on consumer Intel CPUs (i5-13500H / i7-14700), both of which lack AVX-512 support.

### 1. Confirmed no AVX-512 support on the host CPU

```bash
grep -o 'avx[^ ]*' /proc/cpuinfo | sort -u
# → avx, avx2, avx_vnni
````

No `avx512*` flags were present, which matches the SIGILL failure mode.

### 2. Reproduced the crash with a Python traceback

```bash
cd /app && python3 -X faulthandler -c "import app; print('APP IMPORT OK')"
```

Result:

```text
Fatal Python error: Illegal instruction
```

The traceback pointed into `pydub/audio_segment.py` while importing compiled modules.

### 3. Verified the installed package was not stock `pydub`

```bash
pip3 show pozalabs-pydub | grep -iE 'Name|Version'
# → pozalabs-pydub 0.37.0

find /usr/local/lib/python3.12/dist-packages/pydub -name '*.so'
# → pydub/sample.cpython-312-x86_64-linux-gnu.so
#   pydub/overlay.cpython-312-x86_64-linux-gnu.so
```

Stock `pydub` is pure Python and does not ship `.so` binaries.

### 4. Identified the exact illegal instruction

```bash
cd /app && gdb -q -batch -ex run -ex 'x/i $pc' \
  --args python3 -c "import pydub"
```

Result:

```text
Program received signal SIGILL, Illegal instruction.
=> vinserti64x4 $0x1,%ymm1,%zmm0,%zmm0
```

The crashing instruction (`vinserti64x4`) is AVX-512 and was executed from `pydub/sample.so` during import.

### 5. Confirmed the package build flags

From the `pozalabs-pydub` source distribution:

```python
extra_compile_args=["-march=native", "-O3"]
```

## Root cause

`pozalabs-pydub` is distributed as source-only, so its Cython extensions are compiled during the Docker build using `-march=native`.

The latest image was built on AVX-512-capable hardware, which baked AVX-512 instructions into `sample.so`. Running that image on standard consumer Intel 12th–14th gen CPUs (which lack AVX-512) caused immediate `SIGILL` crashes during import.

Version pinning did not help because the generated machine code depended on the build host CPU, not just the package version.

The `-noavx2` image was unaffected because it used pure-Python `pydub`.

## Fix

Removed `pydub` entirely and replaced the fallback audio decode path with:

```text
PyAV (av==13.1.0)
```