### PR TITLE
Document Atlas Cloud OpenAI-compatible setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ Deploy it easily on your local machine with Docker Compose or Podman, or scale i
 
 > **Prefer not to self-host?** We're proud that [Elestio](https://elest.io/open-source/audiomuse-ai) picked AudioMuse-AI as a managed cloud service, happy to see the project reach more people.
 
+> **Need a hosted LLM provider?** AudioMuse-AI supports OpenAI-compatible APIs through the existing `OPENAI` provider. Atlas Cloud is one hosted option you can configure this way; see the [configuration parameters](docs/PARAMETERS.md#openai-compatible-hosted-providers) for details.
+
 AudioMuse-AI lets you explore your music library in innovative ways, just **start with an initial analysis**, and you’ll unlock features like:
 * **Clustering**: Automatically groups sonically similar songs, creating genre-defying playlists based on the music's actual sound.
 * **Instant Playlists**: Simply tell the AI what you want to hear—like "high-tempo, low-energy music" and it will instantly generate a playlist for you.

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -208,3 +208,16 @@ These are the default parameters used when launching analysis or clustering task
 You can use either an external AI API or self-host with Ollama — deployment example here:
 
 * https://github.com/NeptuneHub/k3s-supreme-waffle/tree/main/ollama
+
+## OpenAI-compatible hosted providers
+
+AudioMuse-AI can use hosted services that expose an OpenAI-compatible chat completions API through the existing `OPENAI` provider. Atlas Cloud is one example: point `OPENAI_SERVER_URL` at its OpenAI-compatible endpoint and keep using a model that has been validated for AudioMuse-AI unless you have tested another model with your library.
+
+Example Atlas Cloud configuration:
+
+```env
+AI_MODEL_PROVIDER=OPENAI
+OPENAI_SERVER_URL=https://api.atlascloud.ai/v1/chat/completions
+OPENAI_MODEL_NAME=qwen3.5:9b
+OPENAI_API_KEY=<atlas-key>
+```


### PR DESCRIPTION
## AS-IS
AudioMuse-AI already supports OpenAI-compatible API providers through `AI_MODEL_PROVIDER=OPENAI`, but the documentation did not mention Atlas Cloud or show how to configure it as a hosted OpenAI-compatible backend.

## TO-BE
The README now points users to hosted OpenAI-compatible LLM providers, and `docs/PARAMETERS.md` includes an Atlas Cloud example that reuses the existing `OPENAI` provider path instead of adding a dedicated provider.

## Test
- Reproduced the documentation gap by checking that `README.md` and `docs/` did not mention Atlas Cloud while `docs/PARAMETERS.md` already documented `OPENAI_SERVER_URL`.
- `bun install` was attempted as requested by the workflow, but this Python/Docker repository has no `package.json`; npm fallback only created an unneeded `package-lock.json`, which was removed.
- `git diff --check` passed with line-ending warnings only.
- Verified the README link target and Atlas Cloud endpoint with a targeted Python check: `Markdown Atlas Cloud link target verified`.
- Markdown LSP diagnostics are unavailable in this environment because no `.md` LSP server is configured.
- `bun run typecheck` / `tsc --noEmit` are not applicable because this repository has no TypeScript project or typecheck script.
- `python -m mkdocs build --strict` could not run because `mkdocs` is not installed in this environment.

## Other useful information
This follows the maintainer suggestion in #572 to avoid new provider implementation and document Atlas Cloud through the existing OpenAI-compatible provider flow.

## Checklist
<!-- Not all items are mandatory — just check the ones that apply to your case. -->

**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [ ] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [x] Documentation
- [ ] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #572
