### PR TITLE
docs: Duplicate authentication parameter tables and typos in PARAMETERS.md

### DIFF
--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -39,20 +39,10 @@ The **mandatory** parameter that you need to change from the example are this:
 | `OPENAI_API_KEY`     | (Required if `AI_MODEL_PROVIDER` is OPENAI) Your OpenAI / OpenRouter API Key. | *(N/A - from Secret)* |
 | **AudioMuse-AI Authentication**                        |                                                                 |                 |
 | `AUTH_ENABLED`     | Enable the AudioMuse-AI authentication layer | `true`|
-| `AUDIOMUSE_USER`    | User to login on the AudioMuse-AI integrated frontned     | *(N/A - from Secret)* |
-| `AUDIOMUSE_PASSWORD`     | Password to login on the AudioMuse-AI integrated frontned   | *(N/A - from Secret)* |
-| `API_TOKEN`     | API_TOLEN for plugin authentication | *(N/A - from Secret)* |
-| `JWT_SECRET`     | Used to inizializate the JWT session with a predefined value | *from Secret OR automatically created if blank* |
-
-The following additional parameter control authentication.  Leave
-all four empty to disable auth (default).
-
-| Parameter            | Description                                          | Default |
-|----------------------|------------------------------------------------------|---------|
-| `AUDIOMUSE_USER`     | Username for web UI login                            | ``      |
-| `AUDIOMUSE_PASSWORD` | Password for web UI login                            | ``      |
-| `API_TOKEN`          | Bearer token for API/worker requests                 | ``      |
-| `JWT_SECRET`         | HMAC key used to sign session JWTs                   | ``      |
+| `AUDIOMUSE_USER`    | Username for web UI login     | *(N/A - from Secret)* |
+| `AUDIOMUSE_PASSWORD`     | Password for web UI login   | *(N/A - from Secret)* |
+| `API_TOKEN`     | Bearer token for API/worker requests | *(N/A - from Secret)* |
+| `JWT_SECRET`     | HMAC key used to sign session JWTs | *from Secret OR automatically created if blank* |
 
 
 These parameters can be left as-is:


### PR DESCRIPTION
 While reading through the configuration guide, I noticed that the Authentication parameters (AUDIOMUSE_USER, AUDIOMUSE_PASSWORD, API_TOKEN, JWT_SECRET) are documented twice in consecutive tables in docs/PARAMETERS.md (around line 40).

Furthermore, the first instance of this table contains several typos:

"frontned" instead of "frontend" (repeated twice)
"API_TOLEN" instead of "API_TOKEN"
"inizializate" instead of "initialize"
This duplication can cause confusion regarding the default values (one lists "" while the other lists *(N/A - from Secret)*). I propose consolidating these into a single table utilizing the corrected text to ensure a smooth setup experience for new users. I can open a small PR to address this if it sounds good.