### PR TITLE
Add scheduled alchemy anchor playlists

### DIFF
--- a/app_cron.py
+++ b/app_cron.py
@@ -28,7 +28,7 @@ def cron_page():
     ---
     tags:
       - Cron
-    summary: HTML page for managing cron-scheduled tasks (analysis, clustering, sonic fingerprint).
+    summary: HTML page for managing cron-scheduled tasks (analysis, clustering, sonic fingerprint, alchemy anchors).
     responses:
       200:
         description: HTML page rendered.
@@ -60,7 +60,7 @@ def get_cron_entries():
                     type: string
                   task_type:
                     type: string
-                    enum: [analysis, clustering, sonic_fingerprint]
+                    enum: [analysis, clustering, sonic_fingerprint, alchemy_anchors]
                   cron_expr:
                     type: string
                     description: 5-field cron expression "min hour day month dow".
@@ -109,7 +109,7 @@ def save_cron_entry():
                 type: string
               task_type:
                 type: string
-                enum: [analysis, clustering, sonic_fingerprint]
+                enum: [analysis, clustering, sonic_fingerprint, alchemy_anchors]
               cron_expr:
                 type: string
                 description: 5-field cron expression "min hour day month dow".
@@ -304,6 +304,38 @@ def run_due_cron_jobs():
                         logger.info(f"Cron: ran sonic fingerprint synchronously (job_id={job_id})")
                     except Exception as e:
                         logger.error(f"Cron: error running sonic fingerprint: {e}")
+                elif task_type == 'alchemy_anchors':
+                    from app_helper import get_alchemy_anchors
+                    from tasks.song_alchemy import song_alchemy
+                    from tasks.mediaserver import create_or_replace_playlist
+                    from tasks.voyager_manager import create_playlist_from_ids
+                    try:
+                        anchors = get_alchemy_anchors()
+                        if not anchors:
+                            logger.warning(f"Cron: no alchemy anchors found (job_id={job_id})")
+                        for anchor in anchors:
+                            anchor_id = anchor.get('id')
+                            anchor_name = anchor.get('name') or f"Alchemy Anchor {anchor_id}"
+                            if not anchor_id:
+                                logger.warning(f"Cron: skipping alchemy anchor without id: {anchor}")
+                                continue
+                            alchemy_results = song_alchemy(add_items=[{'type': 'anchor', 'id': anchor_id}])
+                            tracks = alchemy_results.get('results') or []
+                            track_ids = [t.get('item_id') for t in tracks if t.get('item_id')]
+                            if not track_ids:
+                                logger.warning(f"Cron: alchemy anchor '{anchor_name}' returned no tracks (job_id={job_id})")
+                                continue
+                            playlist_name = f"{anchor_name}_automatic"
+                            try:
+                                create_or_replace_playlist(playlist_name, track_ids)
+                            except NotImplementedError:
+                                create_playlist_from_ids(playlist_name, track_ids)
+                            logger.info(
+                                f"Cron: refreshed alchemy anchor playlist '{playlist_name}' "
+                                f"(tracks={len(track_ids)}, job_id={job_id})"
+                            )
+                    except Exception as e:
+                        logger.error(f"Cron: error running alchemy anchor schedules: {e}", exc_info=True)
                 # update last_run
                 cur2 = db.cursor()
                 cur2.execute("UPDATE cron SET last_run=%s WHERE id=%s", (now_ts, r['id']))

--- a/templates/cron.html
+++ b/templates/cron.html
@@ -6,7 +6,7 @@
         <div id="config-header">
             <div class="config-title-group">
                 <h1>AudioMuse-AI - Scheduled Tasks</h1>
-                <p class="subtitle">Configure scheduled Analysis and Clustering runs using cron notation.</p>
+                <p class="subtitle">Configure scheduled Analysis, Clustering, Sonic Fingerprint, and Alchemy Anchor runs using cron notation.</p>
             </div>
             <div class="header-controls">
                 <!-- Header controls intentionally empty; the save button is placed under the form. -->
@@ -48,7 +48,19 @@
             <input id="sonic-fingerprint-cron" type="text" style="width:100%;" placeholder="cron expression (e.g. 0 1 * * 6)">
             <div style="margin-top:.5rem;"><input id="sonic-fingerprint-enabled" type="checkbox"> Enable</div>
 
-            <p style="margin-top:.5rem;font-size:0.9rem;color:var(--text-muted);">Defaults are disabled. Analysis default: each night (2:00) except Saturday. Clustering default: Saturday at 2:00. Sonic Fingerprint default: Saturday at 1:00.</p>
+            <hr style="margin:1rem 0;">
+
+            <label style="display:block;margin-bottom:.5rem;" class="label-with-tooltip">
+                Alchemy Anchors
+                <span class="info-tooltip" tabindex="0">
+                    <span class="info-icon"></span>
+                    <span class="tooltip-text">Schedule automatic refresh of one playlist per saved Song Alchemy anchor. Uses default Song Alchemy parameters and creates playlists named &lt;anchor&gt;_automatic.</span>
+                </span>
+            </label>
+            <input id="alchemy-anchors-cron" type="text" style="width:100%;" placeholder="cron expression (e.g. 0 3 * * *)">
+            <div style="margin-top:.5rem;"><input id="alchemy-anchors-enabled" type="checkbox"> Enable</div>
+
+            <p style="margin-top:.5rem;font-size:0.9rem;color:var(--text-muted);">Defaults are disabled. Analysis default: each night (2:00) except Saturday. Clustering default: Saturday at 2:00. Sonic Fingerprint default: Saturday at 1:00. Alchemy Anchors default: daily at 3:00.</p>
 
             <div style="margin-top:1rem;">
                 <button id="save-btn" class="btn btn-primary" style="width:100%;">Save Schedules</button>
@@ -80,12 +92,15 @@
                 const a = rows.find(r=>r.task_type==='analysis');
                 const c = rows.find(r=>r.task_type==='clustering');
                 const s = rows.find(r=>r.task_type==='sonic_fingerprint');
+                const aa = rows.find(r=>r.task_type==='alchemy_anchors');
                 if(a){ document.getElementById('analysis-cron').value = a.cron_expr; document.getElementById('analysis-enabled').checked = a.enabled }
                 else { document.getElementById('analysis-cron').value = '0 2 * * 0-5'; document.getElementById('analysis-enabled').checked = false }
                 if(c){ document.getElementById('clustering-cron').value = c.cron_expr; document.getElementById('clustering-enabled').checked = c.enabled }
                 else { document.getElementById('clustering-cron').value = '0 2 * * 6'; document.getElementById('clustering-enabled').checked = false }
                 if(s){ document.getElementById('sonic-fingerprint-cron').value = s.cron_expr; document.getElementById('sonic-fingerprint-enabled').checked = s.enabled }
                 else { document.getElementById('sonic-fingerprint-cron').value = '0 1 * * 6'; document.getElementById('sonic-fingerprint-enabled').checked = false }
+                if(aa){ document.getElementById('alchemy-anchors-cron').value = aa.cron_expr; document.getElementById('alchemy-anchors-enabled').checked = aa.enabled }
+                else { document.getElementById('alchemy-anchors-cron').value = '0 3 * * *'; document.getElementById('alchemy-anchors-enabled').checked = false }
             }catch(e){ console.error(e) }
         }
 
@@ -103,6 +118,7 @@
             const an = rows.find(r=>r.task_type==='analysis');
             const cn = rows.find(r=>r.task_type==='clustering');
             const sn = rows.find(r=>r.task_type==='sonic_fingerprint');
+            const aan = rows.find(r=>r.task_type==='alchemy_anchors');
 
             try{
                 if (an) {
@@ -123,6 +139,14 @@
                     saveCron({id:sn.id, name:'Sonic Fingerprint', task_type:'sonic_fingerprint', cron_expr:sexpr, enabled:sen})
                 } else {
                     saveCron({name:'Sonic Fingerprint', task_type:'sonic_fingerprint', cron_expr:sexpr, enabled:sen})
+                }
+
+                const aaexpr = document.getElementById('alchemy-anchors-cron').value;
+                const aaen = document.getElementById('alchemy-anchors-enabled').checked;
+                if (aan) {
+                    saveCron({id:aan.id, name:'Alchemy Anchors', task_type:'alchemy_anchors', cron_expr:aaexpr, enabled:aaen})
+                } else {
+                    saveCron({name:'Alchemy Anchors', task_type:'alchemy_anchors', cron_expr:aaexpr, enabled:aaen})
                 }
 
                 // refresh cached rows after saving

--- a/tests/unit/test_app_cron.py
+++ b/tests/unit/test_app_cron.py
@@ -90,3 +90,29 @@ def test_sonic_fingerprint_branch_falls_back_for_mpd(mock_get_db, _matches):
     legacy_name = legacy.call_args[0][0]
     assert legacy_name.startswith('Sonic Fingerprint (Cron ')
     assert legacy.call_args[0][1] == ['a']
+
+
+@patch('app_cron.cron_matches_now', return_value=True)
+@patch('app_cron.get_db')
+def test_alchemy_anchors_branch_refreshes_anchor_playlists(mock_get_db, _matches):
+    """Each saved alchemy anchor refreshes a stable <anchor>_automatic playlist."""
+    from app_cron import run_due_cron_jobs
+
+    cur = MagicMock()
+    cur.fetchall.return_value = [_make_cron_row('alchemy_anchors')]
+    db = MagicMock()
+    db.cursor.return_value = cur
+    mock_get_db.return_value = db
+
+    anchors = [{'id': 7, 'name': 'Jazz Night'}]
+    alchemy = {'results': [{'item_id': 'a'}, {'item_id': 'b'}]}
+
+    with patch('app_helper.get_alchemy_anchors', return_value=anchors), \
+         patch('tasks.song_alchemy.song_alchemy', return_value=alchemy) as run_alchemy, \
+         patch('tasks.mediaserver.create_or_replace_playlist', return_value={'Id': 'pl-1'}) as upsert, \
+         patch('tasks.voyager_manager.create_playlist_from_ids') as legacy:
+        run_due_cron_jobs()
+
+    run_alchemy.assert_called_once_with(add_items=[{'type': 'anchor', 'id': 7}])
+    upsert.assert_called_once_with('Jazz Night_automatic', ['a', 'b'])
+    legacy.assert_not_called()


### PR DESCRIPTION
## AS-IS
Scheduled tasks supported analysis, clustering, and Sonic Fingerprint, but there was no way to refresh saved Song Alchemy anchors into automatic playlists on a schedule.

## TO-BE
Adds an `alchemy_anchors` scheduled task. When due, it loads saved alchemy anchors, runs Song Alchemy with existing default parameters for each anchor, and refreshes a stable `<anchor>_automatic` playlist. The cron page now exposes controls for enabling and configuring this schedule.

## Test
- Reproduced the missing capability by checking `app_cron.py`: `run_due_cron_jobs()` only handled `analysis`, `clustering`, and `sonic_fingerprint`.
- Added unit coverage that a saved anchor refreshes `Jazz Night_automatic` through `create_or_replace_playlist()` with the Song Alchemy result IDs.
- `python -m py_compile app_cron.py tests/unit/test_app_cron.py` passed.
- `git diff --check` passed with line-ending warnings only.
- LSP diagnostics are limited by missing local `flask` / `psycopg2` environment imports.
- `pytest` is not installed in this environment, so the targeted test could not be executed here.

## Other useful information
This intentionally uses the existing Song Alchemy defaults first. Custom per-schedule alchemy parameters can be added later without blocking the core scheduled-anchor workflow.

## Checklist
<!-- Not all items are mandatory — just check the ones that apply to your case. -->

**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [ ] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #476
