### PR TITLE
Safe mediaserver emby and jellyfin check added

### DIFF
--- a/tasks/mediaserver_emby.py
+++ b/tasks/mediaserver_emby.py
@@ -195,7 +195,7 @@ def _get_recent_standalone_tracks(limit, target_library_ids=None, user_creds=Non
                 r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                 r.raise_for_status()
                 response_data = r.json()
-                tracks_on_page = response_data.get("Items", [])
+                tracks_on_page = response_data.get("Items") or []
                 
                 if not tracks_on_page:
                     break
@@ -252,7 +252,7 @@ def _get_recent_standalone_tracks(limit, target_library_ids=None, user_creds=Non
                     r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                     r.raise_for_status()
                     response_data = r.json()
-                    tracks_on_page = response_data.get("Items", [])
+                    tracks_on_page = response_data.get("Items") or []
                     
                     if not tracks_on_page:
                         break
@@ -336,7 +336,7 @@ def _get_recent_albums_only(limit, user_creds=None):
                 r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                 r.raise_for_status()
                 response_data = r.json()
-                albums_on_page = response_data.get("Items", [])
+                albums_on_page = response_data.get("Items") or []
                 
                 if not albums_on_page:
                     break
@@ -367,7 +367,7 @@ def _get_recent_albums_only(limit, user_creds=None):
                     r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                     r.raise_for_status()
                     response_data = r.json()
-                    albums_on_page = response_data.get("Items", [])
+                    albums_on_page = response_data.get("Items") or []
                     
                     if not albums_on_page:
                         break
@@ -479,7 +479,7 @@ def get_tracks_from_album(album_id, user_creds=None):
     try:
         r = requests.get(url, headers=_emby_headers_from_creds(user_creds), params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
 
         # Apply artist field prioritization to each track
         for item in items:
@@ -578,7 +578,7 @@ def get_all_songs(user_creds=None):
         try:
             r = requests.get(url, headers=_emby_headers_from_creds(user_creds), params=params, timeout=REQUESTS_TIMEOUT)
             r.raise_for_status()
-            items = r.json().get("Items", [])
+            items = r.json().get("Items") or []
 
             # Apply artist field prioritization
             for item in items:
@@ -622,7 +622,7 @@ def search_albums(query, user_creds=None):
     try:
         r = requests.get(url, headers=_emby_headers_from_creds(user_creds), params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", []) or []
+        items = r.json().get("Items") or []
         return [
             {
                 'id':          item.get('Id'),
@@ -686,7 +686,7 @@ def get_playlist_by_name(playlist_name, user_creds=None):
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        playlists = r.json().get("Items", [])
+        playlists = r.json().get("Items") or []
 
         # Filter manually by name (case-sensitive exact match)
         for playlist in playlists:
@@ -766,7 +766,7 @@ def get_all_playlists(user_creds=None):
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        return r.json().get("Items", [])
+        return r.json().get("Items") or []
     except Exception as e:
         logger.error(f"Emby get_all_playlists failed: {e}", exc_info=True)
         return []
@@ -805,7 +805,7 @@ def get_top_played_songs(limit, user_creds=None):
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
 
         # Apply artist field prioritization to each track
         for item in items:
@@ -930,7 +930,7 @@ def _get_playlist_entry_ids(playlist_id, user_id, headers):
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
         entry_ids = [it.get("PlaylistItemId") for it in items if it.get("PlaylistItemId")]
         if len(entry_ids) != len(items):
             logger.warning(

--- a/tasks/mediaserver_jellyfin.py
+++ b/tasks/mediaserver_jellyfin.py
@@ -171,7 +171,7 @@ def get_recent_albums(limit):
                 r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                 r.raise_for_status()
                 response_data = r.json()
-                albums_on_page = response_data.get("Items", [])
+                albums_on_page = response_data.get("Items") or []
                 
                 if not albums_on_page:
                     break
@@ -202,7 +202,7 @@ def get_recent_albums(limit):
                     r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
                     r.raise_for_status()
                     response_data = r.json()
-                    albums_on_page = response_data.get("Items", [])
+                    albums_on_page = response_data.get("Items") or []
                     
                     if not albums_on_page:
                         break
@@ -238,7 +238,7 @@ def get_tracks_from_album(album_id, user_creds=None):
     try:
         r = requests.get(url, headers=_jellyfin_headers_from_creds(user_creds), params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
 
         # Apply artist field prioritization to each track
         for item in items:
@@ -385,7 +385,7 @@ def search_albums(query, user_creds=None):
     try:
         r = requests.get(url, headers=_jellyfin_headers_from_creds(user_creds), params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", []) or []
+        items = r.json().get("Items") or []
         return [
             {
                 'id':          item.get('Id'),
@@ -450,7 +450,7 @@ def get_playlist_by_name(playlist_name):
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        playlists = r.json().get("Items", [])
+        playlists = r.json().get("Items") or []
         for playlist in playlists:
             if playlist.get("Name") == playlist_name:
                 return playlist
@@ -476,7 +476,7 @@ def get_all_playlists():
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        return r.json().get("Items", [])
+        return r.json().get("Items") or []
     except Exception as e:
         logger.error(f"Jellyfin get_all_playlists failed: {e}", exc_info=True)
         return []
@@ -505,7 +505,7 @@ def get_top_played_songs(limit, user_creds=None):
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
 
         # Apply artist field prioritization to each item
         for item in items:
@@ -604,7 +604,7 @@ def _get_playlist_entry_ids(playlist_id):
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
-        items = r.json().get("Items", [])
+        items = r.json().get("Items") or []
         entry_ids = [it.get("PlaylistItemId") for it in items if it.get("PlaylistItemId")]
         if len(entry_ids) != len(items):
             logger.warning(


### PR DESCRIPTION
Harden Jellyfin and Emby media server clients against null API responses. When the server returns {"Items": null}, .get("Items", []) yielded None, crashing the subsequent iteration with a TypeError. Replaced every occurrence with .get("Items") or [] across both files (20 sites), coercing missing or null values to an empty list.

<!-- macos-test-build:start -->
### PR test image:
- MacOS Public download: [AudioMuse-AI-arm64.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/26835609447/AudioMuse-AI-arm64.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:build-arm64-pr-600`
- Docker image noavx2: `ghcr.io/neptunehub/audiomuse-ai:pr-600-noavx2`
- Docker image nvidia: `ghcr.io/neptunehub/audiomuse-ai:pr-600-nvidia`
<!-- macos-test-build:end -->