### PR TITLE
Improve setup media server error feedback

### DIFF
--- a/app_error_handler.py
+++ b/app_error_handler.py
@@ -1,0 +1,36 @@
+"""Centralized safe error messages for web UI responses."""
+
+SETUP_ERROR_MESSAGES = {
+    'MEDIA_SERVER_AUTH_FAILED': 'Media server credentials were rejected. Check the username, password, API token, and user ID.',
+    'MEDIA_SERVER_UNREACHABLE': 'AudioMuse-AI could not reach the media server. Check the URL and make sure it is reachable from the AudioMuse-AI container.',
+    'MEDIA_SERVER_EMPTY_LIBRARY': 'Connected to the media server, but no top-played songs were returned. Play a few tracks or check that this account can read the library.',
+    'MEDIA_SERVER_CONFIG_INCOMPLETE': 'Media server configuration is incomplete. Fill in all required media-server fields and try again.',
+    'MEDIA_SERVER_TEST_FAILED': 'Media server connection test failed. Check the configuration and try again.',
+    'SETUP_SAVE_FAILED': 'Unable to save configuration. Check the server log for details.',
+}
+
+
+def classify_setup_error(exc):
+    """Return a stable setup error code without exposing raw exception details."""
+    text = str(exc or '').lower()
+    if any(token in text for token in ('unauthorized', 'forbidden', 'invalid credentials', 'authentication', '401', '403')):
+        return 'MEDIA_SERVER_AUTH_FAILED'
+    if any(token in text for token in ('connection', 'connect', 'timeout', 'timed out', 'resolve', 'refused', 'unreachable')):
+        return 'MEDIA_SERVER_UNREACHABLE'
+    if any(token in text for token in ('no top-played', 'no top played', 'no items', 'no songs', 'empty')):
+        return 'MEDIA_SERVER_EMPTY_LIBRARY'
+    if any(token in text for token in ('incomplete', 'missing', 'required')):
+        return 'MEDIA_SERVER_CONFIG_INCOMPLETE'
+    return 'MEDIA_SERVER_TEST_FAILED'
+
+
+def setup_error_payload(exc, default_code='SETUP_SAVE_FAILED'):
+    """Build a JSON-safe error payload with a stable code and safe message."""
+    if default_code == 'MEDIA_SERVER_TEST_FAILED':
+        code = classify_setup_error(exc)
+    else:
+        code = default_code
+    return {
+        'error': SETUP_ERROR_MESSAGES.get(code, SETUP_ERROR_MESSAGES['SETUP_SAVE_FAILED']),
+        'error_code': code,
+    }

--- a/app_setup.py
+++ b/app_setup.py
@@ -9,6 +9,7 @@ from app import app, setup_manager
 from app_helper import check_setup_needed
 import restart_manager
 import tasks.mediaserver as mediaserver
+from app_error_handler import setup_error_payload
 
 BASIC_SERVER_FIELDS = ["MEDIASERVER_TYPE"] + [
     field
@@ -522,7 +523,7 @@ def setup_api():
     except Exception as exc:
         app.logger.error('Setup save failed: %s', exc, exc_info=True)
         if is_test_connection:
-            return jsonify({'error': 'Unable to get top player song. Check the server log for details.'}), 500
+            return jsonify(setup_error_payload(exc, default_code='MEDIA_SERVER_TEST_FAILED')), 400
         return jsonify({'error': 'Unable to save configuration. Check the server log for details.'}), 500
 
     response = make_response(jsonify({
@@ -601,7 +602,7 @@ def setup_provider_libraries_api():
         result = _list_provider_libraries(filtered_values)
     except Exception as exc:
         app.logger.error('setup_provider_libraries_api failed: %s', exc, exc_info=True)
-        return jsonify({'error': 'Unable to list libraries. Check the server log for details.'}), 500
+        return jsonify(setup_error_payload(exc, default_code='MEDIA_SERVER_TEST_FAILED')), 400
 
     return jsonify({
         'libraries': result.get('libraries', []),

--- a/static/setup.js
+++ b/static/setup.js
@@ -808,7 +808,7 @@ function testConnection() {
     }).catch(function(err) {
         testFeedback.className = 'status-failure inline-feedback';
         testFeedback.style.display = 'block';
-        testFeedback.textContent = '✕ Connection test failed: ' + err.message;
+        testFeedback.textContent = '✕ ' + (err.message || 'Media server connection test failed.');
     }).finally(function() {
         testButton.disabled = false;
         saveButton.disabled = false;

--- a/tests/unit/test_app_error_handler.py
+++ b/tests/unit/test_app_error_handler.py
@@ -1,0 +1,27 @@
+from app_error_handler import classify_setup_error, setup_error_payload
+
+
+def test_setup_error_payload_uses_safe_unreachable_message():
+    payload = setup_error_payload(
+        TimeoutError('Connection timed out to http://internal-host:8096'),
+        default_code='MEDIA_SERVER_TEST_FAILED',
+    )
+
+    assert payload == {
+        'error': 'AudioMuse-AI could not reach the media server. Check the URL and make sure it is reachable from the AudioMuse-AI container.',
+        'error_code': 'MEDIA_SERVER_UNREACHABLE',
+    }
+
+
+def test_setup_error_payload_uses_safe_auth_message():
+    payload = setup_error_payload(
+        PermissionError('401 Unauthorized: invalid credentials'),
+        default_code='MEDIA_SERVER_TEST_FAILED',
+    )
+
+    assert payload['error_code'] == 'MEDIA_SERVER_AUTH_FAILED'
+    assert 'credentials were rejected' in payload['error']
+
+
+def test_classify_setup_error_handles_empty_library_probe():
+    assert classify_setup_error(ValueError('No top-played songs were returned')) == 'MEDIA_SERVER_EMPTY_LIBRARY'


### PR DESCRIPTION
## AS-IS
The setup wizard caught media-server connection probe failures and returned a generic `Unable to get top player song. Check the server log for details.` message. Users could not tell from the web UI whether the likely problem was credentials, reachability, incomplete config, or an empty top-played probe.

## TO-BE
Adds a centralized setup UI error helper that maps setup probe exceptions to stable, safe error codes and actionable web UI messages without exposing raw exception details. The setup connection test and provider-library probe now use that helper, and the wizard displays the returned guidance directly.

## Test
- Reproduced by reading `app_setup.py`: failed `test_connection` requests always returned the same generic server-log message from the catch block.
- Added unit coverage for unreachable, auth, and empty-library setup error classifications.
- `python -m py_compile app_error_handler.py app_setup.py tests/unit/test_app_error_handler.py` passed.
- `python -c "from app_error_handler import setup_error_payload; print(setup_error_payload(TimeoutError('Connection timed out'), default_code='MEDIA_SERVER_TEST_FAILED'))"` returned `MEDIA_SERVER_UNREACHABLE` with the safe UI message.
- `git diff --check` passed with line-ending warnings only.
- `python -m pytest tests/unit/test_app_error_handler.py` could not run because `pytest` is not installed in this environment.
- LSP diagnostics: modified new helper/test files have no diagnostics; `app_setup.py` is limited by missing local `flask` import.

## Other useful information
The helper intentionally avoids returning raw provider exceptions to the browser. It gives user-actionable categories while keeping detailed stack traces in server logs.

## Checklist
<!-- Not all items are mandatory — just check the ones that apply to your case. -->

**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [ ] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #107
