### PR TITLE
Feat/Add MAX_SONGS_PER_ALBUM diversity cap (mirrors MAX_SONGS_PER_ARTIST)

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,7 @@ from flasgger import Swagger, swag_from
 
 # Import configuration
 from config import JELLYFIN_URL, JELLYFIN_USER_ID, JELLYFIN_TOKEN, HEADERS, TEMP_DIR, \
-  REDIS_URL, DATABASE_URL, MAX_DISTANCE, MAX_SONGS_PER_CLUSTER, MAX_SONGS_PER_ARTIST, NUM_RECENT_ALBUMS, \
+  REDIS_URL, DATABASE_URL, MAX_DISTANCE, MAX_SONGS_PER_CLUSTER, MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM, NUM_RECENT_ALBUMS, \
   SCORE_WEIGHT_DIVERSITY, SCORE_WEIGHT_SILHOUETTE, SCORE_WEIGHT_DAVIES_BOULDIN, SCORE_WEIGHT_CALINSKI_HARABASZ, \
   SCORE_WEIGHT_PURITY, SCORE_WEIGHT_OTHER_FEATURE_DIVERSITY, SCORE_WEIGHT_OTHER_FEATURE_PURITY, \
   MIN_SONGS_PER_GENRE_FOR_STRATIFICATION, STRATIFIED_SAMPLING_TARGET_PERCENTILE, \
@@ -591,6 +591,7 @@ def get_config_endpoint():
     return jsonify({
         "num_recent_albums": config.NUM_RECENT_ALBUMS, "max_distance": config.MAX_DISTANCE,
         "max_songs_per_cluster": config.MAX_SONGS_PER_CLUSTER, "max_songs_per_artist": config.MAX_SONGS_PER_ARTIST,
+        "max_songs_per_album": config.MAX_SONGS_PER_ALBUM,
         "cluster_algorithm": config.CLUSTER_ALGORITHM, "num_clusters_min": config.NUM_CLUSTERS_MIN, "num_clusters_max": config.NUM_CLUSTERS_MAX,
         "dbscan_eps_min": config.DBSCAN_EPS_MIN, "dbscan_eps_max": config.DBSCAN_EPS_MAX, "gmm_covariance_type": config.GMM_COVARIANCE_TYPE,
         "dbscan_min_samples_min": config.DBSCAN_MIN_SAMPLES_MIN, "dbscan_min_samples_max": config.DBSCAN_MIN_SAMPLES_MAX,

--- a/config.py
+++ b/config.py
@@ -105,6 +105,7 @@ APP_VERSION = "v2.1.1"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering
+MAX_SONGS_PER_ALBUM = int(os.getenv("MAX_SONGS_PER_ALBUM", "0")) # Max songs per album in similarity results and clustering. 0 = disabled. Mirrors MAX_SONGS_PER_ARTIST.
 # New: Default behavior for eliminating duplicates in similarity search. If param not passed to API, this is the default.
 SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT = os.environ.get("SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT", "True").lower() == 'true'
 # Default behavior for radius similarity mode. Can be toggled via environment variable.

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -124,7 +124,7 @@ Additional DB & deployment knobs (explicit)
    * `AI_MODEL_PROVIDER`, `OLLAMA_SERVER_URL`, `OLLAMA_MODEL_NAME`, `GEMINI_API_KEY`, `GEMINI_MODEL_NAME`, `MISTRAL_API_KEY`, `MISTRAL_MODEL_NAME` — control how AI naming/chat is performed.
 
 - Safety & result caps:
-   * `ALCHEMY_MAX_N_RESULTS`, `ALCHEMY_DEFAULT_N_RESULTS`, `CLEANING_SAFETY_LIMIT`, `MAX_SONGS_PER_ARTIST` — enforce limits on returned/affected rows.
+   * `ALCHEMY_MAX_N_RESULTS`, `ALCHEMY_DEFAULT_N_RESULTS`, `CLEANING_SAFETY_LIMIT`, `MAX_SONGS_PER_ARTIST`, `MAX_SONGS_PER_ALBUM` — enforce limits on returned/affected rows.
 
 Operational notes:
 

--- a/docs/ALGORITHM_DETAILS.md
+++ b/docs/ALGORITHM_DETAILS.md
@@ -393,6 +393,9 @@ candidate playlist inside
 - **Per-artist cap** — at most `MAX_SONGS_PER_ARTIST` (3) songs per artist
   (case-insensitive author key); set ≤ 0 to disable. Consistent with the path
   and voyager managers.
+- **Per-album cap** — at most `MAX_SONGS_PER_ALBUM` (0 = disabled) songs per
+  album (case-insensitive album key); tracks without an album are never capped.
+  Consistent with the path and voyager managers.
 - **Per-cluster cap** — at most `max_songs_per_cluster` songs (0 = unlimited).
 - **Naming** — [`_name_cluster`](../tasks/clustering_helper.py) inverts the
   centroid back to feature space and builds a name from the tempo band

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -85,6 +85,7 @@ These are the default parameters used when launching analysis or clustering task
 | `CLUSTER_ALGORITHM`                         | Default clustering: `kmeans`, `dbscan`, `gmm`, `spectral`.                                                                | `kmeans`        |
 | `MAX_SONGS_PER_CLUSTER`                     | Max songs per generated playlist segment.                                                                                 | `0`             |
 | `MAX_SONGS_PER_ARTIST`                      | Max songs from one artist per cluster.                                                                                    | `3`             |
+| `MAX_SONGS_PER_ALBUM`                       | Max songs from one album across similarity, clustering, paths and Sonic Fingerprint. `0` = disabled.                      | `0`             |
 | `MAX_DISTANCE`                              | Normalized distance threshold for tracks in a cluster.                                                                    | `0.5`           |
 | `CLUSTERING_RUNS`                           | Iterations for Monte Carlo evolutionary search.                                                                           | `1000`          |
 | `TOP_N_PLAYLISTS`                           | POST Clustering it keep only the top N diverse playlist.                                                                  | `8`             |
@@ -94,7 +95,7 @@ These are the default parameters used when launching analysis or clustering task
 | `VOYAGER_M`                                 | Number of neighbor links per node in the HNSW graph. Higher = better recall + larger on-disk index + slower rebuilds. `32` is a tuned default; `64` was the previous default and roughly doubles the link payload.                                                                               | `32`            |
 | `VOYAGER_QUERY_EF`                          | Number neighbor analyzed during the query.                                                                                | `1024`          |
 | `VOYAGER_METRIC`                            | Different tipe of distance metrics: `angular`, `euclidean`,`dot`                                                          | `angular`       |
-| `SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT`   | It enable the possibility of use the `MAX_SONGS_PER_ARTIST` also in similar song                                          | `true`          |
+| `SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT`   | It enable the possibility of use the `MAX_SONGS_PER_ARTIST` and `MAX_SONGS_PER_ALBUM` also in similar song                 | `true`          |
 | `SIMILARITY_RADIUS_DEFAULT`                 | Default behavior for radius similarity mode. When `true`, similarity results may be re-ordered using the radius (bucketed) algorithm for better listening paths. | `true`          |
 | **Sonic Fingerprint General**               |                                                                                                                            |                 |
 | `SONIC_FINGERPRINT_NEIGHBORS`               | Default number of track for the sonic fingerprint                                                                         | `100`           |

--- a/tasks/ai/tool_impl.py
+++ b/tasks/ai/tool_impl.py
@@ -910,7 +910,7 @@ def _lyrics_search_sync(query: str, get_songs: int) -> Dict:
     try:
         from tasks.lyrics_manager import search_by_text
         log_messages.append(f"Lyrics search: '{text}'")
-        results = search_by_text(text, limit=int(get_songs) if get_songs else 200, artist_cap=0)
+        results = search_by_text(text, limit=int(get_songs) if get_songs else 200, artist_cap=0, album_cap=0)
         if not results:
             log_messages.append("No lyrics matched (index empty, not loaded, or no semantic match)")
             return {"songs": [], "message": "\n".join(log_messages)}

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -442,15 +442,17 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
             logger.error(f"Failed to generate text embedding for: {query_text}")
             return []
 
-        from config import MAX_SONGS_PER_ARTIST
+        from config import MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM
         artist_cap = MAX_SONGS_PER_ARTIST if MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0 else 0
+        album_cap = MAX_SONGS_PER_ALBUM if MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0 else 0
         # A large limit means the caller wants a big re-rank POOL (the chat
-        # pipeline). Skip the in-CLAP per-artist cap there -- it would inflate the
-        # voyager k to ~5x (e.g. 50 000 for a 10 000 pool) and artist diversity is
-        # applied downstream anyway. Small limits (search page) keep the cap.
+        # pipeline). Skip the in-CLAP per-artist/album caps there -- they would inflate the
+        # voyager k to ~5x (e.g. 50 000 for a 10 000 pool) and diversity is
+        # applied downstream anyway. Small limits (search page) keep the caps.
         if limit >= 1000:
             artist_cap = 0
-        fetch_size = (limit + max(20, limit * 4) + 1) if artist_cap else limit
+            album_cap = 0
+        fetch_size = (limit + max(20, limit * 4) + 1) if (artist_cap or album_cap) else limit
 
         if _CLAP_INDEX_CACHE['loaded'] and _CLAP_INDEX_CACHE['index'] is not None:
             voyager_index = _CLAP_INDEX_CACHE['index']
@@ -469,6 +471,7 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
 
             results = []
             artist_counts: dict = {}
+            album_counts: dict = {}
             for voyager_id, distance in zip(neighbor_ids, distances):
                 if len(results) >= limit:
                     break
@@ -478,12 +481,20 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
 
                 metadata = metadata_map.get(item_id, {'title': '', 'author': '', 'album': ''})
                 author = metadata.get('author', '')
+                album = metadata.get('album', '')
+                author_norm = author.strip().lower() if author else ''
+                album_norm = album.strip().lower() if album else ''
 
-                if artist_cap and author:
-                    author_norm = author.strip().lower()
-                    if artist_counts.get(author_norm, 0) >= artist_cap:
-                        continue
+                # Check both caps before mutating either counter, so a song rejected by
+                # one cap does not inflate the other.
+                if artist_cap and author_norm and artist_counts.get(author_norm, 0) >= artist_cap:
+                    continue
+                if album_cap and album_norm and album_counts.get(album_norm, 0) >= album_cap:
+                    continue
+                if artist_cap and author_norm:
                     artist_counts[author_norm] = artist_counts.get(author_norm, 0) + 1
+                if album_cap and album_norm:
+                    album_counts[album_norm] = album_counts.get(album_norm, 0) + 1
 
                 similarity = 1.0 - float(distance)
                 results.append({
@@ -494,7 +505,7 @@ def search_by_text(query_text: str, limit: int = 100) -> List[Dict]:
                     'similarity': similarity
                 })
 
-            logger.info(f"Text search '{query_text}': found {len(results)} results via CLAP index (artist cap: {artist_cap or 'disabled'})")
+            logger.info(f"Text search '{query_text}': found {len(results)} results via CLAP index (artist cap: {artist_cap or 'disabled'}, album cap: {album_cap or 'disabled'})")
             return results
         
     except Exception as e:

--- a/tasks/clustering_helper.py
+++ b/tasks/clustering_helper.py
@@ -29,7 +29,7 @@ from rq.job import Job
 from rq.exceptions import NoSuchJobError
 
 from config import (STRATIFIED_GENRES, OTHER_FEATURE_LABELS, MOOD_LABELS, MAX_DISTANCE,
-                    MAX_SONGS_PER_ARTIST, GMM_COVARIANCE_TYPE, SPECTRAL_N_NEIGHBORS,
+                    MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM, GMM_COVARIANCE_TYPE, SPECTRAL_N_NEIGHBORS,
                     TOP_K_MOODS_FOR_PURITY_CALCULATION, LN_MOOD_DIVERSITY_STATS,
                     LN_MOOD_PURITY_STATS, LN_MOOD_DIVERSITY_EMBEDING_STATS,
                     LN_MOOD_PURITY_EMBEDING_STATS, LN_OTHER_FEATURES_DIVERSITY_STATS,
@@ -389,13 +389,16 @@ def _format_and_score_iteration_result(
         if not cluster_tracks_info: continue
         
         cluster_tracks_info.sort(key=lambda x: x["distance"])
-        # Track per-artist counts using a normalized author key. Treat MAX_SONGS_PER_ARTIST <= 0
+        # Track per-artist and per-album counts using normalized keys. Treat each cap <= 0
         # or None as DISABLED (no cap), consistent with other modules (path_manager/voyager_manager).
         count_per_artist = defaultdict(int)
+        count_per_album = defaultdict(int)
         selected_tracks_for_playlist = []
         for t_item_info in cluster_tracks_info:
             author = t_item_info["row"].get("author")
             author_norm = (author or "").strip().lower()
+            album = t_item_info["row"].get("album")
+            album_norm = (album or "").strip().lower()
 
             # If MAX_SONGS_PER_ARTIST is not configured or <= 0, disable per-artist cap.
             if MAX_SONGS_PER_ARTIST is None or MAX_SONGS_PER_ARTIST <= 0:
@@ -403,9 +406,18 @@ def _format_and_score_iteration_result(
             else:
                 allowed_by_artist = count_per_artist[author_norm] < MAX_SONGS_PER_ARTIST
 
-            if allowed_by_artist:
+            # If MAX_SONGS_PER_ALBUM is not configured or <= 0, disable per-album cap.
+            # Tracks without an album are never capped.
+            if MAX_SONGS_PER_ALBUM is None or MAX_SONGS_PER_ALBUM <= 0 or not album_norm:
+                allowed_by_album = True
+            else:
+                allowed_by_album = count_per_album[album_norm] < MAX_SONGS_PER_ALBUM
+
+            if allowed_by_artist and allowed_by_album:
                 selected_tracks_for_playlist.append(t_item_info)
                 count_per_artist[author_norm] += 1
+                if album_norm:
+                    count_per_album[album_norm] += 1
 
             if max_songs_per_cluster > 0 and len(selected_tracks_for_playlist) >= max_songs_per_cluster:
                 break

--- a/tasks/lyrics_manager.py
+++ b/tasks/lyrics_manager.py
@@ -586,7 +586,7 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
              everything else → 0.0. Axes the user did not pick contribute 0 across
              all their labels.
     """
-    from config import LYRICS_ENABLED, MAX_SONGS_PER_ARTIST
+    from config import LYRICS_ENABLED, MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM
 
     if not LYRICS_ENABLED:
         return []
@@ -620,7 +620,8 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
     metadata_map = _LYRICS_AXIS_CACHE['metadata'] or {}
 
     artist_cap = MAX_SONGS_PER_ARTIST if MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0 else 0
-    fetch_size = (limit + max(20, limit * 4) + 1) if artist_cap else limit
+    album_cap = MAX_SONGS_PER_ALBUM if MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0 else 0
+    fetch_size = (limit + max(20, limit * 4) + 1) if (artist_cap or album_cap) else limit
     num_to_query = min(fetch_size, len(voyager_index))
     if num_to_query <= 0:
         return []
@@ -633,6 +634,7 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
 
     results: List[Dict] = []
     artist_counts: Dict[str, int] = {}
+    album_counts: Dict[str, int] = {}
     for vid, dist in zip(neighbor_ids, distances):
         if len(results) >= limit:
             break
@@ -641,11 +643,18 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
             continue
         meta = metadata_map.get(item_id, {'title': '', 'author': '', 'album': ''})
         author = meta.get('author', '') or ''
-        if artist_cap and author:
-            an = author.strip().lower()
-            if artist_counts.get(an, 0) >= artist_cap:
-                continue
+        album = meta.get('album', '') or ''
+        an = author.strip().lower() if author else ''
+        al = album.strip().lower() if album else ''
+        # Check both caps before mutating either counter.
+        if artist_cap and an and artist_counts.get(an, 0) >= artist_cap:
+            continue
+        if album_cap and al and album_counts.get(al, 0) >= album_cap:
+            continue
+        if artist_cap and an:
             artist_counts[an] = artist_counts.get(an, 0) + 1
+        if album_cap and al:
+            album_counts[al] = album_counts.get(al, 0) + 1
         similarity = 1.0 - float(dist)
         results.append({
             'item_id': item_id,
@@ -657,7 +666,7 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
 
     logger.info(
         f"Lyrics axis search ({len(selected_pairs)} selections): {len(results)} results "
-        f"(artist cap: {artist_cap or 'disabled'})"
+        f"(artist cap: {artist_cap or 'disabled'}, album cap: {album_cap or 'disabled'})"
     )
     return results
 
@@ -666,15 +675,17 @@ def search_by_axes(targets: Dict[str, str], limit: int = 50) -> List[Dict]:
 # Search: by free text
 # ---------------------------------------------------------------------------
 
-def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] = None) -> List[Dict]:
+def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] = None, album_cap: Optional[int] = None) -> List[Dict]:
     """Search lyrics by embedding the query with gte-multilingual-base and querying the voyager index.
 
     ``artist_cap`` controls the per-artist diversity cap: ``None`` uses the global
     ``MAX_SONGS_PER_ARTIST`` (the default, for direct user-facing search); ``0``
     disables it entirely, returning the full similarity-ranked pool up to ``limit``
     (used when feeding a candidate pool that is diversity-capped downstream).
+    ``album_cap`` mirrors this for the per-album cap (``None`` → global
+    ``MAX_SONGS_PER_ALBUM``; ``0`` disables it).
     """
-    from config import LYRICS_ENABLED, MAX_SONGS_PER_ARTIST
+    from config import LYRICS_ENABLED, MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM
     from lyrics.lyrics_transcriber import embed_query_text
     from tasks.gte_warm_cache import warm_lock, warmup_gte_model
 
@@ -699,7 +710,10 @@ def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] =
         if artist_cap is None:
             artist_cap = MAX_SONGS_PER_ARTIST
         artist_cap = artist_cap if artist_cap and artist_cap > 0 else 0
-        fetch_size = (limit + max(20, limit * 4) + 1) if artist_cap else limit
+        if album_cap is None:
+            album_cap = MAX_SONGS_PER_ALBUM
+        album_cap = album_cap if album_cap and album_cap > 0 else 0
+        fetch_size = (limit + max(20, limit * 4) + 1) if (artist_cap or album_cap) else limit
 
         voyager_index = _LYRICS_INDEX_CACHE['index']
         id_map = _LYRICS_INDEX_CACHE['id_map'] or {}
@@ -714,6 +728,7 @@ def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] =
 
         results: List[Dict] = []
         artist_counts: Dict[str, int] = {}
+        album_counts: Dict[str, int] = {}
         for vid, dist in zip(neighbor_ids, distances):
             if len(results) >= limit:
                 break
@@ -722,11 +737,18 @@ def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] =
                 continue
             meta = metadata_map.get(item_id, {'title': '', 'author': '', 'album': ''})
             author = meta.get('author', '') or ''
-            if artist_cap and author:
-                an = author.strip().lower()
-                if artist_counts.get(an, 0) >= artist_cap:
-                    continue
+            album = meta.get('album', '') or ''
+            an = author.strip().lower() if author else ''
+            al = album.strip().lower() if album else ''
+            # Check both caps before mutating either counter.
+            if artist_cap and an and artist_counts.get(an, 0) >= artist_cap:
+                continue
+            if album_cap and al and album_counts.get(al, 0) >= album_cap:
+                continue
+            if artist_cap and an:
                 artist_counts[an] = artist_counts.get(an, 0) + 1
+            if album_cap and al:
+                album_counts[al] = album_counts.get(al, 0) + 1
             similarity = 1.0 - float(dist)
             results.append({
                 'item_id': item_id,
@@ -738,7 +760,7 @@ def search_by_text(query_text: str, limit: int = 50, artist_cap: Optional[int] =
 
         logger.info(
             f"Lyrics text search '{query_text}': {len(results)} results "
-            f"(artist cap: {artist_cap or 'disabled'})"
+            f"(artist cap: {artist_cap or 'disabled'}, album cap: {album_cap or 'disabled'})"
         )
         return results
     except Exception as e:

--- a/tasks/path_manager.py
+++ b/tasks/path_manager.py
@@ -15,8 +15,8 @@ from config import (
     DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN,
     DUPLICATE_DISTANCE_CHECK_LOOKBACK
 )
-# Also import per-artist cap
-from config import MAX_SONGS_PER_ARTIST
+# Also import per-artist and per-album caps
+from config import MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM
 
 logger = logging.getLogger(__name__)
 
@@ -178,7 +178,7 @@ def _normalize_signature(artist, title):
 
 
 def _find_best_songs_for_job(centroid_vec, used_song_ids, used_signatures, path_songs_details_so_far,
-                             k_search=10, num_to_find=1, artist_counts=None):
+                             k_search=10, num_to_find=1, artist_counts=None, album_counts=None):
     """
     Finds a specific number (`num_to_find`) of best songs for a centroid
     by searching k_search neighbors.
@@ -235,6 +235,14 @@ def _find_best_songs_for_job(centroid_vec, used_song_ids, used_signatures, path_
                 logger.debug(f"Filtering song (ARTIST CAP) '{details.get('title')}' by '{details.get('author')}' because artist cap {MAX_SONGS_PER_ARTIST} reached.")
                 continue
 
+        # Enforce global per-album cap if configured. Treat MAX_SONGS_PER_ALBUM <= 0 as DISABLED.
+        # Songs without an album are never capped.
+        album_norm = (details.get('album') or '').strip().lower()
+        if album_counts is not None and album_norm and MAX_SONGS_PER_ALBUM is not None and MAX_SONGS_PER_ALBUM > 0:
+            if album_counts.get(album_norm, 0) >= MAX_SONGS_PER_ALBUM:
+                logger.debug(f"Filtering song (ALBUM CAP) '{details.get('title')}' from album '{details.get('album')}' because album cap {MAX_SONGS_PER_ALBUM} reached.")
+                continue
+
         candidate_vector = get_vector_by_id(candidate_id)
         if candidate_vector is None:
             continue # Skip if vector is missing
@@ -279,7 +287,8 @@ def _find_best_songs_for_job(centroid_vec, used_song_ids, used_signatures, path_
             "signature": signature,
             "vector": candidate_vector,
             "title": details.get('title'),
-            "author": details.get('author')
+            "author": details.get('author'),
+            "album": details.get('album')
         })
 
         # IMPORTANT: Add to used_song_ids and used_signatures immediately
@@ -289,6 +298,9 @@ def _find_best_songs_for_job(centroid_vec, used_song_ids, used_signatures, path_
         # Increment artist count
         if artist_counts is not None:
             artist_counts[author_norm] = artist_counts.get(author_norm, 0) + 1
+        # Increment album count (skip blank albums)
+        if album_counts is not None and album_norm:
+            album_counts[album_norm] = album_counts.get(album_norm, 0) + 1
 
 
     if len(found_songs) < num_to_find:
@@ -307,6 +319,11 @@ def _find_best_songs_for_job(centroid_vec, used_song_ids, used_signatures, path_
                 auth = (song.get('author') or '').strip().lower()
                 if auth in artist_counts:
                     artist_counts[auth] = max(0, artist_counts.get(auth, 0) - 1)
+            # Decrement album count for rolled-back songs
+            if album_counts is not None:
+                alb = (song.get('album') or '').strip().lower()
+                if alb in album_counts:
+                    album_counts[alb] = max(0, album_counts.get(alb, 0) - 1)
         
         # Return an empty list to signal complete failure of this job
         return []
@@ -372,6 +389,15 @@ def find_path_between_songs(start_item_id, end_item_id, Lreq=PATH_DEFAULT_LENGTH
     if end_author:
         artist_counts[end_author] = artist_counts.get(end_author, 0) + 1
 
+    # Track per-album counts so we can enforce MAX_SONGS_PER_ALBUM across the path
+    album_counts = {}
+    start_album = (start_details.get('album') or '').strip().lower()
+    end_album = (end_details.get('album') or '').strip().lower()
+    if start_album:
+        album_counts[start_album] = album_counts.get(start_album, 0) + 1
+    if end_album:
+        album_counts[end_album] = album_counts.get(end_album, 0) + 1
+
     # This list holds the start song + all *found* intermediate songs
     path_songs_details = [{**start_details, 'vector': start_vector}]
     
@@ -430,7 +456,8 @@ def find_path_between_songs(start_item_id, end_item_id, Lreq=PATH_DEFAULT_LENGTH
                     path_songs_details,
                     k_search=k_base,
                     num_to_find=1,
-                    artist_counts=artist_counts
+                    artist_counts=artist_counts,
+                    album_counts=album_counts
                 )
                 if found and len(found) > 0:
                     path_songs_details.extend(found)
@@ -477,7 +504,8 @@ def find_path_between_songs(start_item_id, end_item_id, Lreq=PATH_DEFAULT_LENGTH
                     path_songs_details, # Pass the list of songs found so far
                     k_search=job['k'],
                     num_to_find=job['num_to_find'],
-                    artist_counts=artist_counts
+                    artist_counts=artist_counts,
+                    album_counts=album_counts
                 )
 
                 num_found = len(found_songs)

--- a/tasks/sem_grove_manager.py
+++ b/tasks/sem_grove_manager.py
@@ -598,14 +598,15 @@ def search_by_song(seed_item_id: str, limit: int = 50) -> List[Dict]:
         logger.error("SemGrove: cannot fetch vector for seed '%s': %s", seed_item_id, exc)
         return []
 
-    from config import MAX_SONGS_PER_ARTIST, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_CHECK_LOOKBACK
+    from config import MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_CHECK_LOOKBACK
     import numpy as np
 
     artist_cap    = MAX_SONGS_PER_ARTIST if MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0 else 0
+    album_cap     = MAX_SONGS_PER_ALBUM if MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0 else 0
     dist_threshold = DUPLICATE_DISTANCE_THRESHOLD_COSINE  # cosine dist < this → near-duplicate
     lookback_n     = DUPLICATE_DISTANCE_CHECK_LOOKBACK if DUPLICATE_DISTANCE_CHECK_LOOKBACK > 0 else 0
     # +1 because the seed itself may appear and will be skipped
-    fetch_size   = (limit + max(20, limit * 4) + 1) if (artist_cap or lookback_n) else (limit + 1)
+    fetch_size   = (limit + max(20, limit * 4) + 1) if (artist_cap or album_cap or lookback_n) else (limit + 1)
     num_to_query = min(fetch_size, len(index))
     if num_to_query <= 0:
         return []
@@ -635,6 +636,7 @@ def search_by_song(seed_item_id: str, limit: int = 50) -> List[Dict]:
         "is_seed":    True,
     }]
     artist_counts:  Dict[str, int]   = {}
+    album_counts:   Dict[str, int]   = {}
     seen_names:     set               = set()   # (title_lower, author_lower) deduplication
     lookback_vecs:  list              = []       # recent kept vectors for distance-based dedup
 
@@ -647,6 +649,7 @@ def search_by_song(seed_item_id: str, limit: int = 50) -> List[Dict]:
         meta   = metadata_map.get(item_id, {"title": "", "author": "", "album": ""})
         author = meta.get("author", "") or ""
         title  = meta.get("title",  "") or ""
+        album  = meta.get("album",  "") or ""
 
         # Name-based deduplication (same title+artist = likely duplicate recording)
         name_key = (title.strip().lower(), author.strip().lower())
@@ -654,11 +657,18 @@ def search_by_song(seed_item_id: str, limit: int = 50) -> List[Dict]:
             continue
         seen_names.add(name_key)
 
-        if artist_cap and author:
-            an = author.strip().lower()
-            if artist_counts.get(an, 0) >= artist_cap:
-                continue
+        an = author.strip().lower() if author else ''
+        al = album.strip().lower() if album else ''
+        # Check both caps before mutating either counter, so a song rejected by one
+        # cap does not inflate the other.
+        if artist_cap and an and artist_counts.get(an, 0) >= artist_cap:
+            continue
+        if album_cap and al and album_counts.get(al, 0) >= album_cap:
+            continue
+        if artist_cap and an:
             artist_counts[an] = artist_counts.get(an, 0) + 1
+        if album_cap and al:
+            album_counts[al] = album_counts.get(al, 0) + 1
 
         # Distance-based near-duplicate filter: skip if this song's merged vector is
         # too close (cosine dist < dist_threshold) to any song in the lookback window.

--- a/tasks/sonic_fingerprint_manager.py
+++ b/tasks/sonic_fingerprint_manager.py
@@ -112,19 +112,43 @@ def generate_sonic_fingerprint(num_neighbors=None, user_creds=None):
     contributing_seed_ids = list(embeddings_map.keys())
     num_seed_songs = len(contributing_seed_ids)
 
+    # Per-album cap for the FINAL fingerprint playlist (seeds + neighbors). 0 = disabled.
+    # Unlike the per-artist/album cap inside the Voyager neighbor search, this also covers
+    # the seed songs (top-played tracks), which are otherwise added uncapped -- the common
+    # cause of many same-album tracks for heavy re-listeners (e.g. a single DJ-mix CD).
+    from config import MAX_SONGS_PER_ALBUM
+    album_cap = MAX_SONGS_PER_ALBUM if (MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0) else 0
+    seed_album_by_id = {}
+    if album_cap:
+        seed_album_by_id = {t['item_id']: (t.get('album') or '').strip().lower() for t in track_details}
+
     # Calculate how many new neighbors to find to reach the total desired size
     neighbors_to_find = total_desired_size - num_seed_songs
 
     if neighbors_to_find <= 0:
         logger.info(f"The number of seed songs ({num_seed_songs}) is >= the desired playlist size ({total_desired_size}). Returning only seed songs, truncated to the desired size.")
-        final_results = [{'item_id': song_id, 'distance': 0.0} for song_id in contributing_seed_ids[:total_desired_size]]
+        final_results = []
+        album_counts = {}
+        for song_id in contributing_seed_ids:
+            if len(final_results) >= total_desired_size:
+                break
+            album = seed_album_by_id.get(song_id, '')
+            if album_cap and album and album_counts.get(album, 0) >= album_cap:
+                continue
+            final_results.append({'item_id': song_id, 'distance': 0.0})
+            if album:
+                album_counts[album] = album_counts.get(album, 0) + 1
         return final_results
 
     try:
-        logger.info(f"Searching for {neighbors_to_find} new neighbors to supplement the {num_seed_songs} seed songs.")
+        # When the album cap is active it can drop some seed songs, freeing slots in
+        # the final playlist. Over-request neighbors so we can still backfill up to the
+        # desired size instead of returning a short playlist.
+        neighbors_to_request = total_desired_size if album_cap else neighbors_to_find
+        logger.info(f"Searching for {neighbors_to_request} new neighbors to supplement the {num_seed_songs} seed songs.")
         similar_songs_from_voyager = find_nearest_neighbors_by_vector(
             query_vector=average_vector,
-            n=neighbors_to_find,
+            n=neighbors_to_request,
             eliminate_duplicates=True
         )
         logger.info(f"Found {len(similar_songs_from_voyager)} similar songs for the sonic fingerprint.")
@@ -133,22 +157,57 @@ def generate_sonic_fingerprint(num_neighbors=None, user_creds=None):
         final_song_ids = set()
         combined_results = []
 
-        # 1. Add the seed songs first
-        for song_id in contributing_seed_ids:
-            if song_id not in final_song_ids:
-                combined_results.append({'item_id': song_id, 'distance': 0.0})
-                final_song_ids.add(song_id)
-        
-        logger.info(f"Added {len(final_song_ids)} seed songs to the results.")
+        # Build an item_id -> normalized album map covering seeds AND the Voyager
+        # neighbors, so the per-album cap is enforced GLOBALLY across the whole
+        # playlist (a neighbor cannot exceed the budget already used by the seeds).
+        album_by_id = dict(seed_album_by_id)
+        if album_cap:
+            from app_helper import get_score_data_by_ids
+            missing_ids = [s['item_id'] for s in similar_songs_from_voyager if s['item_id'] not in album_by_id]
+            if missing_ids:
+                for d in get_score_data_by_ids(missing_ids):
+                    album_by_id[d['item_id']] = (d.get('album') or '').strip().lower()
 
-        # 2. Add the similar songs found by Voyager, skipping duplicates, until the desired size is reached
+        album_counts = {}
+
+        def _album_allows(item_id):
+            """Per-album cap gate. Records the album on success. Songs without an
+            album, or when the cap is disabled, always pass."""
+            if not album_cap:
+                return True
+            album = album_by_id.get(item_id, '')
+            if album and album_counts.get(album, 0) >= album_cap:
+                return False
+            if album:
+                album_counts[album] = album_counts.get(album, 0) + 1
+            return True
+
+        # 1. Add the seed songs first (subject to the per-album cap)
+        skipped_by_album = 0
+        for song_id in contributing_seed_ids:
+            if song_id in final_song_ids:
+                continue
+            if not _album_allows(song_id):
+                skipped_by_album += 1
+                continue
+            combined_results.append({'item_id': song_id, 'distance': 0.0})
+            final_song_ids.add(song_id)
+
+        logger.info(f"Added {len(final_song_ids)} seed songs to the results"
+                    + (f" ({skipped_by_album} seed(s) skipped by album cap {album_cap})." if skipped_by_album else "."))
+
+        # 2. Add the similar songs found by Voyager, skipping duplicates and album-capped
+        #    songs, until the desired size is reached
         for song in similar_songs_from_voyager:
             if len(combined_results) >= total_desired_size:
                 break
-            if song['item_id'] not in final_song_ids:
-                combined_results.append(song)
-                final_song_ids.add(song['item_id'])
-                
+            if song['item_id'] in final_song_ids:
+                continue
+            if not _album_allows(song['item_id']):
+                continue
+            combined_results.append(song)
+            final_song_ids.add(song['item_id'])
+
         logger.info(f"Total unique songs in final fingerprint playlist: {len(combined_results)}")
 
         return combined_results

--- a/tasks/voyager_manager.py
+++ b/tasks/voyager_manager.py
@@ -26,7 +26,7 @@ import math # Import math for ceiling function
 
 from config import (
     EMBEDDING_DIMENSION, INDEX_NAME, VOYAGER_METRIC, VOYAGER_EF_CONSTRUCTION,
-    VOYAGER_M, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB, MAX_SONGS_PER_ARTIST,
+    VOYAGER_M, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB, MAX_SONGS_PER_ARTIST, MAX_SONGS_PER_ALBUM,
     DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN,
     DUPLICATE_DISTANCE_CHECK_LOOKBACK, MOOD_SIMILARITY_THRESHOLD
     , SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT,
@@ -834,13 +834,14 @@ def _radius_walk_get_candidates(
                 except Exception:
                     vector = np.array(vector, dtype=np.float32)
                 dist_to_anchor = get_direct_distance(vector, anchor_vector)
-                info = details_map.get(item_id, {'title': None, 'author': None})
+                info = details_map.get(item_id, {'title': None, 'author': None, 'album': None})
                 candidate_data.append({
                     "item_id": item_id,
                     "vector": vector,
                     "dist_anchor": dist_to_anchor,
                     "title": info.get('title'),
-                    "author": info.get('author')
+                    "author": info.get('author'),
+                    "album": info.get('album')
                 })
             
     logger.info(f"Radius walk: pre-calculated vectors and distances for {len(candidate_data)} candidates.")
@@ -960,6 +961,17 @@ def _execute_radius_walk(
     # rule until the global per-artist cap (MAX_SONGS_PER_ARTIST) is reached.
     artist_bucket_counts = {}
 
+    # Track per-album counts during the walk for a flat global per-album cap
+    # (MAX_SONGS_PER_ALBUM). Unlike the artist rule there is no per-bucket nuance:
+    # an album simply may not exceed the global cap across the whole walk.
+    album_counts = {}
+    try:
+        first_album = first_song.get('album')
+        if first_album:
+            album_counts[first_album] = album_counts.get(first_album, 0) + 1
+    except Exception:
+        pass
+
     # --- Step 3: Iteratively build the playlist (Greedy, low-cost scanning) ---
 
     # Optimization: instead of computing distances for many candidates each iteration,
@@ -1043,6 +1055,11 @@ def _execute_radius_walk(
                         return False
                     if artist_counts.get(author, 0) >= MAX_SONGS_PER_ARTIST:
                         return False
+            # Enforce flat global album cap. Treat MAX_SONGS_PER_ALBUM <= 0 as DISABLED.
+            if eliminate_duplicates and MAX_SONGS_PER_ALBUM is not None and MAX_SONGS_PER_ALBUM > 0:
+                album = items[i].get('album')
+                if album and album_counts.get(album, 0) >= MAX_SONGS_PER_ALBUM:
+                    return False
             return True
 
         # Try to accept start index, otherwise mark it unavailable and find next
@@ -1068,6 +1085,9 @@ def _execute_radius_walk(
                     if a not in bucket_artist_set:
                         bucket_artist_set.add(a)
                         artist_bucket_counts[a] = artist_bucket_counts.get(a, 0) + 1
+                alb = items[cur_idx].get('album')
+                if alb:
+                    album_counts[alb] = album_counts.get(alb, 0) + 1
         else:
             remaining[cur_idx] = False
 
@@ -1118,6 +1138,13 @@ def _execute_radius_walk(
                             if INSTRUMENT_BUCKET_SKIPS:
                                 logger.debug(f"Bucket {bucket_index}: skipping idx={i} artist-cap {auth}")
                             continue
+                # Flat global album cap check (only enforce if positive cap configured)
+                if eliminate_duplicates and MAX_SONGS_PER_ALBUM is not None and MAX_SONGS_PER_ALBUM > 0:
+                    alb = meta.get('album')
+                    if alb and album_counts.get(alb, 0) >= MAX_SONGS_PER_ALBUM:
+                        if INSTRUMENT_BUCKET_SKIPS:
+                            logger.debug(f"Bucket {bucket_index}: skipping idx={i} album-cap {alb}")
+                        continue
 
                 # compute dist_prev (distance to current song) using configured metric
                 try:
@@ -1160,6 +1187,9 @@ def _execute_radius_walk(
                     if a not in bucket_artist_set:
                         bucket_artist_set.add(a)
                         artist_bucket_counts[a] = artist_bucket_counts.get(a, 0) + 1
+                alb = items[best_i].get('album')
+                if alb:
+                    album_counts[alb] = album_counts.get(alb, 0) + 1
 
             if INSTRUMENT_BUCKET_SKIPS:
                 logger.debug(f"Bucket {bucket_index}: accepted idx={best_i} item_id={cid}")
@@ -1422,31 +1452,40 @@ def find_nearest_neighbors_by_id(target_item_id: str, n: int = 10, eliminate_dup
         else:
             logger.info(f"Mood filtering skipped (mood_similarity={mood_similarity}, MOOD_SIMILARITY_ENABLE={MOOD_SIMILARITY_ENABLE})")
         
-        # 5. Apply artist cap (eliminate_duplicates)
-        if eliminate_duplicates:
-            # If MAX_SONGS_PER_ARTIST <= 0, treat as disabled and skip cap enforcement
-            if MAX_SONGS_PER_ARTIST is None or MAX_SONGS_PER_ARTIST <= 0:
-                final_results = unique_results_by_song
-            else:
-                item_ids_to_check = [r['item_id'] for r in unique_results_by_song]
-                
-                track_details_list = get_score_data_by_ids(item_ids_to_check)
-                details_map = {d['item_id']: {'author': d['author']} for d in track_details_list}
+        # 5. Apply artist + album caps (eliminate_duplicates)
+        artist_cap = MAX_SONGS_PER_ARTIST if (MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0) else 0
+        album_cap = MAX_SONGS_PER_ALBUM if (MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0) else 0
+        if eliminate_duplicates and (artist_cap or album_cap):
+            item_ids_to_check = [r['item_id'] for r in unique_results_by_song]
 
-                artist_counts = {}
-                final_results = []
-                for song in unique_results_by_song:
-                    song_id = song['item_id']
-                    author = details_map.get(song_id, {}).get('author')
+            track_details_list = get_score_data_by_ids(item_ids_to_check)
+            details_map = {d['item_id']: {'author': d['author'], 'album': d.get('album')} for d in track_details_list}
 
+            artist_counts = {}
+            album_counts = {}
+            final_results = []
+            for song in unique_results_by_song:
+                song_id = song['item_id']
+                details = details_map.get(song_id, {})
+                author = details.get('author')
+                album = details.get('album')
+
+                # Artist cap (when enabled, songs without an author are skipped, as before)
+                if artist_cap:
                     if not author:
                         logger.warning(f"Could not find author for item_id {song_id} during artist deduplication. Skipping.")
                         continue
+                    if artist_counts.get(author, 0) >= artist_cap:
+                        continue
+                # Album cap (songs without an album are never capped)
+                if album_cap and album and album_counts.get(album, 0) >= album_cap:
+                    continue
 
-                    current_count = artist_counts.get(author, 0)
-                    if current_count < MAX_SONGS_PER_ARTIST:
-                        final_results.append(song)
-                        artist_counts[author] = current_count + 1
+                final_results.append(song)
+                if author:
+                    artist_counts[author] = artist_counts.get(author, 0) + 1
+                if album:
+                    album_counts[album] = album_counts.get(album, 0) + 1
         else:
             final_results = unique_results_by_song
 
@@ -1545,21 +1584,35 @@ def find_nearest_neighbors_by_vector(query_vector: np.ndarray, n: int = 100, eli
             added_songs_details.append(current_details)
 
     if eliminate_duplicates:
-        # If MAX_SONGS_PER_ARTIST <= 0, treat as disabled and skip cap enforcement
-        if MAX_SONGS_PER_ARTIST is None or MAX_SONGS_PER_ARTIST <= 0:
+        # Per-artist and per-album caps. Treat each <= 0 (or None) as DISABLED.
+        artist_cap = MAX_SONGS_PER_ARTIST if (MAX_SONGS_PER_ARTIST and MAX_SONGS_PER_ARTIST > 0) else 0
+        album_cap = MAX_SONGS_PER_ALBUM if (MAX_SONGS_PER_ALBUM and MAX_SONGS_PER_ALBUM > 0) else 0
+        if not artist_cap and not album_cap:
             final_results = unique_songs_by_content
         else:
             artist_counts = {}
+            album_counts = {}
             final_results = []
             for song in unique_songs_by_content:
-                author = item_details.get(song['item_id'], {}).get('author')
-                if not author:
+                details = item_details.get(song['item_id'], {})
+                author = details.get('author')
+                album = details.get('album')
+
+                # Artist cap (when enabled, songs without an author are skipped, as before)
+                if artist_cap:
+                    if not author:
+                        continue
+                    if artist_counts.get(author, 0) >= artist_cap:
+                        continue
+                # Album cap (songs without an album are never capped)
+                if album_cap and album and album_counts.get(album, 0) >= album_cap:
                     continue
 
-                current_count = artist_counts.get(author, 0)
-                if current_count < MAX_SONGS_PER_ARTIST:
-                    final_results.append(song)
-                    artist_counts[author] = current_count + 1
+                final_results.append(song)
+                if author:
+                    artist_counts[author] = artist_counts.get(author, 0) + 1
+                if album:
+                    album_counts[album] = album_counts.get(album, 0) + 1
     else:
         final_results = unique_songs_by_content
 

--- a/tests/unit/test_sem_grove_manager.py
+++ b/tests/unit/test_sem_grove_manager.py
@@ -352,6 +352,52 @@ class TestSearchBySong:
         neighbours = [r for r in results if not r.get("is_seed")]
         assert len(neighbours) <= 1
 
+    def test_album_cap_respected(self):
+        """When album cap = 2, no album should appear more than twice (mirrors artist cap)."""
+        from tasks.sem_grove_manager import search_by_song
+
+        n = 20
+        cache, _ = self._build_cache(n)
+        seed = "song-0"
+
+        # Every song has a DISTINCT artist (so the artist cap is irrelevant) but
+        # they all share the same album, to stress-test the album cap in isolation.
+        def same_album_fetch(item_ids):
+            return {iid: {"title": f"Title {iid}", "author": f"Artist {iid}", "album": "Same Album"} for iid in item_ids}
+
+        with patch("tasks.sem_grove_manager._SEM_GROVE_CACHE", cache), \
+             patch("tasks.sem_grove_manager._fetch_metadata", side_effect=same_album_fetch), \
+             patch("config.MAX_SONGS_PER_ARTIST", 0), \
+             patch("config.MAX_SONGS_PER_ALBUM", 2), \
+             patch("config.DUPLICATE_DISTANCE_THRESHOLD_COSINE", 0.0), \
+             patch("config.DUPLICATE_DISTANCE_CHECK_LOOKBACK", 0):
+            results = search_by_song(seed, limit=10)
+
+        neighbours = [r for r in results if not r.get("is_seed")]
+        assert len(neighbours) <= 2
+
+    def test_album_cap_disabled_by_default(self):
+        """With album cap = 0 (default) the per-album limit must not fire."""
+        from tasks.sem_grove_manager import search_by_song
+
+        n = 20
+        cache, _ = self._build_cache(n)
+        seed = "song-0"
+
+        def same_album_fetch(item_ids):
+            return {iid: {"title": f"Title {iid}", "author": f"Artist {iid}", "album": "Same Album"} for iid in item_ids}
+
+        with patch("tasks.sem_grove_manager._SEM_GROVE_CACHE", cache), \
+             patch("tasks.sem_grove_manager._fetch_metadata", side_effect=same_album_fetch), \
+             patch("config.MAX_SONGS_PER_ARTIST", 0), \
+             patch("config.MAX_SONGS_PER_ALBUM", 0), \
+             patch("config.DUPLICATE_DISTANCE_THRESHOLD_COSINE", 0.0), \
+             patch("config.DUPLICATE_DISTANCE_CHECK_LOOKBACK", 0):
+            results = search_by_song(seed, limit=10)
+
+        neighbours = [r for r in results if not r.get("is_seed")]
+        assert len(neighbours) > 2
+
     def test_name_deduplication_removes_same_title_artist(self):
         """Two entries with identical (title, author) must be deduplicated."""
         from tasks.sem_grove_manager import search_by_song

--- a/tests/unit/test_sonic_fingerprint_manager.py
+++ b/tests/unit/test_sonic_fingerprint_manager.py
@@ -510,9 +510,87 @@ class TestEdgeCases:
         ]
         
         result = generate_sonic_fingerprint(num_neighbors=10)
-        
+
         # Should have exactly 10 results
         assert len(result) == 10
+
+
+class TestAlbumCap:
+    """Test the MAX_SONGS_PER_ALBUM cap on the final fingerprint playlist.
+
+    This cap is special: unlike the per-artist/album cap inside the Voyager
+    neighbor search, it ALSO covers the seed songs (top-played tracks), which
+    are otherwise added uncapped.
+    """
+
+    @patch('tasks.sonic_fingerprint_manager.get_top_played_songs')
+    @patch('app_helper.get_tracks_by_ids')
+    @patch('tasks.sonic_fingerprint_manager.get_last_played_time')
+    @patch('tasks.sonic_fingerprint_manager.find_nearest_neighbors_by_vector')
+    def test_seed_songs_from_same_album_are_capped(self, mock_voyager, mock_last_played, mock_get_tracks, mock_top_songs):
+        """5 seed songs from one album, cap=2 -> only 2 survive."""
+        mock_top_songs.return_value = [{'Id': f's{i}'} for i in range(5)]
+        mock_get_tracks.return_value = [
+            {'item_id': f's{i}', 'embedding_vector': np.array([1.0, 0.0]), 'album': 'Mix CD'}
+            for i in range(5)
+        ]
+        mock_last_played.return_value = None
+        mock_voyager.return_value = []  # isolate the seed cap
+
+        with patch('config.MAX_SONGS_PER_ALBUM', 2):
+            result = generate_sonic_fingerprint(num_neighbors=10)
+
+        assert len(result) == 2
+
+    @patch('tasks.sonic_fingerprint_manager.get_top_played_songs')
+    @patch('app_helper.get_tracks_by_ids')
+    @patch('tasks.sonic_fingerprint_manager.get_last_played_time')
+    @patch('tasks.sonic_fingerprint_manager.find_nearest_neighbors_by_vector')
+    def test_disabled_by_default_keeps_all_same_album_seeds(self, mock_voyager, mock_last_played, mock_get_tracks, mock_top_songs):
+        """With the default cap (0) all 5 same-album seeds are kept."""
+        mock_top_songs.return_value = [{'Id': f's{i}'} for i in range(5)]
+        mock_get_tracks.return_value = [
+            {'item_id': f's{i}', 'embedding_vector': np.array([1.0, 0.0]), 'album': 'Mix CD'}
+            for i in range(5)
+        ]
+        mock_last_played.return_value = None
+        mock_voyager.return_value = []
+
+        with patch('config.MAX_SONGS_PER_ALBUM', 0):
+            result = generate_sonic_fingerprint(num_neighbors=10)
+
+        assert len(result) == 5
+
+    @patch('tasks.sonic_fingerprint_manager.get_top_played_songs')
+    @patch('app_helper.get_tracks_by_ids')
+    @patch('app_helper.get_score_data_by_ids')
+    @patch('tasks.sonic_fingerprint_manager.get_last_played_time')
+    @patch('tasks.sonic_fingerprint_manager.find_nearest_neighbors_by_vector')
+    def test_cap_is_global_across_seeds_and_neighbors(self, mock_voyager, mock_last_played, mock_get_score, mock_get_tracks, mock_top_songs):
+        """1 seed + neighbors all from one album, cap=2 -> seed + 1 neighbor only."""
+        mock_top_songs.return_value = [{'Id': 's0'}]
+        mock_get_tracks.return_value = [
+            {'item_id': 's0', 'embedding_vector': np.array([1.0, 0.0]), 'album': 'Mix CD'}
+        ]
+        mock_last_played.return_value = None
+        mock_voyager.return_value = [
+            {'item_id': 'n1', 'distance': 0.1},
+            {'item_id': 'n2', 'distance': 0.2},
+            {'item_id': 'n3', 'distance': 0.3},
+        ]
+        # All neighbors are from the SAME album as the seed
+        mock_get_score.return_value = [
+            {'item_id': 'n1', 'album': 'Mix CD'},
+            {'item_id': 'n2', 'album': 'Mix CD'},
+            {'item_id': 'n3', 'album': 'Mix CD'},
+        ]
+
+        with patch('config.MAX_SONGS_PER_ALBUM', 2):
+            result = generate_sonic_fingerprint(num_neighbors=10)
+
+        # seed counts toward the budget, so only 1 neighbor is allowed
+        assert len(result) == 2
+        assert result[0]['item_id'] == 's0'
 
 
 


### PR DESCRIPTION
## AS-IS
No max album for sonic fingerprint

## TO-BE
Adds a per-album cap analogous to MAX_SONGS_PER_ARTIST, enforced across the same sites: similarity (Voyager vector/id search + greedy walk), clustering, song paths, CLAP text search, lyrics search, and SemGrove. Off by default (0 = disabled) so existing playlists are unchanged.

Also caps same-album tracks in Sonic Fingerprint, including the top-played seed songs (which bypass the in-search caps). The cap is enforced globally across seeds + neighbors so the playlist truly respects the limit; neighbors are over-requested when the cap is active to avoid short playlists when seeds get dropped.

The per-artist cap keys on track artist, so it cannot limit a compilation / DJ-mix where every track has a different artist, which is why a per-album cap is needed.

## Test
still testing

## Other useful information


## Checklist


**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [x] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [x] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [x] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #525
