### PR TITLE
Feature/swappable sonic backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -413,6 +413,9 @@ RUN set -ux; \
 FROM base AS libraries
 
 ARG BASE_IMAGE
+# Set to 1 to bundle PyTorch + MERT-backend dependencies into the image.
+# Required when SONIC_BACKEND=mert at runtime. Adds ~700 MB on CPU.
+ARG INSTALL_MERT=0
 
 WORKDIR /app
 
@@ -429,6 +432,10 @@ RUN if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then \
     else \
         echo "CPU base image: installing all packages together for dependency resolution"; \
         uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/cpu.txt -r /app/requirements/common.txt || exit 1; \
+    fi \
+    && if [ "$INSTALL_MERT" = "1" ]; then \
+        echo "INSTALL_MERT=1: adding torch + MERT runtime deps"; \
+        uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/mert.txt || exit 1; \
     fi \
     && echo "Verifying psycopg2 installation..." \
     && python3 -c "import psycopg2; print('psycopg2 OK')" \

--- a/app.py
+++ b/app.py
@@ -739,6 +739,17 @@ def listen_for_index_reloads():
               logger.warning(f"SemGrove cache reload failed: {e}")
               sg_success = False
 
+            # Invalidate the per-backend mood centroid cache so the next
+            # request picks up the freshly-rebuilt rows from
+            # mood_centroids_data. Cheap rebuild — handful of JSONB rows.
+            try:
+              import app_voyager as _av
+              _av._mood_centroids_loaded = False
+              _av._MOOD_CENTROIDS_DATA.clear()
+              _av._MOOD_CENTROIDS_META.clear()
+            except Exception as e:
+              logger.warning(f"Mood centroid cache invalidation failed: {e}")
+
             logger.info(f"In-memory reload complete: Voyager ✓, Artist ✓, Maps ✓, CLAP {'✓' if clap_success else '✗'}, Lyrics {'✓' if lyrics_success else '✗'}, SemGrove {'✓' if sg_success else '✗'}")
           except Exception as e:
             logger.error(f"Error reloading indexes/maps from background listener: {e}", exc_info=True)

--- a/app_analysis.py
+++ b/app_analysis.py
@@ -176,42 +176,37 @@ def start_cleaning_endpoint():
 
 @analysis_bp.route('/api/cleaning/sonic_state', methods=['GET'])
 def sonic_state_endpoint():
-    """Report current vs stored sonic-backend embedding state.
+    """Report per-backend embedding + Voyager state for the Cleaning UI.
 
-    Used by the Cleaning UI to surface a "stale audio embeddings" panel
-    after a ``SONIC_BACKEND`` change. The body is exactly whatever
-    ``tasks.cleaning.inspect_sonic_state`` returns:
-    ``current_backend``, ``current_dim``, ``embedding_row_count``,
-    ``sample_stored_dim``, ``voyager_row_count``, ``stored_voyager_dim``,
-    ``mismatch``.
+    Body shape (see ``tasks.cleaning.inspect_sonic_state``):
+    ``active_backend``, ``active_dim``, and a ``backends`` list with
+    one row per backend that has stored data (plus the active one).
+    Each row carries ``embedding_row_count``, ``sample_stored_dim``,
+    ``voyager_row_count``, ``stored_voyager_dim``, and ``is_active``.
     ---
     tags:
       - Cleaning
     responses:
       200:
-        description: Sonic state snapshot.
-      500:
-        description: Database error while inspecting state.
+        description: Per-backend sonic state snapshot.
     """
     from tasks.cleaning import inspect_sonic_state
-    state = inspect_sonic_state()
-    return jsonify(state), 200
+    return jsonify(inspect_sonic_state()), 200
 
 
 @analysis_bp.route('/api/cleaning/sonic_state/clear', methods=['POST'])
 def sonic_state_clear_endpoint():
-    """Wipe stored audio embeddings + Voyager audio index rows.
+    """Drop one inactive backend's audio embeddings + Voyager index.
 
-    Destructive: every row in ``embedding`` is deleted, the audio
-    Voyager index rows are dropped, and the backend-derived columns on
-    ``score`` (tempo / key / scale / energy / mood_vector /
-    other_features) are nulled. CLAP embeddings, lyrics, artist data,
-    playlists, config and task history are untouched.
+    Removes only the ``embedding`` rows whose ``backend`` column equals
+    the supplied value and the matching ``voyager_index_data`` rows
+    (single or segmented). The active ``SONIC_BACKEND`` is protected —
+    switching ``SONIC_BACKEND`` first is required to clear it.
+    Untouched: CLAP / lyrics / artist data, playlists, app_config,
+    task history, score rows.
 
-    Requires the body to include ``{"confirm": true}`` so a stray
-    fetch can't drop the table. Runs synchronously — the operation is
-    one DELETE + one UPDATE and finishes in seconds even on a 100k+
-    track library.
+    Body: ``{"backend": "musicnn", "confirm": true}``. The confirm flag
+    is required so a stray fetch can't drop the table.
     ---
     tags:
       - Cleaning
@@ -222,27 +217,35 @@ def sonic_state_clear_endpoint():
           schema:
             type: object
             properties:
+              backend:
+                type: string
               confirm:
                 type: boolean
     responses:
       200:
-        description: Cleared. Body lists the row counts removed/nulled.
+        description: Cleared. Body returns the summary + refreshed state.
       400:
-        description: Missing/false confirmation flag.
+        description: Missing/invalid backend, missing confirmation, or
+                     attempt to clear the active backend.
       500:
         description: Database error during cleanup.
     """
     data = request.json or {}
+    backend = (data.get('backend') or '').strip()
+    if not backend:
+        return jsonify({"error": "Missing 'backend' field."}), 400
     if not data.get('confirm') is True:
         return jsonify({
             "error": "Refusing to clear without explicit confirmation.",
-            "hint": 'POST {"confirm": true} to proceed.',
+            "hint": 'POST {"backend": "<name>", "confirm": true} to proceed.',
         }), 400
 
-    from tasks.cleaning import clear_sonic_audio_state, inspect_sonic_state
+    from tasks.cleaning import clear_inactive_backend_data, inspect_sonic_state
     try:
-        summary = clear_sonic_audio_state()
+        summary = clear_inactive_backend_data(backend)
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
-        logger.error("clear_sonic_audio_state failed: %s", e, exc_info=True)
+        logger.error("clear_inactive_backend_data failed: %s", e, exc_info=True)
         return jsonify({"error": str(e)}), 500
     return jsonify({"summary": summary, "state": inspect_sonic_state()}), 200

--- a/app_analysis.py
+++ b/app_analysis.py
@@ -172,3 +172,77 @@ def start_cleaning_endpoint():
         job_timeout=-1 # No timeout
     )
     return jsonify({"task_id": job.id, "task_type": "cleaning", "status": job.get_status()}), 202
+
+
+@analysis_bp.route('/api/cleaning/sonic_state', methods=['GET'])
+def sonic_state_endpoint():
+    """Report current vs stored sonic-backend embedding state.
+
+    Used by the Cleaning UI to surface a "stale audio embeddings" panel
+    after a ``SONIC_BACKEND`` change. The body is exactly whatever
+    ``tasks.cleaning.inspect_sonic_state`` returns:
+    ``current_backend``, ``current_dim``, ``embedding_row_count``,
+    ``sample_stored_dim``, ``voyager_row_count``, ``stored_voyager_dim``,
+    ``mismatch``.
+    ---
+    tags:
+      - Cleaning
+    responses:
+      200:
+        description: Sonic state snapshot.
+      500:
+        description: Database error while inspecting state.
+    """
+    from tasks.cleaning import inspect_sonic_state
+    state = inspect_sonic_state()
+    return jsonify(state), 200
+
+
+@analysis_bp.route('/api/cleaning/sonic_state/clear', methods=['POST'])
+def sonic_state_clear_endpoint():
+    """Wipe stored audio embeddings + Voyager audio index rows.
+
+    Destructive: every row in ``embedding`` is deleted, the audio
+    Voyager index rows are dropped, and the backend-derived columns on
+    ``score`` (tempo / key / scale / energy / mood_vector /
+    other_features) are nulled. CLAP embeddings, lyrics, artist data,
+    playlists, config and task history are untouched.
+
+    Requires the body to include ``{"confirm": true}`` so a stray
+    fetch can't drop the table. Runs synchronously — the operation is
+    one DELETE + one UPDATE and finishes in seconds even on a 100k+
+    track library.
+    ---
+    tags:
+      - Cleaning
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              confirm:
+                type: boolean
+    responses:
+      200:
+        description: Cleared. Body lists the row counts removed/nulled.
+      400:
+        description: Missing/false confirmation flag.
+      500:
+        description: Database error during cleanup.
+    """
+    data = request.json or {}
+    if not data.get('confirm') is True:
+        return jsonify({
+            "error": "Refusing to clear without explicit confirmation.",
+            "hint": 'POST {"confirm": true} to proceed.',
+        }), 400
+
+    from tasks.cleaning import clear_sonic_audio_state, inspect_sonic_state
+    try:
+        summary = clear_sonic_audio_state()
+    except Exception as e:
+        logger.error("clear_sonic_audio_state failed: %s", e, exc_info=True)
+        return jsonify({"error": str(e)}), 500
+    return jsonify({"summary": summary, "state": inspect_sonic_state()}), 200

--- a/app_analysis.py
+++ b/app_analysis.py
@@ -234,7 +234,7 @@ def sonic_state_clear_endpoint():
     backend = (data.get('backend') or '').strip()
     if not backend:
         return jsonify({"error": "Missing 'backend' field."}), 400
-    if not data.get('confirm') is True:
+    if data.get('confirm') is not True:
         return jsonify({
             "error": "Refusing to clear without explicit confirmation.",
             "hint": 'POST {"backend": "<name>", "confirm": true} to proceed.',
@@ -246,6 +246,6 @@ def sonic_state_clear_endpoint():
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
     except Exception as e:
-        logger.error("clear_inactive_backend_data failed: %s", e, exc_info=True)
+        logger.exception("clear_inactive_backend_data failed: %s", e)
         return jsonify({"error": str(e)}), 500
     return jsonify({"summary": summary, "state": inspect_sonic_state()}), 200

--- a/app_external.py
+++ b/app_external.py
@@ -100,7 +100,11 @@ def get_embedding_endpoint():
     try:
         db = get_db()
         cur = db.cursor(cursor_factory=DictCursor)
-        cur.execute("SELECT * FROM embedding WHERE item_id = %s", (item_id,))
+        from tasks.sonic_backends import active_backend_name
+        cur.execute(
+            "SELECT * FROM embedding WHERE item_id = %s AND backend = %s",
+            (item_id, active_backend_name()),
+        )
         embedding_data = cur.fetchone()
         cur.close()
 

--- a/app_helper.py
+++ b/app_helper.py
@@ -280,6 +280,21 @@ def init_db():
             if not cur.fetchone()[0]: cur.execute("ALTER TABLE clap_embedding ADD COLUMN embedding BYTEA")
             # Create 'voyager_index_data' table
             cur.execute("CREATE TABLE IF NOT EXISTS voyager_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+            # Per-backend mood centroids derived from each backend's own
+            # embeddings + score.other_features. Replaces the static
+            # mood_centroids_real_080_clap.json — which was frozen against
+            # 200-dim MusiCNN — so the Similarity/Alchemy/Path features
+            # work for any active SONIC_BACKEND.
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS mood_centroids_data (
+                    backend       TEXT NOT NULL,
+                    mood          TEXT NOT NULL,
+                    centroids     JSONB NOT NULL,
+                    embedding_dim INTEGER NOT NULL,
+                    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (backend, mood)
+                )
+            """)
             # Voyager index names are now namespaced per sonic backend
             # (e.g. ``music_library_musicnn``, ``music_library_mert``).
             # Rename any legacy bare-named rows ('music_library' and its

--- a/app_helper.py
+++ b/app_helper.py
@@ -238,10 +238,33 @@ def init_db():
                     note TEXT
                 )
             """)
-            # Create 'embedding' table
-            cur.execute("CREATE TABLE IF NOT EXISTS embedding (item_id TEXT PRIMARY KEY, FOREIGN KEY (item_id) REFERENCES score (item_id) ON DELETE CASCADE)")
+            # Create 'embedding' table. Composite (item_id, backend) primary
+            # key so each sonic backend stores its own embedding alongside
+            # the others — switching SONIC_BACKEND no longer destroys the
+            # outgoing backend's data.
+            cur.execute("CREATE TABLE IF NOT EXISTS embedding (item_id TEXT, FOREIGN KEY (item_id) REFERENCES score (item_id) ON DELETE CASCADE)")
             cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'embedding' AND column_name = 'embedding')")
             if not cur.fetchone()[0]: cur.execute("ALTER TABLE embedding ADD COLUMN embedding BYTEA")
+            # backend column: pre-existing rows were all written by MusiCNN
+            # (the only backend before this column existed), so backfill with
+            # 'musicnn'. New rows always carry the producing backend name.
+            cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'embedding' AND column_name = 'backend')")
+            if not cur.fetchone()[0]:
+                cur.execute("ALTER TABLE embedding ADD COLUMN backend TEXT NOT NULL DEFAULT 'musicnn'")
+                logger.info("Added 'backend' column to embedding table (backfilled to 'musicnn')")
+            # Composite PK on (item_id, backend). If the legacy single-column
+            # PK is still in place, swap it.
+            cur.execute("""
+                SELECT a.attname FROM pg_index i
+                JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
+                WHERE i.indrelid = 'embedding'::regclass AND i.indisprimary
+                ORDER BY a.attname
+            """)
+            pk_cols = sorted(r[0] for r in cur.fetchall())
+            if pk_cols == ['item_id']:
+                cur.execute("ALTER TABLE embedding DROP CONSTRAINT IF EXISTS embedding_pkey")
+                cur.execute("ALTER TABLE embedding ADD PRIMARY KEY (item_id, backend)")
+                logger.info("Migrated embedding PK from (item_id) to (item_id, backend)")
             # Create 'lyrics_embedding' table for lyrics similarity and axis scores
             cur.execute("CREATE TABLE IF NOT EXISTS lyrics_embedding (item_id TEXT PRIMARY KEY, FOREIGN KEY (item_id) REFERENCES score (item_id) ON DELETE CASCADE)")
             cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'lyrics_embedding' AND column_name = 'embedding')")
@@ -257,6 +280,34 @@ def init_db():
             if not cur.fetchone()[0]: cur.execute("ALTER TABLE clap_embedding ADD COLUMN embedding BYTEA")
             # Create 'voyager_index_data' table
             cur.execute("CREATE TABLE IF NOT EXISTS voyager_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
+            # Voyager index names are now namespaced per sonic backend
+            # (e.g. ``music_library_musicnn``, ``music_library_mert``).
+            # Rename any legacy bare-named rows ('music_library' and its
+            # segmented form 'music_library_<part>_<total>') to the musicnn
+            # namespace so existing data is preserved without colliding with
+            # a freshly-built index from a different backend.
+            from config import INDEX_NAME as _LEGACY_INDEX_NAME
+            cur.execute(
+                "UPDATE voyager_index_data SET index_name = %s "
+                "WHERE index_name = %s",
+                (f"{_LEGACY_INDEX_NAME}_musicnn", _LEGACY_INDEX_NAME),
+            )
+            if cur.rowcount:
+                logger.info(
+                    "Renamed legacy bare voyager index '%s' to '%s_musicnn'",
+                    _LEGACY_INDEX_NAME, _LEGACY_INDEX_NAME,
+                )
+            cur.execute(
+                "UPDATE voyager_index_data SET index_name = %s || regexp_replace(index_name, %s, '') "
+                "WHERE index_name ~ %s",
+                (
+                    f"{_LEGACY_INDEX_NAME}_musicnn",
+                    f"^{_LEGACY_INDEX_NAME}",
+                    f"^{_LEGACY_INDEX_NAME}_[0-9]+_[0-9]+$",
+                ),
+            )
+            if cur.rowcount:
+                logger.info("Renamed legacy segmented voyager rows under musicnn namespace")
             # Create 'clap_index_data' table for stored CLAP text search indexes
             cur.execute("CREATE TABLE IF NOT EXISTS clap_index_data (index_name VARCHAR(255) PRIMARY KEY, index_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, embedding_dimension INTEGER NOT NULL, created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)")
             # Create 'lyrics_index_data' table for stored Lyrics voyager indexes (mirrors clap_index_data; supports chunked storage).
@@ -942,13 +993,17 @@ def save_track_analysis_and_embedding(item_id, title, author, tempo, key, scale,
                 file_path = EXCLUDED.file_path
         """, (item_id, title, author, tempo, key, scale, mood_str, energy, other_features, album, album_artist, year, rating, file_path))
 
-        # Save embedding
+        # Save embedding under the active sonic backend's namespace.
+        # Composite (item_id, backend) PK lets every backend keep its
+        # own embedding row alongside the others, so switching
+        # SONIC_BACKEND does not destroy the previous backend's data.
         if isinstance(embedding_vector, np.ndarray) and embedding_vector.size > 0:
+            from tasks.sonic_backends import active_backend_name
             embedding_blob = embedding_vector.astype(np.float32).tobytes()
             cur.execute("""
-                INSERT INTO embedding (item_id, embedding) VALUES (%s, %s)
-                ON CONFLICT (item_id) DO UPDATE SET embedding = EXCLUDED.embedding
-            """, (item_id, psycopg2.Binary(embedding_blob)))
+                INSERT INTO embedding (item_id, backend, embedding) VALUES (%s, %s, %s)
+                ON CONFLICT (item_id, backend) DO UPDATE SET embedding = EXCLUDED.embedding
+            """, (item_id, active_backend_name(), psycopg2.Binary(embedding_blob)))
 
         conn.commit()
     except Exception as e:
@@ -1043,13 +1098,14 @@ def get_tracks_by_ids(item_ids_list):
     # Convert item_ids to strings to match the text type in database
     item_ids_str = [str(item_id) for item_id in item_ids_list]
     
+    from tasks.sonic_backends import active_backend_name
     query = """
         SELECT s.item_id, s.title, s.author, s.album, s.album_artist, s.tempo, s.key, s.scale, s.mood_vector, s.energy, s.other_features, s.year, s.rating, s.file_path, e.embedding
         FROM score s
-        LEFT JOIN embedding e ON s.item_id = e.item_id
+        LEFT JOIN embedding e ON s.item_id = e.item_id AND e.backend = %s
         WHERE s.item_id IN %s
     """
-    cur.execute(query, (tuple(item_ids_str),))
+    cur.execute(query, (active_backend_name(), tuple(item_ids_str)))
     rows = cur.fetchall()
     cur.close()
 

--- a/app_helper.py
+++ b/app_helper.py
@@ -252,8 +252,9 @@ def init_db():
             if not cur.fetchone()[0]:
                 cur.execute("ALTER TABLE embedding ADD COLUMN backend TEXT NOT NULL DEFAULT 'musicnn'")
                 logger.info("Added 'backend' column to embedding table (backfilled to 'musicnn')")
-            # Composite PK on (item_id, backend). If the legacy single-column
-            # PK is still in place, swap it.
+            # Composite PK on (item_id, backend). Covers both fresh installs
+            # (no PK on the CREATE TABLE above) and legacy upgrades where the
+            # single-column (item_id) PK still exists.
             cur.execute("""
                 SELECT a.attname FROM pg_index i
                 JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
@@ -261,10 +262,10 @@ def init_db():
                 ORDER BY a.attname
             """)
             pk_cols = sorted(r[0] for r in cur.fetchall())
-            if pk_cols == ['item_id']:
+            if pk_cols != ['backend', 'item_id']:
                 cur.execute("ALTER TABLE embedding DROP CONSTRAINT IF EXISTS embedding_pkey")
                 cur.execute("ALTER TABLE embedding ADD PRIMARY KEY (item_id, backend)")
-                logger.info("Migrated embedding PK from (item_id) to (item_id, backend)")
+                logger.info("Set embedding PK to (item_id, backend)")
             # Create 'lyrics_embedding' table for lyrics similarity and axis scores
             cur.execute("CREATE TABLE IF NOT EXISTS lyrics_embedding (item_id TEXT PRIMARY KEY, FOREIGN KEY (item_id) REFERENCES score (item_id) ON DELETE CASCADE)")
             cur.execute("SELECT EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'lyrics_embedding' AND column_name = 'embedding')")

--- a/app_map.py
+++ b/app_map.py
@@ -88,11 +88,12 @@ def build_map_cache():
     conn = get_db()
     cur = conn.cursor()
     try:
+        from tasks.sonic_backends import active_backend_name
         cur.execute("""
             SELECT s.item_id, s.title, s.author, s.mood_vector, e.embedding
             FROM score s
-            JOIN embedding e ON s.item_id = e.item_id
-        """)
+            JOIN embedding e ON s.item_id = e.item_id AND e.backend = %s
+        """, (active_backend_name(),))
         rows = cur.fetchall()
     finally:
         cur.close()

--- a/app_path.py
+++ b/app_path.py
@@ -16,15 +16,25 @@ _MOOD_CENTROIDS = {}  # mood_name -> list of np.array centroids
 
 def _load_mood_centroids():
     try:
-        with open(MOOD_CENTROIDS_FILE) as f:
-            data = json.load(f)
+        from tasks.mood_centroids_manager import load_mood_centroids
+        data = load_mood_centroids()
+        _MOOD_CENTROIDS.clear()
         for mood, info in data.items():
             _MOOD_CENTROIDS[mood] = [np.array(c['centroid'], dtype=np.float32) for c in info['centroids']]
-        logger.info(f"Loaded mood centroids: {', '.join(f'{m}({len(cs)})' for m, cs in _MOOD_CENTROIDS.items())}")
+        logger.info(
+            "Loaded mood centroids (backend-aware): %s",
+            ', '.join(f'{m}({len(cs)})' for m, cs in _MOOD_CENTROIDS.items()) or '(none)',
+        )
     except Exception as e:
-        logger.warning(f"Could not load mood centroids from {MOOD_CENTROIDS_FILE}: {e}")
+        logger.warning(f"Could not load mood centroids: {e}", exc_info=True)
 
-_load_mood_centroids()
+# Import-time load is best-effort (DB may not be reachable yet during
+# tests); the in-memory cache is cleared and re-populated on each
+# 'index-updates' reload broadcast (see app.py).
+try:
+    _load_mood_centroids()
+except Exception:
+    pass
 
 VALID_MOODS = {'happy', 'sad', 'aggressive', 'relaxed', 'danceable'}
 

--- a/app_sync.py
+++ b/app_sync.py
@@ -133,9 +133,14 @@ def _payload_page(cur, page, limit, include_embeddings, id_filter):
     clap_on = include_embeddings and config.CLAP_ENABLED
     select_extra = ""
     join_extra = ""
+    embedding_params = ()
     if include_embeddings:
+        from tasks.sonic_backends import active_backend_name
+        # ``musicnn_blob`` alias kept for sync-protocol back-compat —
+        # the consumer just sees "the active backend's embedding".
         select_extra += ", e.embedding AS musicnn_blob"
-        join_extra += " LEFT JOIN embedding e ON e.item_id = s.item_id"
+        join_extra += " LEFT JOIN embedding e ON e.item_id = s.item_id AND e.backend = %s"
+        embedding_params = (active_backend_name(),)
     if clap_on:
         select_extra += ", c.embedding AS clap_blob"
         join_extra += " LEFT JOIN clap_embedding c ON c.item_id = s.item_id"
@@ -155,7 +160,7 @@ def _payload_page(cur, page, limit, include_embeddings, id_filter):
             placeholders = ",".join(["%s"] * len(id_filter))
             cur.execute(
                 base_select + " WHERE s.item_id IN (" + placeholders + ") ORDER BY s.item_id ASC",
-                tuple(id_filter),
+                embedding_params + tuple(id_filter),
             )
             rows = cur.fetchall()
             total_tracks = len(rows)
@@ -167,7 +172,7 @@ def _payload_page(cur, page, limit, include_embeddings, id_filter):
         offset = (page - 1) * limit
         cur.execute(
             base_select + " ORDER BY s.item_id ASC LIMIT %s OFFSET %s",
-            (limit, offset),
+            embedding_params + (limit, offset),
         )
         rows = cur.fetchall()
         has_more = (offset + len(rows)) < total_tracks

--- a/app_voyager.py
+++ b/app_voyager.py
@@ -25,27 +25,46 @@ _mood_centroids_loaded = False
 _mood_centroids_lock = threading.Lock()
 
 def _load_mood_centroids_for_similarity():
+    """Populate the in-memory centroid caches from the active backend.
+
+    The legacy bundled JSON (200-dim MusiCNN) is now only consulted as a
+    fallback for the very first boot under SONIC_BACKEND=musicnn when
+    no analysis has yet produced ``mood_centroids_data`` rows. Other
+    backends rely entirely on the per-backend table.
+
+    The ``top_tags`` field changed shape over time: the legacy JSON
+    encoded it as ``{label: count}`` while the new builder emits a flat
+    ``[label, ...]`` list ordered by representativeness. The loader
+    handles both so old JSON installs and new DB-backed installs render
+    identically in the Similarity / Alchemy pickers.
+    """
     try:
-        with open(MOOD_CENTROIDS_FILE) as f:
-            data = json.load(f)
+        from tasks.mood_centroids_manager import load_mood_centroids
+        data = load_mood_centroids()
         for mood, info in data.items():
             centroids = info.get('centroids', [])
             _MOOD_CENTROIDS_DATA[mood] = centroids
             meta_list = []
             for i, c in enumerate(centroids):
-                tags = c.get('top_tags', {})
-                top5 = sorted(tags.items(), key=lambda x: -x[1])[:5]
+                tags = c.get('top_tags', [])
+                if isinstance(tags, dict):
+                    top5 = [t[0] for t in sorted(tags.items(), key=lambda x: -x[1])[:5]]
+                else:
+                    top5 = list(tags)[:5]
                 meta_list.append({
                     'index': i,
-                    'top_tags': [t[0] for t in top5],
+                    'top_tags': top5,
                     'n_songs': c.get('n_songs', 0),
                     'mood_score': c.get('mood_score', 0),
                     'cluster_id': c.get('cluster_id', i),
                 })
             _MOOD_CENTROIDS_META[mood] = meta_list
-        logger.info(f"Loaded mood centroids for similarity: {', '.join(f'{m}({len(cs)})' for m, cs in _MOOD_CENTROIDS_DATA.items())}")
+        logger.info(
+            "Loaded mood centroids for similarity (backend-aware): %s",
+            ', '.join(f'{m}({len(cs)})' for m, cs in _MOOD_CENTROIDS_DATA.items()) or '(none)',
+        )
     except Exception as e:
-        logger.warning(f"Could not load mood centroids from {MOOD_CENTROIDS_FILE}: {e}")
+        logger.warning(f"Could not load mood centroids: {e}", exc_info=True)
 
 def _ensure_mood_centroids_loaded():
     """Parse the mood-centroids JSON on first use instead of at import.

--- a/config.py
+++ b/config.py
@@ -345,6 +345,18 @@ MERT_LAYER = int(os.environ.get("MERT_LAYER", "-1"))
 # ``auto`` picks CUDA when torch reports it available, else CPU.
 MERT_DEVICE = os.environ.get("MERT_DEVICE", "auto").lower()
 MERT_TARGET_SR = int(os.environ.get("MERT_TARGET_SR", "24000"))
+# Long tracks are processed in fixed-length windows and the per-window
+# embeddings are mean-pooled. This matches the way MusiCNN's
+# prepare_spectrogram_patches already chunks input, keeps MERT inside
+# its short-clip pretraining distribution, and bounds per-track
+# latency to ``ceil(track_seconds / chunk_seconds)`` forward passes.
+# 30 s is the sweet spot — long enough to capture rhythm + timbre +
+# arrangement, short enough that an 8-minute track is 16 cheap passes
+# instead of one ruinously expensive one.
+MERT_CHUNK_SECONDS = float(os.environ.get("MERT_CHUNK_SECONDS", "30"))
+# Trailing audio shorter than this is discarded — it's noise from the
+# tail-end split and wouldn't contribute meaningfully to the mean.
+MERT_MIN_CHUNK_SECONDS = float(os.environ.get("MERT_MIN_CHUNK_SECONDS", "5"))
 # Override the Hugging Face cache location when, e.g., the default
 # ~/.cache/huggingface path is not writable inside the worker
 # container. Empty string = use HF default.

--- a/config.py
+++ b/config.py
@@ -350,6 +350,17 @@ MERT_TARGET_SR = int(os.environ.get("MERT_TARGET_SR", "24000"))
 # container. Empty string = use HF default.
 MERT_HF_CACHE_DIR = os.environ.get("MERT_HF_CACHE_DIR", "")
 
+# --- Mood centroids (per-backend derivation) ---
+# Number of KMeans clusters built per ``OTHER_FEATURE_LABELS`` mood. The
+# legacy frozen JSON used a BIC sweep to pick k; a fixed 4 hits the
+# typical sweet spot for the available label volume and keeps the rebuild
+# cheap. Override per deployment if you have a much larger library.
+MOOD_CENTROIDS_K = int(os.environ.get("MOOD_CENTROIDS_K", "4"))
+# Minimum CLAP "other_features" score for a track to count toward a
+# mood's cluster pool. 0.4 mirrors the heuristic the legacy JSON
+# implicitly used (tracks with a clear-enough mood signal).
+MOOD_CENTROIDS_MIN_SCORE = float(os.environ.get("MOOD_CENTROIDS_MIN_SCORE", "0.4"))
+
 # Resolved per-backend embedding dim. Voyager builders / persistence
 # code import ``EMBEDDING_DIMENSION`` directly as a scalar, so we
 # resolve at import time. We deliberately do NOT import the backend

--- a/config.py
+++ b/config.py
@@ -322,7 +322,51 @@ MOOD_LABELS = [
 TOP_N_MOODS = int(os.environ.get("TOP_N_MOODS", "5"))  # Number of top moods to consider (configurable via env)
 EMBEDDING_MODEL_PATH = os.environ.get("EMBEDDING_MODEL_PATH", "/app/model/musicnn_embedding.onnx")
 PREDICTION_MODEL_PATH = os.environ.get("PREDICTION_MODEL_PATH", "/app/model/musicnn_prediction.onnx")
-EMBEDDING_DIMENSION = 200
+
+# --- Pluggable Sonic Backend ---
+# Which model produces the per-track similarity embedding stored in the
+# ``embedding`` table and indexed by Voyager. ``musicnn`` is the
+# historical default (200-dim, ONNX, behaves bit-for-bit like prior
+# releases). ``mert`` uses the self-supervised MERT music foundation
+# model (768-dim @ MERT-95M / 1024-dim @ MERT-330M, via HF transformers)
+# and keeps the MusiCNN-prediction ONNX head for mood/genre tags so
+# mood_vector rows stay schema-compatible.
+#
+# Switching backends is a destructive operation for the Voyager / audio
+# embedding tables — embedding dimensions differ — so a full
+# re-analysis is required after toggling. See tasks/sonic_backends/.
+SONIC_BACKEND = os.environ.get("SONIC_BACKEND", "musicnn").lower()
+MERT_MODEL_ID = os.environ.get("MERT_MODEL_ID", "m-a-p/MERT-v1-95M")
+# Which transformer layer to mean-pool. ``-1`` = last hidden layer (a
+# safe default across MERT variants). Music-tagging downstream tasks
+# often peak around layers 5–7 for MERT-95M; tune if you have a
+# labeled eval set.
+MERT_LAYER = int(os.environ.get("MERT_LAYER", "-1"))
+# ``auto`` picks CUDA when torch reports it available, else CPU.
+MERT_DEVICE = os.environ.get("MERT_DEVICE", "auto").lower()
+MERT_TARGET_SR = int(os.environ.get("MERT_TARGET_SR", "24000"))
+# Override the Hugging Face cache location when, e.g., the default
+# ~/.cache/huggingface path is not writable inside the worker
+# container. Empty string = use HF default.
+MERT_HF_CACHE_DIR = os.environ.get("MERT_HF_CACHE_DIR", "")
+
+# Resolved per-backend embedding dim. Voyager builders / persistence
+# code import ``EMBEDDING_DIMENSION`` directly as a scalar, so we
+# resolve at import time. We deliberately do NOT import the backend
+# registry here — that pulls in ``tasks.analysis_helper`` ➜
+# ``app_helper`` ➜ Flask machinery, which is not safe at config import
+# time. The dim lookup table below mirrors the ``embedding_dim`` class
+# attributes on the shipped backends; adding a new backend means
+# adding a row here too. The unit test in
+# ``test/unit/test_sonic_backends.py`` enforces parity.
+_BACKEND_EMBEDDING_DIMS = {
+    "musicnn": 200,
+    "mert": {
+        "m-a-p/MERT-v1-95M": 768,
+        "m-a-p/MERT-v1-330M": 1024,
+    }.get(MERT_MODEL_ID, 768),
+}
+EMBEDDING_DIMENSION = _BACKEND_EMBEDDING_DIMS.get(SONIC_BACKEND, 200)
 
 # --- CLAP Model Constants (for text search) ---
 CLAP_ENABLED = os.environ.get("CLAP_ENABLED", "true").lower() == "true"

--- a/docs/SONIC_BACKENDS.md
+++ b/docs/SONIC_BACKENDS.md
@@ -30,22 +30,17 @@ The trade-offs:
   (~1–3 s/track on an i9-14900K). MERT-330M is meaningfully better but
   effectively requires a GPU.
 * **Image size**. Pulling in `torch` adds ~700 MB.
-* **Switching is destructive**. Embedding dimensions differ (200 vs
-  768/1024), so the Voyager index and the `embedding` table must be
-  rebuilt from scratch — exactly like the v2.0.0 lyrics-model swap.
+* **Switching is non-destructive.** Each backend stores its embeddings
+  and Voyager index under its own namespace (composite
+  `(item_id, backend)` PK on `embedding`; namespaced Voyager
+  `INDEX_NAME`), so flipping `SONIC_BACKEND` preserves the outgoing
+  backend's data — you can switch back later without re-analyzing.
+  When you no longer want the outgoing backend's data, drop it from
+  the Admin → Cleaning → Sonic Backend Storage panel.
 
 ## Switching backends
 
-1. Drop the audio embedding tables (Voyager picks up the new
-   dimensionality from `EMBEDDING_DIMENSION` automatically):
-
-   ```bash
-   docker compose exec -e PGPASSWORD=audiomusepassword postgres \
-     psql -U audiomuse -d audiomusedb \
-     -c "TRUNCATE embedding; DELETE FROM voyager_index_data;"
-   ```
-
-2. Rebuild the image with MERT deps and set the backend env vars:
+1. Rebuild the image with MERT deps and set the backend env vars:
 
    ```yaml
    # compose snippet
@@ -61,8 +56,17 @@ The trade-offs:
        MERT_LAYER: "-1"                     # last hidden layer; tune if desired
    ```
 
-3. Restart the stack and run a full analysis (the Admin → Analysis
-   page). Voyager rebuild happens automatically at the end of the run.
+2. Restart the stack and run a full analysis (Admin → Analysis). Tracks
+   that already have the previous backend's embedding stay tagged as
+   "needs analysis under the active backend" until their new row is
+   written. Voyager rebuild for the active backend happens
+   automatically at the end of the run.
+
+3. Once you're happy with the new backend, go to Admin → Cleaning →
+   **Sonic Backend Storage**, find the previous backend in the table
+   and click "Clear this backend" to free the disk space. The active
+   backend is read-only there — switching `SONIC_BACKEND` is the only
+   way to free the active backend's data.
 
 ## Configuration reference
 

--- a/docs/SONIC_BACKENDS.md
+++ b/docs/SONIC_BACKENDS.md
@@ -1,0 +1,101 @@
+# Sonic Backends
+
+AudioMuse-AI's per-track *similarity embedding* (the vector stored in
+`embedding` and queried via the Voyager index for "find similar songs")
+is produced by a swappable backend. Two are shipped:
+
+| Backend  | Embedding dim | Source                                    | Tag head        | Default? |
+| -------- | ------------- | ----------------------------------------- | --------------- | -------- |
+| musicnn  | 200           | Legacy MusiCNN ONNX (Essentia lineage)    | MusiCNN-prediction | yes      |
+| mert     | 768 / 1024    | `m-a-p/MERT-v1-95M` / `-330M` via HF      | MusiCNN-prediction | no       |
+
+Selection is controlled by the `SONIC_BACKEND` environment variable.
+`mood_vector` / mood-tagging output is currently produced by the same
+MusiCNN-prediction ONNX in both backends, so `score.mood_vector` rows
+stay schema-compatible across backend changes.
+
+## When to switch
+
+`mert` produces a richer, self-supervised embedding trained on millions
+of hours of music. Open-MIR benchmarks consistently show it
+out-performing CNN-on-mel-spectrogram models like MusiCNN on genre
+tagging, mood, instrument and similarity tasks. If you find the default
+"Instant Mix" / "similar tracks" recommendations underwhelming on
+non-Western or instrumental material — exactly where MusiCNN is weakest
+— switching to MERT is the highest-leverage change you can make.
+
+The trade-offs:
+
+* **Compute**. MERT-95M runs comfortably on a modern desktop CPU
+  (~1–3 s/track on an i9-14900K). MERT-330M is meaningfully better but
+  effectively requires a GPU.
+* **Image size**. Pulling in `torch` adds ~700 MB.
+* **Switching is destructive**. Embedding dimensions differ (200 vs
+  768/1024), so the Voyager index and the `embedding` table must be
+  rebuilt from scratch — exactly like the v2.0.0 lyrics-model swap.
+
+## Switching backends
+
+1. Drop the audio embedding tables (Voyager picks up the new
+   dimensionality from `EMBEDDING_DIMENSION` automatically):
+
+   ```bash
+   docker compose exec -e PGPASSWORD=audiomusepassword postgres \
+     psql -U audiomuse -d audiomusedb \
+     -c "TRUNCATE embedding; DELETE FROM voyager_index_data;"
+   ```
+
+2. Rebuild the image with MERT deps and set the backend env vars:
+
+   ```yaml
+   # compose snippet
+   audiomuse-flask:
+     build:
+       context: /path/to/AudioMuse-AI
+       args:
+         INSTALL_MERT: "1"
+     environment:
+       SONIC_BACKEND: "mert"
+       MERT_MODEL_ID: "m-a-p/MERT-v1-95M"   # or -330M
+       MERT_DEVICE: "auto"                  # cuda if available, else cpu
+       MERT_LAYER: "-1"                     # last hidden layer; tune if desired
+   ```
+
+3. Restart the stack and run a full analysis (the Admin → Analysis
+   page). Voyager rebuild happens automatically at the end of the run.
+
+## Configuration reference
+
+| Variable             | Default               | Notes                                             |
+| -------------------- | --------------------- | ------------------------------------------------- |
+| `SONIC_BACKEND`      | `musicnn`             | One of `musicnn`, `mert`                          |
+| `MERT_MODEL_ID`      | `m-a-p/MERT-v1-95M`   | HF model id; `-330M` for the larger checkpoint    |
+| `MERT_LAYER`         | `-1`                  | Hidden-layer index to mean-pool. `-1` = last      |
+| `MERT_DEVICE`        | `auto`                | `auto` / `cpu` / `cuda`                           |
+| `MERT_TARGET_SR`     | `24000`               | MERT's training sample rate                       |
+| `MERT_HF_CACHE_DIR`  | *(HF default)*        | Override `$HF_HOME` for the MERT download         |
+
+## Writing a new backend
+
+Implement `tasks/sonic_backends/base.SonicBackend` and `register()` an
+instance in your module. The minimum surface is:
+
+```python
+from tasks.sonic_backends import SonicBackend, register
+
+class MyBackend(SonicBackend):
+    name = "mybackend"
+    embedding_dim = 1024
+    target_sr = 16000
+
+    def load_sessions(self): ...
+    def cleanup_sessions(self, sessions, context=""): ...
+    def analyze(self, audio, sr, sessions, *, file_basename, mood_labels):
+        return track_embedding, {label: float_score, ...}
+
+register(MyBackend())
+```
+
+Add the embedding dimension to `_BACKEND_EMBEDDING_DIMS` in `config.py`
+so the Voyager builder picks up the correct size, then point your
+deployment at `SONIC_BACKEND=mybackend`.

--- a/docs/SONIC_BACKENDS.md
+++ b/docs/SONIC_BACKENDS.md
@@ -68,6 +68,32 @@ The trade-offs:
    backend is read-only there — switching `SONIC_BACKEND` is the only
    way to free the active backend's data.
 
+## Mood centroids
+
+The Similarity / Song Alchemy / Path features expose mood-centroid
+discovery ("give me tracks near the 'happy' #3 cluster"). The shipped
+`mood_centroids_real_080_clap.json` is frozen against 200-dim MusiCNN,
+so it can't be used directly under a different backend.
+
+To make those features work for any backend, the centroids are
+recomputed at the end of every analysis run (after the Voyager
+rebuild) and stored in `mood_centroids_data` keyed by `(backend, mood)`.
+The loader (`tasks.mood_centroids_manager.load_mood_centroids`)
+returns the active backend's centroids automatically; the legacy JSON
+is only consulted as a first-boot fallback under
+`SONIC_BACKEND=musicnn`.
+
+The two knobs:
+
+| Variable                    | Default | Notes                                                       |
+| --------------------------- | ------- | ----------------------------------------------------------- |
+| `MOOD_CENTROIDS_K`          | `4`     | KMeans clusters per `OTHER_FEATURE_LABELS` mood             |
+| `MOOD_CENTROIDS_MIN_SCORE`  | `0.4`   | Min CLAP `other_features` score for a track to qualify      |
+
+When you clear a backend from the Cleaning panel, the matching
+`mood_centroids_data` rows are dropped alongside the embeddings and
+Voyager rows.
+
 ## Configuration reference
 
 | Variable             | Default               | Notes                                             |

--- a/requirements/mert.txt
+++ b/requirements/mert.txt
@@ -15,5 +15,12 @@
 # of torch from https://pytorch.org/get-started/locally/ matching the
 # CUDA version of the base image.
 --extra-index-url https://download.pytorch.org/whl/cpu
-torch==2.5.1
-torchaudio==2.5.1
+# torch >= 2.6 required by transformers' CVE-mitigated torch.load gate.
+# MERT-v1-95M/-330M ship their HF checkpoints as pickle .bin (not
+# safetensors) and load via trust_remote_code=True, which routes
+# through torch.load. transformers refuses that path under torch < 2.6
+# with a hard ValueError, so the worker dies before producing any
+# embeddings. Keep this floor in sync with whatever transformers
+# version is in requirements/common.txt.
+torch==2.6.0
+torchaudio==2.6.0

--- a/requirements/mert.txt
+++ b/requirements/mert.txt
@@ -1,0 +1,19 @@
+# Optional deps for SONIC_BACKEND=mert.
+#
+# Installed on top of common.txt + cpu.txt / gpu.txt when the Dockerfile
+# is built with --build-arg INSTALL_MERT=1, OR manually via:
+#
+#   uv pip install --system --no-cache --index-strategy unsafe-best-match \
+#       -r requirements/mert.txt
+#
+# MERT (m-a-p/MERT-v1-95M / -330M) ships custom Python code on
+# HuggingFace and is loaded via transformers.AutoModel with
+# trust_remote_code=True. ``transformers`` and ``huggingface-hub`` are
+# already in common.txt so only torch is added here.
+#
+# CPU-only wheels by default — for GPU inference, install a CUDA build
+# of torch from https://pytorch.org/get-started/locally/ matching the
+# CUDA version of the base image.
+--extra-index-url https://download.pytorch.org/whl/cpu
+torch==2.5.1
+torchaudio==2.5.1

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -138,6 +138,7 @@ def _run_all_index_builds(log_fn=None):
     from .lyrics_manager import build_and_store_lyrics_index, build_and_store_lyrics_axes_index
     from .sem_grove_manager import build_and_store_sem_grove_index
     from .artist_gmm_manager import build_and_store_artist_index
+    from .mood_centroids_manager import build_and_store_mood_centroids
 
     def _step(label, fn, progress=None, banner=None, fatal=False):
         if log_fn and progress is not None and banner is not None:
@@ -161,6 +162,9 @@ def _run_all_index_builds(log_fn=None):
           lambda: build_and_store_voyager_index(get_db()),
           progress=95, banner="Building Voyager audio index...",
           fatal=True)
+    _step("Mood centroids rebuilt",
+          lambda: build_and_store_mood_centroids(get_db()),
+          progress=95, banner="Building per-backend mood centroids...")
     _step("CLAP text search index",
           lambda: build_and_store_clap_index(get_db()),
           progress=96, banner="Building CLAP text search index...")

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -289,7 +289,7 @@ def _analyze_track_via_backend(*, file_path, mood_labels_list, sessions, return_
             file_basename=name, mood_labels=mood_labels_list,
         )
     except Exception as e:
-        logger.error(f"Backend '{backend.name}' inference failed for {name}: {e}", exc_info=True)
+        logger.exception("Backend '%s' inference failed for %s: %s", backend.name, name, e)
         return (None, None, None, None) if return_audio else (None, None)
 
     if result is None:

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -28,7 +28,7 @@ from config import (
     TEMP_DIR, MOOD_LABELS, EMBEDDING_MODEL_PATH, PREDICTION_MODEL_PATH,
     OTHER_FEATURE_LABELS,
     REBUILD_INDEX_BATCH_SIZE, MAX_QUEUED_ANALYSIS_JOBS, PER_SONG_MODEL_RELOAD,
-    AUDIO_LOAD_TIMEOUT, LYRICS_ENABLED,
+    AUDIO_LOAD_TIMEOUT, LYRICS_ENABLED, SONIC_BACKEND,
 )
 
 
@@ -249,6 +249,89 @@ def robust_load_audio_with_fallback(file_path, target_sr=16000):
         logger.error(f"PyAV fallback loading also failed for {name}: {e}")
         return None, None
 
+def _get_sonic_backend():
+    """Return the configured :class:`SonicBackend` singleton.
+
+    Imported lazily so a missing optional dependency (e.g. transformers
+    when ``SONIC_BACKEND=mert``) raises at the first analysis call rather
+    than at module import — keeping the rest of the app bootable.
+    """
+    from .sonic_backends import get_backend
+    return get_backend(SONIC_BACKEND)
+
+
+def _analyze_track_via_backend(*, file_path, mood_labels_list, sessions, return_audio):
+    """Backend-routed equivalent of :func:`analyze_track`.
+
+    Mirrors the legacy return shape:
+      * ``(analysis_dict, embedding)`` when ``return_audio`` is False
+      * ``(analysis_dict, embedding, audio, sr)`` when True
+      * ``(None, None[, None, None])`` on per-track failure
+    """
+    backend = _get_sonic_backend()
+    name = os.path.basename(file_path)
+    logger.info(f"Starting analysis for: {name} (backend={backend.name})")
+
+    audio, sr = robust_load_audio_with_fallback(file_path, target_sr=backend.target_sr)
+    if audio is None or not np.any(audio) or audio.size == 0:
+        logger.warning(f"Could not load a valid audio signal for {name}. Skipping track.")
+        return (None, None, None, None) if return_audio else (None, None)
+
+    tempo, average_energy, musical_key, scale = extract_basic_features(audio, sr)
+
+    try:
+        result = backend.analyze(
+            audio, sr, sessions,
+            file_basename=name, mood_labels=mood_labels_list,
+        )
+    except Exception as e:
+        logger.error(f"Backend '{backend.name}' inference failed for {name}: {e}", exc_info=True)
+        return (None, None, None, None) if return_audio else (None, None)
+
+    if result is None:
+        return (None, None, None, None) if return_audio else (None, None)
+
+    processed_embeddings, moods = result
+    analysis_result = {
+        "tempo": tempo,
+        "key": musical_key,
+        "scale": scale,
+        "moods": moods,
+        "energy": average_energy,
+    }
+
+    return_values = (analysis_result, processed_embeddings, audio, sr) if return_audio else (analysis_result, processed_embeddings)
+    try:
+        if not return_audio:
+            del audio, sr
+        gc.collect()
+        comprehensive_memory_cleanup(force_cuda=False, reset_onnx_pool=False)
+    except Exception as cleanup_error:
+        logger.warning(f"Error during final tensor cleanup: {cleanup_error}")
+    return return_values
+
+
+def _backend_load_sessions():
+    """Backend-aware replacement for ``load_musicnn_sessions(model_paths)``.
+
+    Routes session allocation through the configured backend so the
+    MusiCNN path (default) keeps using the existing ONNX session pair
+    and alternative backends (MERT, …) can stash whatever they need
+    behind the same opaque dict the rest of ``analyze_album_task``
+    treats as black-box state.
+    """
+    return _get_sonic_backend().load_sessions()
+
+
+def _backend_cleanup_sessions(sessions, context=""):
+    if sessions is None:
+        return
+    try:
+        _get_sonic_backend().cleanup_sessions(sessions, context=context)
+    except Exception as e:
+        logger.warning(f"Error during backend session cleanup: {e}")
+
+
 def rebuild_all_indexes_task():
     """Rebuild all indexes as a standalone RQ task (enqueued on default queue)."""
     logger.info("🔨 Starting index rebuild task (enqueued as subtask)...")
@@ -263,15 +346,30 @@ def rebuild_all_indexes_task():
 
 def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, return_audio=False):
     """
-    Analyzes a single track using ONNX Runtime for inference.
-    
+    Analyzes a single track using the configured sonic backend.
+
+    The MusiCNN code path below is preserved bit-for-bit so unit tests
+    that patch ``tasks.analysis.ort`` etc. keep exercising the original
+    flow when ``SONIC_BACKEND=musicnn`` (the default). For any other
+    backend the call is dispatched to
+    :func:`_analyze_track_via_backend`, which routes through
+    ``tasks.sonic_backends`` and returns the same tuple shape.
+
     Args:
         file_path: Path to audio file
         mood_labels_list: List of mood labels
         model_paths: Dict of model paths
-        onnx_sessions: Optional dict of pre-loaded ONNX sessions (for album-level reuse)
+        onnx_sessions: Optional dict of pre-loaded sessions (album-level reuse)
         return_audio: If True, return the loaded audio array and sample rate as part of the result.
     """
+    if SONIC_BACKEND != "musicnn":
+        return _analyze_track_via_backend(
+            file_path=file_path,
+            mood_labels_list=mood_labels_list,
+            sessions=onnx_sessions,
+            return_audio=return_audio,
+        )
+
     logger.info(f"Starting analysis for: {os.path.basename(file_path)}")
 
     # --- 1. Load Audio and Compute Basic Features ---
@@ -548,12 +646,12 @@ def analyze_album_task(album_id, album_name, top_n_moods, parent_task_id):
                     if needs_musicnn:
                         if onnx_sessions is None:
                             logger.info(f"Lazy-loading MusiCNN models for album: {album_name}")
-                            onnx_sessions = load_musicnn_sessions(model_paths)
+                            onnx_sessions = _backend_load_sessions()
                         elif session_recycler.should_recycle():
                             logger.info(f"Recycling ONNX sessions after {session_recycler.get_use_count()} tracks")
-                            cleanup_musicnn_sessions(onnx_sessions, context="recycle")
+                            _backend_cleanup_sessions(onnx_sessions, context="recycle")
                             comprehensive_memory_cleanup(force_cuda=True, reset_onnx_pool=True)
-                            onnx_sessions = load_musicnn_sessions(model_paths)
+                            onnx_sessions = _backend_load_sessions()
                             if onnx_sessions:
                                 logger.info(f"✓ Recycled {len(onnx_sessions)} MusiCNN model sessions")
                             session_recycler.mark_recycled()
@@ -616,7 +714,7 @@ def analyze_album_task(album_id, album_name, top_n_moods, parent_task_id):
                     if path and os.path.exists(path):
                         os.remove(path)
 
-            cleanup_musicnn_sessions(onnx_sessions, context="album end")
+            _backend_cleanup_sessions(onnx_sessions, context="album end")
             onnx_sessions = None
             cleanup_optional_models(context="album end")
             logger.info("Performing final comprehensive cleanup after album analysis")
@@ -637,7 +735,7 @@ def analyze_album_task(album_id, album_name, top_n_moods, parent_task_id):
             log_and_update_album_task(f"Failed to analyze album '{album_name}': {e}", current_progress_val, task_state=TASK_STATUS_FAILURE, error=err, final_summary_details={"error": str(e)})
             raise
         finally:
-            cleanup_musicnn_sessions(onnx_sessions, context="finally")
+            _backend_cleanup_sessions(onnx_sessions, context="finally")
             onnx_sessions = None
             try:
                 comprehensive_memory_cleanup(force_cuda=True, reset_onnx_pool=True)

--- a/tasks/analysis_helper.py
+++ b/tasks/analysis_helper.py
@@ -312,16 +312,27 @@ def _str_ids(ids):
 
 
 def get_existing_track_ids(track_ids):
-    """Return the subset of track_ids already fully analyzed by MusiCNN."""
+    """Return the subset of track_ids already fully analyzed under the
+    *active* sonic backend.
+
+    A track is considered "done" only if there is an ``embedding`` row
+    for the currently-configured backend AND the score columns are
+    populated. After a ``SONIC_BACKEND`` switch, tracks that have only
+    the outgoing backend's embedding row will fall back into the queue
+    and get the active backend's embedding written alongside the
+    existing one (composite ``(item_id, backend)`` PK).
+    """
     if not track_ids:
         return set()
+    from .sonic_backends import active_backend_name
     with get_db() as conn, conn.cursor() as cur:
         cur.execute(
-            "SELECT s.item_id FROM score s JOIN embedding e ON s.item_id = e.item_id "
+            "SELECT s.item_id FROM score s "
+            "JOIN embedding e ON s.item_id = e.item_id AND e.backend = %s "
             "WHERE s.item_id IN %s AND s.other_features IS NOT NULL "
             "AND s.energy IS NOT NULL AND s.mood_vector IS NOT NULL "
             "AND s.tempo IS NOT NULL",
-            (tuple(_str_ids(track_ids)),),
+            (active_backend_name(), tuple(_str_ids(track_ids))),
         )
         return {row[0] for row in cur.fetchall()}
 

--- a/tasks/artist_gmm_manager.py
+++ b/tasks/artist_gmm_manager.py
@@ -370,12 +370,13 @@ def build_and_store_artist_index(db_conn=None):
             item_ids = [track['item_id'] for track in tracks]
 
             try:
-                # Batch fetch embeddings from database
+                # Batch fetch embeddings from database (active backend only)
+                from .sonic_backends import active_backend_name
                 cur.execute("""
                     SELECT item_id, embedding
                     FROM embedding
-                    WHERE item_id = ANY(%s) AND embedding IS NOT NULL
-                """, (item_ids,))
+                    WHERE item_id = ANY(%s) AND embedding IS NOT NULL AND backend = %s
+                """, (item_ids, active_backend_name()))
 
                 embedding_rows = cur.fetchall()
 
@@ -803,13 +804,14 @@ def get_representative_songs_for_component(artist_name: str, component_index: in
     cur = conn.cursor()
     
     try:
+        from .sonic_backends import active_backend_name
         cur.execute("""
             SELECT s.item_id, s.title, e.embedding
             FROM score s
-            JOIN embedding e ON s.item_id = e.item_id
+            JOIN embedding e ON s.item_id = e.item_id AND e.backend = %s
             WHERE s.author = %s AND e.embedding IS NOT NULL
             ORDER BY s.title
-        """, (artist_name,))
+        """, (active_backend_name(), artist_name))
         
         rows = cur.fetchall()
         

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from rq import get_current_job
 
 # Import configuration
-from config import CLEANING_SAFETY_LIMIT
+from config import CLEANING_SAFETY_LIMIT, EMBEDDING_DIMENSION, INDEX_NAME, SONIC_BACKEND
 
 from error import error_manager
 from error.error_dictionary import ERR_CLEANING_FAILED, ERR_DB_CONNECTION
@@ -21,6 +21,123 @@ from .mediaserver import get_recent_albums, get_tracks_from_album
 from psycopg2 import OperationalError
 
 logger = logging.getLogger(__name__)
+
+
+# --- Sonic-backend-switch cleanup -------------------------------------------
+
+def inspect_sonic_state():
+    """Return a dict describing the current vs stored sonic embedding state.
+
+    Used by the Admin "Cleaning" panel to decide whether stale audio
+    embeddings need to be wiped after a ``SONIC_BACKEND`` change. Shape
+    is intentionally small and JSON-safe so
+    ``GET /api/cleaning/sonic_state`` can return it verbatim.
+    """
+    from app_helper import get_db
+
+    state = {
+        "current_backend": SONIC_BACKEND,
+        "current_dim": int(EMBEDDING_DIMENSION),
+        "embedding_row_count": 0,
+        "sample_stored_dim": None,
+        "voyager_row_count": 0,
+        "stored_voyager_dim": None,
+        "mismatch": False,
+    }
+
+    seg_pattern = INDEX_NAME.replace("_", r"\_") + r"\_%\_%"
+    try:
+        with get_db() as conn, conn.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM embedding")
+            state["embedding_row_count"] = int(cur.fetchone()[0] or 0)
+            if state["embedding_row_count"] > 0:
+                cur.execute("SELECT embedding FROM embedding WHERE embedding IS NOT NULL LIMIT 1")
+                row = cur.fetchone()
+                if row and row[0] is not None:
+                    raw = bytes(row[0])
+                    if len(raw) % 4 == 0:
+                        state["sample_stored_dim"] = len(raw) // 4
+
+            cur.execute(
+                "SELECT COUNT(*) FROM voyager_index_data "
+                "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
+                (INDEX_NAME, seg_pattern),
+            )
+            state["voyager_row_count"] = int(cur.fetchone()[0] or 0)
+            if state["voyager_row_count"] > 0:
+                cur.execute(
+                    "SELECT embedding_dimension FROM voyager_index_data "
+                    "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\' "
+                    "ORDER BY index_name LIMIT 1",
+                    (INDEX_NAME, seg_pattern),
+                )
+                row = cur.fetchone()
+                if row and row[0] is not None:
+                    state["stored_voyager_dim"] = int(row[0])
+    except Exception as e:
+        logger.warning(f"Failed to inspect sonic embedding state: {e}", exc_info=True)
+        state["error"] = str(e)
+        return state
+
+    state["mismatch"] = (
+        (state["sample_stored_dim"] is not None and state["sample_stored_dim"] != state["current_dim"])
+        or (state["stored_voyager_dim"] is not None and state["stored_voyager_dim"] != state["current_dim"])
+    )
+    return state
+
+
+def clear_sonic_audio_state():
+    """Wipe stored audio similarity embeddings + Voyager audio index rows.
+
+    Intended for use after switching ``SONIC_BACKEND`` to a model with a
+    different embedding dimension (e.g. MusiCNN 200 → MERT 768). Removes
+    only what depends on the audio embedding dim — the CLAP embedding
+    (512-dim, fixed), lyrics embedding, artist index, app_config,
+    playlists, and task history are all preserved. Score rows are kept
+    but their backend-derived columns (tempo / key / scale / energy /
+    mood_vector / other_features) are nulled so the next analysis pass
+    treats every track as needing a fresh run.
+
+    Returns a summary dict for the API response.
+    """
+    from app_helper import get_db
+
+    summary = {
+        "deleted_embeddings": 0,
+        "deleted_voyager_rows": 0,
+        "score_audio_fields_cleared": 0,
+    }
+
+    seg_pattern = INDEX_NAME.replace("_", r"\_") + r"\_%\_%"
+    with get_db() as conn, conn.cursor() as cur:
+        cur.execute("DELETE FROM embedding")
+        summary["deleted_embeddings"] = cur.rowcount or 0
+
+        cur.execute(
+            "DELETE FROM voyager_index_data "
+            "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
+            (INDEX_NAME, seg_pattern),
+        )
+        summary["deleted_voyager_rows"] = cur.rowcount or 0
+
+        cur.execute(
+            "UPDATE score SET tempo = NULL, energy = NULL, "
+            "mood_vector = NULL, other_features = NULL, "
+            "\"key\" = NULL, scale = NULL"
+        )
+        summary["score_audio_fields_cleared"] = cur.rowcount or 0
+
+        conn.commit()
+
+    logger.info(
+        "Sonic audio state cleared: %d embeddings, %d voyager rows, "
+        "%d score rows nulled (current backend=%s, dim=%d)",
+        summary["deleted_embeddings"],
+        summary["deleted_voyager_rows"],
+        summary["score_audio_fields_cleared"],
+        SONIC_BACKEND, EMBEDDING_DIMENSION,
+    )
+    return summary
 
 
 def identify_and_clean_orphaned_albums_task():

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -174,11 +174,15 @@ def clear_inactive_backend_data(backend: str):
 
         # mood_centroids_data is per-(backend, mood) — drop every mood
         # row for the cleared backend so stale centroids don't linger.
-        # Table may not exist on a partial install; ignore the miss.
+        # Table may not exist on a partial install; the SAVEPOINT lets us
+        # swallow the miss without aborting the surrounding transaction.
+        cur.execute("SAVEPOINT mood_centroids_delete")
         try:
             cur.execute("DELETE FROM mood_centroids_data WHERE backend = %s", (backend,))
             summary["deleted_mood_centroids"] = cur.rowcount or 0
+            cur.execute("RELEASE SAVEPOINT mood_centroids_delete")
         except Exception as e:
+            cur.execute("ROLLBACK TO SAVEPOINT mood_centroids_delete")
             logger.info("mood_centroids_data not cleared (%s); skipping.", e)
 
         conn.commit()

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -155,7 +155,12 @@ def clear_inactive_backend_data(backend: str):
     main = f"{INDEX_NAME}_{backend}"
     seg_pattern = main.replace("_", r"\_") + r"\_%\_%"
 
-    summary = {"backend": backend, "deleted_embeddings": 0, "deleted_voyager_rows": 0}
+    summary = {
+        "backend": backend,
+        "deleted_embeddings": 0,
+        "deleted_voyager_rows": 0,
+        "deleted_mood_centroids": 0,
+    }
     with get_db() as conn, conn.cursor() as cur:
         cur.execute("DELETE FROM embedding WHERE backend = %s", (backend,))
         summary["deleted_embeddings"] = cur.rowcount or 0
@@ -166,6 +171,15 @@ def clear_inactive_backend_data(backend: str):
             (main, seg_pattern),
         )
         summary["deleted_voyager_rows"] = cur.rowcount or 0
+
+        # mood_centroids_data is per-(backend, mood) — drop every mood
+        # row for the cleared backend so stale centroids don't linger.
+        # Table may not exist on a partial install; ignore the miss.
+        try:
+            cur.execute("DELETE FROM mood_centroids_data WHERE backend = %s", (backend,))
+            summary["deleted_mood_centroids"] = cur.rowcount or 0
+        except Exception as e:
+            logger.info("mood_centroids_data not cleared (%s); skipping.", e)
 
         conn.commit()
 

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -23,118 +23,156 @@ from psycopg2 import OperationalError
 logger = logging.getLogger(__name__)
 
 
-# --- Sonic-backend-switch cleanup -------------------------------------------
+# --- Sonic-backend storage inspection / cleanup -----------------------------
+#
+# Per-backend storage means every backend's embedding rows and Voyager
+# index live alongside each other (composite (item_id, backend) PK on
+# ``embedding``; namespaced ``voyager_index_data.index_name``). The
+# admin "Cleaning" panel uses these helpers to:
+#   * report per-backend row counts so users can see what's on disk;
+#   * drop a specific backend's audio data. The active backend is
+#     protected — switching away first is required to clear it.
+
+
+def _voyager_rows_for(cur, backend: str):
+    """Return (row_count, embedding_dim) for ``backend``'s Voyager rows.
+
+    Matches both the single-row form (``music_library_<backend>``) and
+    the segmented form (``music_library_<backend>_<part>_<total>``).
+    """
+    from config import INDEX_NAME
+    main = f"{INDEX_NAME}_{backend}"
+    seg_pattern = main.replace("_", r"\_") + r"\_%\_%"
+    cur.execute(
+        "SELECT COUNT(*), MIN(embedding_dimension) FROM voyager_index_data "
+        "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
+        (main, seg_pattern),
+    )
+    row = cur.fetchone() or (0, None)
+    return int(row[0] or 0), (int(row[1]) if row[1] is not None else None)
+
+
+def _embedding_rows_for(cur, backend: str):
+    """Return (row_count, sampled_dim) for ``backend``'s embedding rows."""
+    cur.execute("SELECT COUNT(*) FROM embedding WHERE backend = %s", (backend,))
+    count = int((cur.fetchone() or (0,))[0] or 0)
+    sample_dim = None
+    if count > 0:
+        cur.execute(
+            "SELECT embedding FROM embedding "
+            "WHERE backend = %s AND embedding IS NOT NULL LIMIT 1",
+            (backend,),
+        )
+        row = cur.fetchone()
+        if row and row[0] is not None:
+            raw = bytes(row[0])
+            if len(raw) % 4 == 0:
+                sample_dim = len(raw) // 4
+    return count, sample_dim
+
 
 def inspect_sonic_state():
-    """Return a dict describing the current vs stored sonic embedding state.
+    """Return per-backend embedding + Voyager state for the Cleaning UI.
 
-    Used by the Admin "Cleaning" panel to decide whether stale audio
-    embeddings need to be wiped after a ``SONIC_BACKEND`` change. Shape
-    is intentionally small and JSON-safe so
-    ``GET /api/cleaning/sonic_state`` can return it verbatim.
+    Shape (JSON-safe; returned by ``GET /api/cleaning/sonic_state``):
+      * ``active_backend``: the SONIC_BACKEND currently writing data.
+      * ``active_dim``: the embedding dim that backend produces.
+      * ``backends``: list of ``{backend, embedding_row_count,
+        sample_stored_dim, voyager_row_count, stored_voyager_dim,
+        is_active}`` rows — one per backend with any stored audio data,
+        plus the active backend even if it currently has none.
+
+    Stored backends are detected by SELECT DISTINCT on ``embedding`` +
+    parsing ``voyager_index_data.index_name`` so the panel surfaces
+    legacy backends the user no longer has registered, not just the
+    backends shipped in this image.
     """
     from app_helper import get_db
+    from config import INDEX_NAME
 
-    state = {
-        "current_backend": SONIC_BACKEND,
-        "current_dim": int(EMBEDDING_DIMENSION),
-        "embedding_row_count": 0,
-        "sample_stored_dim": None,
-        "voyager_row_count": 0,
-        "stored_voyager_dim": None,
-        "mismatch": False,
+    snapshot = {
+        "active_backend": SONIC_BACKEND,
+        "active_dim": int(EMBEDDING_DIMENSION),
+        "backends": [],
     }
 
-    seg_pattern = INDEX_NAME.replace("_", r"\_") + r"\_%\_%"
     try:
         with get_db() as conn, conn.cursor() as cur:
-            cur.execute("SELECT COUNT(*) FROM embedding")
-            state["embedding_row_count"] = int(cur.fetchone()[0] or 0)
-            if state["embedding_row_count"] > 0:
-                cur.execute("SELECT embedding FROM embedding WHERE embedding IS NOT NULL LIMIT 1")
-                row = cur.fetchone()
-                if row and row[0] is not None:
-                    raw = bytes(row[0])
-                    if len(raw) % 4 == 0:
-                        state["sample_stored_dim"] = len(raw) // 4
+            cur.execute("SELECT DISTINCT backend FROM embedding")
+            backends_with_emb = {r[0] for r in cur.fetchall() if r[0]}
 
             cur.execute(
-                "SELECT COUNT(*) FROM voyager_index_data "
-                "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
-                (INDEX_NAME, seg_pattern),
+                "SELECT DISTINCT regexp_replace("
+                "  regexp_replace(index_name, '_[0-9]+_[0-9]+$', ''), "
+                "  %s, '') AS backend "
+                "FROM voyager_index_data "
+                "WHERE index_name LIKE %s ESCAPE '\\'",
+                (f"^{INDEX_NAME}_", INDEX_NAME.replace("_", r"\_") + r"\_%"),
             )
-            state["voyager_row_count"] = int(cur.fetchone()[0] or 0)
-            if state["voyager_row_count"] > 0:
-                cur.execute(
-                    "SELECT embedding_dimension FROM voyager_index_data "
-                    "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\' "
-                    "ORDER BY index_name LIMIT 1",
-                    (INDEX_NAME, seg_pattern),
-                )
-                row = cur.fetchone()
-                if row and row[0] is not None:
-                    state["stored_voyager_dim"] = int(row[0])
+            backends_with_voy = {r[0] for r in cur.fetchall() if r[0]}
+
+            backend_set = backends_with_emb | backends_with_voy | {SONIC_BACKEND}
+            for backend in sorted(backend_set):
+                emb_count, emb_dim = _embedding_rows_for(cur, backend)
+                voy_count, voy_dim = _voyager_rows_for(cur, backend)
+                snapshot["backends"].append({
+                    "backend": backend,
+                    "embedding_row_count": emb_count,
+                    "sample_stored_dim": emb_dim,
+                    "voyager_row_count": voy_count,
+                    "stored_voyager_dim": voy_dim,
+                    "is_active": backend == SONIC_BACKEND,
+                })
     except Exception as e:
         logger.warning(f"Failed to inspect sonic embedding state: {e}", exc_info=True)
-        state["error"] = str(e)
-        return state
-
-    state["mismatch"] = (
-        (state["sample_stored_dim"] is not None and state["sample_stored_dim"] != state["current_dim"])
-        or (state["stored_voyager_dim"] is not None and state["stored_voyager_dim"] != state["current_dim"])
-    )
-    return state
+        snapshot["error"] = str(e)
+    return snapshot
 
 
-def clear_sonic_audio_state():
-    """Wipe stored audio similarity embeddings + Voyager audio index rows.
+def clear_inactive_backend_data(backend: str):
+    """Drop one inactive backend's embedding rows + Voyager index.
 
-    Intended for use after switching ``SONIC_BACKEND`` to a model with a
-    different embedding dimension (e.g. MusiCNN 200 → MERT 768). Removes
-    only what depends on the audio embedding dim — the CLAP embedding
-    (512-dim, fixed), lyrics embedding, artist index, app_config,
-    playlists, and task history are all preserved. Score rows are kept
-    but their backend-derived columns (tempo / key / scale / energy /
-    mood_vector / other_features) are nulled so the next analysis pass
-    treats every track as needing a fresh run.
+    Refuses to operate on ``SONIC_BACKEND`` (a configuration swap must
+    happen first; otherwise the next analysis pass would simply repopulate
+    the rows). Only touches ``embedding`` rows where ``backend = X`` and
+    ``voyager_index_data`` rows under that backend's namespace. The
+    CLAP / lyrics / artist / score / playlist / config tables are
+    untouched.
 
-    Returns a summary dict for the API response.
+    Returns a small summary dict for the API response.
     """
+    if not backend or not isinstance(backend, str):
+        raise ValueError("backend must be a non-empty string")
+    if backend == SONIC_BACKEND:
+        raise ValueError(
+            f"Refusing to clear the active backend ({backend!r}). Set "
+            "SONIC_BACKEND to a different backend first, then come back "
+            "to this panel."
+        )
+
     from app_helper import get_db
+    from config import INDEX_NAME
+    main = f"{INDEX_NAME}_{backend}"
+    seg_pattern = main.replace("_", r"\_") + r"\_%\_%"
 
-    summary = {
-        "deleted_embeddings": 0,
-        "deleted_voyager_rows": 0,
-        "score_audio_fields_cleared": 0,
-    }
-
-    seg_pattern = INDEX_NAME.replace("_", r"\_") + r"\_%\_%"
+    summary = {"backend": backend, "deleted_embeddings": 0, "deleted_voyager_rows": 0}
     with get_db() as conn, conn.cursor() as cur:
-        cur.execute("DELETE FROM embedding")
+        cur.execute("DELETE FROM embedding WHERE backend = %s", (backend,))
         summary["deleted_embeddings"] = cur.rowcount or 0
 
         cur.execute(
             "DELETE FROM voyager_index_data "
             "WHERE index_name = %s OR index_name LIKE %s ESCAPE '\\'",
-            (INDEX_NAME, seg_pattern),
+            (main, seg_pattern),
         )
         summary["deleted_voyager_rows"] = cur.rowcount or 0
-
-        cur.execute(
-            "UPDATE score SET tempo = NULL, energy = NULL, "
-            "mood_vector = NULL, other_features = NULL, "
-            "\"key\" = NULL, scale = NULL"
-        )
-        summary["score_audio_fields_cleared"] = cur.rowcount or 0
 
         conn.commit()
 
     logger.info(
-        "Sonic audio state cleared: %d embeddings, %d voyager rows, "
-        "%d score rows nulled (current backend=%s, dim=%d)",
-        summary["deleted_embeddings"],
-        summary["deleted_voyager_rows"],
-        summary["score_audio_fields_cleared"],
+        "Cleared inactive backend %r: %d embeddings, %d voyager rows. "
+        "(active backend remains %s/%d-dim.)",
+        backend, summary["deleted_embeddings"], summary["deleted_voyager_rows"],
         SONIC_BACKEND, EMBEDDING_DIMENSION,
     )
     return summary

--- a/tasks/clustering_postprocessing.py
+++ b/tasks/clustering_postprocessing.py
@@ -42,7 +42,12 @@ def get_vectors_from_database(item_ids: list, db_conn):
     vectors_map = {}
     
     with db_conn.cursor(cursor_factory=DictCursor) as cur:
-        cur.execute("SELECT item_id, embedding FROM embedding WHERE item_id = ANY(%s)", (item_ids,))
+        from .sonic_backends import active_backend_name
+        cur.execute(
+            "SELECT item_id, embedding FROM embedding "
+            "WHERE item_id = ANY(%s) AND backend = %s",
+            (item_ids, active_backend_name()),
+        )
         rows = cur.fetchall()
         
         for row in rows:

--- a/tasks/mood_centroids_manager.py
+++ b/tasks/mood_centroids_manager.py
@@ -181,7 +181,11 @@ def build_and_store_mood_centroids(db_conn=None) -> bool:
     with db_conn.cursor() as cur:
         for mood in OTHER_FEATURE_LABELS:
             rows = _fetch_tracks_for_mood(cur, mood, backend, MOOD_CENTROIDS_MIN_SCORE)
-            centroids = _cluster_one_mood(rows, EMBEDDING_DIMENSION, MOOD_CENTROIDS_K)
+            try:
+                centroids = _cluster_one_mood(rows, EMBEDDING_DIMENSION, MOOD_CENTROIDS_K)
+            except Exception as e:
+                logger.error("Failed to cluster mood '%s': %s", mood, e, exc_info=True)
+                continue
             payload = {
                 "best_k": len(centroids),
                 "bic_values": None,  # informational; original JSON had BIC sweep

--- a/tasks/mood_centroids_manager.py
+++ b/tasks/mood_centroids_manager.py
@@ -1,0 +1,254 @@
+# tasks/mood_centroids_manager.py
+"""Per-backend mood centroids builder.
+
+Replaces the static ``mood_centroids_real_080_clap.json`` (frozen
+200-dim MusiCNN vectors) with a build-time derivation against whichever
+``SONIC_BACKEND`` is currently active. Centroids are stored in the
+``mood_centroids_data`` table keyed by ``(backend, mood)`` so multiple
+backends can coexist alongside their respective embeddings.
+
+Pipeline position: invoked from
+:func:`tasks.analysis._run_all_index_builds` right after the Voyager
+index rebuild, before the projection builds. That ordering means
+centroids always reflect the embedding distribution of the same
+analysis run that produced the current Voyager index.
+
+Reader contract: ``load_mood_centroids(backend)`` returns the same
+``{mood: {best_k, bic_values, centroids: [...]}}`` shape the legacy JSON
+exposed, so existing consumers in ``app_voyager``, ``app_path`` and
+``tasks.song_alchemy`` are a one-line swap.
+
+Algorithm: for each mood in ``OTHER_FEATURE_LABELS``, pull every
+analyzed track whose CLAP-derived ``score.other_features`` score for
+that mood crosses ``MOOD_CENTROIDS_MIN_SCORE``; fetch the
+active-backend embeddings for those tracks; run KMeans with
+``MOOD_CENTROIDS_K`` clusters (capped at the number of qualifying
+tracks); persist one row per (backend, mood) carrying every cluster's
+centroid vector, member count, average mood score, and top-tag
+representative pulled from the cluster members' ``mood_vector`` strings.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_score_dict(raw: Optional[str]) -> Dict[str, float]:
+    """Parse a 'label1:0.42,label2:0.55' string into ``{label: score}``."""
+    out: Dict[str, float] = {}
+    if not raw:
+        return out
+    for part in raw.split(','):
+        k, _, v = part.partition(':')
+        k = k.strip()
+        if not k:
+            continue
+        try:
+            out[k] = float(v)
+        except ValueError:
+            continue
+    return out
+
+
+def _fetch_tracks_for_mood(cur, mood: str, backend: str, min_score: float):
+    """Return ``[(item_id, embedding_bytes, mood_score, mood_vector)]``."""
+    cur.execute(
+        """
+        SELECT s.item_id, e.embedding, s.other_features, s.mood_vector
+        FROM score s
+        JOIN embedding e ON s.item_id = e.item_id AND e.backend = %s
+        WHERE s.other_features IS NOT NULL AND e.embedding IS NOT NULL
+        """,
+        (backend,),
+    )
+    out = []
+    for item_id, blob, other_features, mood_vector in cur.fetchall():
+        scores = _parse_score_dict(other_features)
+        score = scores.get(mood, 0.0)
+        if score >= min_score:
+            out.append((item_id, blob, score, mood_vector))
+    return out
+
+
+def _top_tags(mood_vectors: List[str], top_n: int = 5) -> List[str]:
+    """Return the most common top-1 mood label across a cluster's tracks."""
+    counter: Counter = Counter()
+    for mv in mood_vectors:
+        d = _parse_score_dict(mv)
+        if not d:
+            continue
+        # Pick the single highest-scored label in this track's mood_vector
+        # as the "representative" tag, then count across the cluster.
+        best = max(d.items(), key=lambda kv: kv[1])
+        counter[best[0]] += 1
+    return [label for label, _ in counter.most_common(top_n)]
+
+
+def _cluster_one_mood(
+    rows: List[tuple], embedding_dim: int, k_target: int,
+) -> List[Dict[str, Any]]:
+    """KMeans-cluster a single mood's embeddings into centroids."""
+    if not rows:
+        return []
+    # Decode embeddings + drop dimension-mismatched rows defensively. The
+    # rest of the pipeline (Voyager build) already does the same check,
+    # but a stale row can sneak through if the Voyager rebuild hasn't
+    # run yet against the current backend.
+    vectors: List[np.ndarray] = []
+    mood_scores: List[float] = []
+    mood_vectors: List[str] = []
+    item_ids: List[str] = []
+    skipped_dim = 0
+    for item_id, blob, score, mv in rows:
+        if blob is None or len(blob) != embedding_dim * 4:
+            skipped_dim += 1
+            continue
+        vectors.append(np.frombuffer(blob, dtype=np.float32))
+        mood_scores.append(score)
+        mood_vectors.append(mv or "")
+        item_ids.append(item_id)
+    if skipped_dim:
+        logger.info("mood_centroids: skipped %d rows with mismatched embedding dim", skipped_dim)
+    if not vectors:
+        return []
+
+    X = np.stack(vectors, axis=0).astype(np.float32, copy=False)
+    k = max(1, min(int(k_target), X.shape[0]))
+
+    # sklearn KMeans is already a transitive dependency (umap-learn /
+    # scikit-learn); import inline so module import is still cheap.
+    from sklearn.cluster import KMeans
+    km = KMeans(n_clusters=k, n_init=10, random_state=42)
+    labels = km.fit_predict(X)
+    centroids = km.cluster_centers_.astype(np.float32, copy=False)
+
+    out: List[Dict[str, Any]] = []
+    for cluster_id in range(k):
+        mask = labels == cluster_id
+        n_songs = int(mask.sum())
+        if n_songs == 0:
+            continue
+        cluster_mood_scores = [mood_scores[i] for i in range(len(mood_scores)) if mask[i]]
+        cluster_mood_vecs = [mood_vectors[i] for i in range(len(mood_vectors)) if mask[i]]
+        out.append({
+            "cluster_id": cluster_id,
+            "n_songs": n_songs,
+            "mood_score": float(np.mean(cluster_mood_scores)) if cluster_mood_scores else 0.0,
+            "centroid": centroids[cluster_id].tolist(),
+            "top_tags": _top_tags(cluster_mood_vecs),
+        })
+    # Sort by cluster size descending so cluster #0 is always the
+    # largest "core" group for the mood — the UI surfaces them in this
+    # order in the centroid picker dropdown.
+    out.sort(key=lambda c: -c["n_songs"])
+    for new_id, entry in enumerate(out):
+        entry["cluster_id"] = new_id
+    return out
+
+
+def build_and_store_mood_centroids(db_conn=None) -> bool:
+    """Recompute and persist mood centroids for the active backend.
+
+    Reads embeddings from the active backend, clusters per
+    ``OTHER_FEATURE_LABELS``, writes one ``mood_centroids_data`` row per
+    (active_backend, mood). Returns True on success even when some
+    moods had no qualifying tracks (those rows are deleted so stale
+    centroids don't linger).
+    """
+    from config import (
+        EMBEDDING_DIMENSION, OTHER_FEATURE_LABELS,
+        MOOD_CENTROIDS_K, MOOD_CENTROIDS_MIN_SCORE,
+    )
+    from .sonic_backends import active_backend_name
+
+    backend = active_backend_name()
+    if db_conn is None:
+        from app_helper import get_db
+        db_conn = get_db()
+
+    logger.info(
+        "Building mood centroids for backend=%s dim=%d (k=%d, min_score=%.2f)",
+        backend, EMBEDDING_DIMENSION, MOOD_CENTROIDS_K, MOOD_CENTROIDS_MIN_SCORE,
+    )
+
+    with db_conn.cursor() as cur:
+        for mood in OTHER_FEATURE_LABELS:
+            rows = _fetch_tracks_for_mood(cur, mood, backend, MOOD_CENTROIDS_MIN_SCORE)
+            centroids = _cluster_one_mood(rows, EMBEDDING_DIMENSION, MOOD_CENTROIDS_K)
+            payload = {
+                "best_k": len(centroids),
+                "bic_values": None,  # informational; original JSON had BIC sweep
+                "centroids": centroids,
+            }
+            if centroids:
+                cur.execute(
+                    """
+                    INSERT INTO mood_centroids_data (backend, mood, centroids, embedding_dim)
+                    VALUES (%s, %s, %s::jsonb, %s)
+                    ON CONFLICT (backend, mood) DO UPDATE SET
+                        centroids = EXCLUDED.centroids,
+                        embedding_dim = EXCLUDED.embedding_dim,
+                        created_at = CURRENT_TIMESTAMP
+                    """,
+                    (backend, mood, json.dumps(payload), EMBEDDING_DIMENSION),
+                )
+                logger.info(
+                    "  ✓ mood='%s' clusters=%d (sizes %s)",
+                    mood, len(centroids),
+                    [c["n_songs"] for c in centroids],
+                )
+            else:
+                cur.execute(
+                    "DELETE FROM mood_centroids_data WHERE backend = %s AND mood = %s",
+                    (backend, mood),
+                )
+                logger.info("  ✗ mood='%s' no qualifying tracks; cleared stale row", mood)
+        db_conn.commit()
+    return True
+
+
+def load_mood_centroids(backend: Optional[str] = None) -> Dict[str, Dict[str, Any]]:
+    """Return ``{mood: {best_k, bic_values, centroids: [...]}}`` for backend.
+
+    When the per-backend DB rows are empty AND ``backend == 'musicnn'``,
+    fall back to the legacy bundled JSON so a fresh install with no
+    analysis yet still produces a usable Similarity / Alchemy page.
+    """
+    from .sonic_backends import active_backend_name
+    from app_helper import get_db
+
+    backend = backend or active_backend_name()
+    result: Dict[str, Dict[str, Any]] = {}
+    try:
+        with get_db() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT mood, centroids FROM mood_centroids_data WHERE backend = %s",
+                (backend,),
+            )
+            for mood, payload in cur.fetchall():
+                if isinstance(payload, str):
+                    payload = json.loads(payload)
+                result[mood] = payload
+    except Exception as e:
+        logger.warning("Failed to read mood_centroids_data for backend %r: %s", backend, e)
+
+    if result:
+        return result
+
+    # First-boot fallback: ship the legacy 200-dim MusiCNN JSON so the
+    # UI isn't empty before the first analysis run completes.
+    if backend == "musicnn":
+        try:
+            from config import MOOD_CENTROIDS_FILE
+            with open(MOOD_CENTROIDS_FILE) as f:
+                return json.load(f)
+        except Exception as e:
+            logger.info("Legacy mood centroids JSON unavailable: %s", e)
+    return {}

--- a/tasks/mood_centroids_manager.py
+++ b/tasks/mood_centroids_manager.py
@@ -184,7 +184,7 @@ def build_and_store_mood_centroids(db_conn=None) -> bool:
             try:
                 centroids = _cluster_one_mood(rows, EMBEDDING_DIMENSION, MOOD_CENTROIDS_K)
             except Exception as e:
-                logger.error("Failed to cluster mood '%s': %s", mood, e, exc_info=True)
+                logger.exception("Failed to cluster mood '%s': %s", mood, e)
                 continue
             payload = {
                 "best_k": len(centroids),

--- a/tasks/sem_grove_manager.py
+++ b/tasks/sem_grove_manager.py
@@ -184,11 +184,12 @@ def build_and_store_sem_grove_index(db_conn=None) -> bool:
             return False
 
         logger.info("SemGrove: streaming audio embeddings…")
+        from .voyager_manager import _backend_sql_literal
         audio_buf, audio_ids = stream_embeddings_to_buffer(
             table="embedding",
             column="embedding",
             dim=audio_dim,
-            where_clause="embedding IS NOT NULL",
+            where_clause=f"embedding IS NOT NULL AND backend = {_backend_sql_literal()}",
         )
         if audio_buf.shape[0] == 0:
             logger.warning("SemGrove: no audio embeddings found; aborting.")

--- a/tasks/song_alchemy.py
+++ b/tasks/song_alchemy.py
@@ -74,15 +74,13 @@ def _get_mood_centroid_vector(item_id: str):
     mood_name, idx_str = parts[0].strip().lower(), parts[1].strip()
     try:
         cidx = int(idx_str)
-        import json as _json
-        with open(config.MOOD_CENTROIDS_FILE) as _f:
-            _mcdata = _json.load(_f)
-        centroids_list = _mcdata.get(mood_name, {}).get('centroids', [])
+        from .mood_centroids_manager import load_mood_centroids
+        centroids_list = load_mood_centroids().get(mood_name, {}).get('centroids', [])
         if 0 <= cidx < len(centroids_list):
             vec = centroids_list[cidx].get('centroid')
             if vec:
                 return np.array(vec, dtype=float)
-    except (ValueError, FileNotFoundError) as exc:
+    except (ValueError, KeyError) as exc:
         logger.warning(f"Failed to load mood centroid from '{item_id}': {exc}")
     return None
 

--- a/tasks/sonic_backends/__init__.py
+++ b/tasks/sonic_backends/__init__.py
@@ -1,0 +1,47 @@
+# tasks/sonic_backends/__init__.py
+"""Sonic-analysis backend registry.
+
+Backend modules are imported lazily on first ``get_backend()`` call so
+that simply importing ``tasks.sonic_backends`` does not pull in optional
+ML dependencies (transformers, torch) that the default ``musicnn``
+backend does not need.
+"""
+
+from .base import SonicBackend, available_backends, get_backend, register
+
+_LOADED = False
+
+
+def _ensure_loaded() -> None:
+    """Import every shipped backend module exactly once.
+
+    Each module registers itself by instantiating its backend class at
+    import time. Imports that fail (e.g. MERT when ``transformers`` is
+    not installed) are logged at warning level and the rest still
+    register — selecting a missing backend then raises a clear error in
+    ``get_backend()``.
+    """
+    global _LOADED
+    if _LOADED:
+        return
+    _LOADED = True  # guard against re-entry on import errors
+
+    import logging
+    logger = logging.getLogger(__name__)
+
+    # musicnn must always be importable — it is the default backend and
+    # has no optional deps.
+    from . import musicnn  # noqa: F401
+
+    for optional in ("mert",):
+        try:
+            __import__(f"{__name__}.{optional}")
+        except Exception as e:  # noqa: BLE001
+            logger.info(
+                "Sonic backend '%s' not available: %s. "
+                "Install its extras to enable.",
+                optional, e,
+            )
+
+
+__all__ = ["SonicBackend", "available_backends", "get_backend", "register"]

--- a/tasks/sonic_backends/__init__.py
+++ b/tasks/sonic_backends/__init__.py
@@ -9,6 +9,29 @@ backend does not need.
 
 from .base import SonicBackend, available_backends, get_backend, register
 
+
+def active_backend_name() -> str:
+    """Return the currently configured backend name.
+
+    Read lazily from :mod:`config` so reloading the module (e.g. during
+    tests that monkeypatch ``SONIC_BACKEND``) picks up the new value.
+    """
+    from config import SONIC_BACKEND
+    return SONIC_BACKEND
+
+
+def voyager_index_name(backend: str | None = None) -> str:
+    """Per-backend Voyager primary key in ``voyager_index_data``.
+
+    Always namespaced: legacy bare-named ``music_library`` rows are
+    migrated to ``music_library_musicnn`` at ``init_db`` time so every
+    row has an unambiguous backend tag. When ``backend`` is None, the
+    active backend is used.
+    """
+    from config import INDEX_NAME
+    name = backend or active_backend_name()
+    return f"{INDEX_NAME}_{name}"
+
 _LOADED = False
 
 
@@ -44,4 +67,7 @@ def _ensure_loaded() -> None:
             )
 
 
-__all__ = ["SonicBackend", "available_backends", "get_backend", "register"]
+__all__ = [
+    "SonicBackend", "active_backend_name", "available_backends",
+    "get_backend", "register", "voyager_index_name",
+]

--- a/tasks/sonic_backends/base.py
+++ b/tasks/sonic_backends/base.py
@@ -1,0 +1,109 @@
+# tasks/sonic_backends/base.py
+"""Pluggable sonic-analysis backend interface.
+
+Each backend owns the entire ``(audio, sr) -> (track_embedding, moods)``
+pipeline for a single track. The default backend (``musicnn``) reproduces
+the historical Essentia-lineage path bit-for-bit so existing Voyager
+indexes, ``embedding`` rows and ``score.mood_vector`` strings stay valid.
+Alternative backends (e.g. ``mert``) can substitute the embedding (and
+optionally the tagging head) without the rest of the analysis pipeline
+needing to care.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class SonicBackend(ABC):
+    """Backend for sonic embedding + mood-tag prediction.
+
+    Lifecycle:
+      * ``load_sessions()`` is called once per album (or once per track
+        when ``PER_SONG_MODEL_RELOAD`` is set). The returned dict is
+        opaque to callers — backends can stash ONNX sessions, torch
+        modules, tokenizers, anything they need.
+      * ``analyze()`` is called per track and returns the per-track
+        embedding + a ``{mood_label: score}`` dict (or ``None`` on
+        failure).
+      * ``cleanup_sessions()`` releases the resources allocated by
+        ``load_sessions()``.
+
+    The ``target_sr`` class attribute tells the orchestrator at what
+    sample rate to load audio. Backends that need a different rate
+    internally should resample inside ``analyze()`` rather than forcing
+    the orchestrator to round-trip to disk.
+    """
+
+    name: str = ""
+    embedding_dim: int = 0
+    target_sr: int = 16000
+
+    @abstractmethod
+    def load_sessions(self) -> Dict[str, Any]:
+        """Allocate model resources. May raise on permanent failure."""
+
+    @abstractmethod
+    def cleanup_sessions(self, sessions: Dict[str, Any], context: str = "") -> None:
+        """Release model resources. Must never raise."""
+
+    @abstractmethod
+    def analyze(
+        self,
+        audio: np.ndarray,
+        sr: int,
+        sessions: Optional[Dict[str, Any]],
+        *,
+        file_basename: str,
+        mood_labels: List[str],
+    ) -> Optional[Tuple[np.ndarray, Dict[str, float]]]:
+        """Run the full per-track pipeline.
+
+        Returns ``(track_embedding, moods)`` where ``track_embedding`` is
+        a 1-D float32 array of length ``embedding_dim`` and ``moods`` is
+        ``{mood_label: probability}`` aligned with ``mood_labels``.
+
+        Returns ``None`` on per-track failures the caller should skip.
+        Hard failures (model load errors, etc.) should raise.
+        """
+
+
+_REGISTRY: Dict[str, SonicBackend] = {}
+
+
+def register(backend: SonicBackend) -> SonicBackend:
+    """Register a backend instance under its ``name``."""
+    if not backend.name:
+        raise ValueError("Backend must define a non-empty .name")
+    _REGISTRY[backend.name] = backend
+    return backend
+
+
+def get_backend(name: str) -> SonicBackend:
+    """Return the singleton backend instance for ``name``.
+
+    Importing this module triggers backend module imports lazily via
+    ``tasks.sonic_backends`` so callers do not need to worry about
+    registration order.
+    """
+    if name not in _REGISTRY:
+        from . import _ensure_loaded  # noqa: WPS433 — lazy load on demand
+        _ensure_loaded()
+    if name not in _REGISTRY:
+        available = ", ".join(sorted(_REGISTRY)) or "(none registered)"
+        raise ValueError(
+            f"Unknown SONIC_BACKEND '{name}'. Available backends: {available}"
+        )
+    return _REGISTRY[name]
+
+
+def available_backends() -> List[str]:
+    from . import _ensure_loaded
+    _ensure_loaded()
+    return sorted(_REGISTRY)

--- a/tasks/sonic_backends/mert.py
+++ b/tasks/sonic_backends/mert.py
@@ -80,6 +80,7 @@ class MERTBackend(SonicBackend):
             EMBEDDING_MODEL_PATH, PREDICTION_MODEL_PATH,
             MERT_MODEL_ID, MERT_LAYER, MERT_DEVICE,
             MERT_HF_CACHE_DIR, MERT_TARGET_SR,
+            MERT_CHUNK_SECONDS, MERT_MIN_CHUNK_SECONDS,
         )
         self._musicnn_paths = {
             "embedding": EMBEDDING_MODEL_PATH,
@@ -90,6 +91,8 @@ class MERTBackend(SonicBackend):
         self._device_pref = MERT_DEVICE
         self._cache_dir = MERT_HF_CACHE_DIR or None
         self.target_sr = int(MERT_TARGET_SR)
+        self._chunk_seconds = float(MERT_CHUNK_SECONDS)
+        self._min_chunk_seconds = float(MERT_MIN_CHUNK_SECONDS)
         if self._model_id in _KNOWN_DIMS:
             self.embedding_dim = _KNOWN_DIMS[self._model_id]
         else:
@@ -261,21 +264,50 @@ class MERTBackend(SonicBackend):
             logger.warning("MERT got empty audio for %s", file_basename)
             return None
 
-        inputs = processor(
-            audio, sampling_rate=target_sr, return_tensors="pt",
-        )
-        # Move tensor inputs to the model's device. ``processor`` returns
-        # a BatchFeature dict-like.
-        inputs = {k: v.to(device) for k, v in inputs.items() if hasattr(v, "to")}
-
-        with torch.no_grad():
-            outputs = model(**inputs, output_hidden_states=True)
-        hidden_states = outputs.hidden_states  # tuple of (B, T, D), len = num_layers+1
+        # Chunk the audio into fixed-length windows and mean-pool the
+        # per-chunk track embeddings. MERT was pretrained on short
+        # clips (HuBERT-style), so chunking keeps inference in
+        # distribution and bounds per-track latency to a constant
+        # ``ceil(track_seconds / chunk_seconds)`` forward passes. A
+        # trailing chunk shorter than ``min_chunk_samples`` is dropped
+        # rather than padded, since its mean would just be noise from
+        # the tail end. If the whole track is shorter than the min
+        # chunk threshold, we still embed it as one short pass so
+        # very short clips don't silently fail to produce a vector.
+        chunk_samples = int(self._chunk_seconds * target_sr)
+        min_chunk_samples = int(self._min_chunk_seconds * target_sr)
         layer = self._layer if isinstance(self._layer, int) else -1
-        layer_out = hidden_states[layer]  # (1, T, D)
-        # Mean-pool over the time axis to get a single fixed-dim vector.
-        track_vec = layer_out.mean(dim=1).squeeze(0)
-        return track_vec.detach().cpu().numpy()
+
+        if audio.size <= chunk_samples:
+            chunks = [audio]
+        else:
+            chunks = [
+                audio[i:i + chunk_samples]
+                for i in range(0, audio.size, chunk_samples)
+            ]
+            if len(chunks) > 1 and chunks[-1].size < min_chunk_samples:
+                chunks.pop()
+
+        chunk_vecs = []
+        for chunk in chunks:
+            inputs = processor(
+                chunk, sampling_rate=target_sr, return_tensors="pt",
+            )
+            inputs = {k: v.to(device) for k, v in inputs.items() if hasattr(v, "to")}
+            with torch.no_grad():
+                outputs = model(**inputs, output_hidden_states=True)
+            layer_out = outputs.hidden_states[layer]  # (1, T, D)
+            chunk_vecs.append(
+                layer_out.mean(dim=1).squeeze(0).detach().cpu().numpy()
+            )
+
+        if not chunk_vecs:
+            return None
+        # Mean-pool across chunks. Equal weighting is the standard
+        # MIR choice — both volume-weighted and energy-weighted
+        # variants exist but don't measurably help similarity recall
+        # in the published benchmarks.
+        return np.mean(np.stack(chunk_vecs, axis=0), axis=0)
 
 
 register(MERTBackend())

--- a/tasks/sonic_backends/mert.py
+++ b/tasks/sonic_backends/mert.py
@@ -1,0 +1,281 @@
+# tasks/sonic_backends/mert.py
+"""MERT-based sonic backend (self-supervised music foundation model).
+
+MERT (`m-a-p/MERT-v1-95M` / `-330M`) replaces the MusiCNN CNN as the
+source of the *similarity* embedding stored in the ``embedding`` table
+and indexed by Voyager. Mood tagging is intentionally still handled by
+the existing MusiCNN-prediction ONNX head: it consumes MusiCNN
+embeddings, so swapping it requires either training a new head on MERT
+features (out of scope for this backend) or using a zero-shot text
+scorer like CLAP. Keeping the legacy tag head means ``mood_vector`` /
+``score.mood_vector`` rows stay consistent with what the rest of the
+codebase expects (Song Alchemy mood priors, CLAP "other features"
+zero-shot scoring, the UI filters, etc.).
+
+Backend selection is controlled by the ``SONIC_BACKEND`` env var. When
+``mert`` is selected:
+
+  * The ``embedding`` column stores a 768-dim (MERT-95M) or 1024-dim
+    (MERT-330M) float32 vector instead of 200-dim MusiCNN.
+  * ``EMBEDDING_DIMENSION`` in :mod:`config` resolves to the MERT dim,
+    so the Voyager index is built at the correct size.
+  * Existing 200-dim Voyager indexes / ``embedding`` rows are NOT
+    forwards-compatible — switching backends requires re-running
+    analysis from scratch. See the release notes pattern used for the
+    v2.0 lyrics model swap.
+
+Audio is resampled inside this backend (MERT wants 24 kHz mono); the
+orchestrator still loads at ``target_sr`` = 24000 to skip the
+re-resample, but ``analyze()`` also accepts 16 kHz audio and resamples
+on the fly so the same audio buffer can feed both the MERT embedding
+and the (16 kHz) MusiCNN tag head without a second decode.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .base import SonicBackend, register
+from .musicnn import _run_musicnn
+
+logger = logging.getLogger(__name__)
+
+# Imported at use time so the module can register itself even when torch
+# / transformers are not installed (selection-time error is friendlier
+# than import-time crash).
+_torch = None
+_transformers = None
+_librosa = None
+
+
+def _lazy_imports() -> None:
+    global _torch, _transformers, _librosa
+    if _torch is None:
+        import torch  # noqa: WPS433
+        _torch = torch
+    if _transformers is None:
+        import transformers  # noqa: WPS433
+        _transformers = transformers
+    if _librosa is None:
+        import librosa  # noqa: WPS433
+        _librosa = librosa
+
+
+# Dimensions of the public MERT-v1 checkpoints, used to pre-declare
+# ``embedding_dim`` before any model weights have been downloaded.
+_KNOWN_DIMS = {
+    "m-a-p/MERT-v1-95M": 768,
+    "m-a-p/MERT-v1-330M": 1024,
+}
+
+
+class MERTBackend(SonicBackend):
+    name = "mert"
+
+    def __init__(self) -> None:
+        from config import (
+            EMBEDDING_MODEL_PATH, PREDICTION_MODEL_PATH,
+            MERT_MODEL_ID, MERT_LAYER, MERT_DEVICE,
+            MERT_HF_CACHE_DIR, MERT_TARGET_SR,
+        )
+        self._musicnn_paths = {
+            "embedding": EMBEDDING_MODEL_PATH,
+            "prediction": PREDICTION_MODEL_PATH,
+        }
+        self._model_id = MERT_MODEL_ID
+        self._layer = MERT_LAYER
+        self._device_pref = MERT_DEVICE
+        self._cache_dir = MERT_HF_CACHE_DIR or None
+        self.target_sr = int(MERT_TARGET_SR)
+        if self._model_id in _KNOWN_DIMS:
+            self.embedding_dim = _KNOWN_DIMS[self._model_id]
+        else:
+            # Unknown checkpoint — fall back to MERT-95M-style 768. Hard
+            # error happens at first inference if the real dim differs.
+            self.embedding_dim = 768
+            logger.warning(
+                "Unknown MERT model id '%s' — assuming embedding_dim=768. "
+                "Set MERT_MODEL_ID to one of %s for an explicit value.",
+                self._model_id, sorted(_KNOWN_DIMS),
+            )
+
+    # --- session management ------------------------------------------------
+
+    def load_sessions(self) -> Dict[str, Any]:
+        _lazy_imports()
+        torch = _torch
+        device = self._resolve_device()
+        logger.info(
+            "Loading MERT model '%s' on %s (layer=%s)",
+            self._model_id, device, self._layer,
+        )
+        kwargs = {"trust_remote_code": True}
+        if self._cache_dir:
+            kwargs["cache_dir"] = self._cache_dir
+        processor = _transformers.Wav2Vec2FeatureExtractor.from_pretrained(
+            self._model_id, **kwargs,
+        )
+        model = _transformers.AutoModel.from_pretrained(
+            self._model_id, **kwargs,
+        )
+        model.eval()
+        model.to(device)
+        # Validate that the configured layer index is actually reachable.
+        # MERT-95M ships 12 hidden layers + the conv output; -1 (last
+        # layer) is always valid.
+        num_layers = getattr(model.config, "num_hidden_layers", None)
+        if num_layers is not None and isinstance(self._layer, int):
+            if self._layer < -1 or self._layer >= num_layers:
+                logger.warning(
+                    "MERT_LAYER=%s out of range for %s (num_hidden_layers=%s); "
+                    "clamping to last layer.",
+                    self._layer, self._model_id, num_layers,
+                )
+                self._layer = -1
+        # MusiCNN sessions for the tag head. Reused via the same shared
+        # dict semantics as the MusiCNN backend so album-level reuse
+        # works identically.
+        from .. import analysis_helper as _ah
+        musicnn = _ah.load_musicnn_sessions(self._musicnn_paths)
+        if musicnn is None:
+            raise RuntimeError("Failed to load MusiCNN tag head for MERT backend")
+
+        return {
+            "mert_model": model,
+            "mert_processor": processor,
+            "mert_device": device,
+            "mert_sr": processor.sampling_rate,
+            "musicnn": musicnn,
+        }
+
+    def cleanup_sessions(self, sessions: Dict[str, Any], context: str = "") -> None:
+        try:
+            from .. import analysis_helper as _ah
+            _ah.cleanup_musicnn_sessions(sessions.get("musicnn"), context=context)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("MusiCNN tag-head cleanup raised (suppressed): %s", e)
+
+        try:
+            model = sessions.pop("mert_model", None)
+            if model is not None:
+                # Move to CPU before dropping refs so any CUDA buffers
+                # held by parameters are freed deterministically.
+                try:
+                    model.to("cpu")
+                except Exception:
+                    pass
+                del model
+            sessions.pop("mert_processor", None)
+            if _torch is not None and _torch.cuda.is_available():
+                _torch.cuda.empty_cache()
+        except Exception as e:  # noqa: BLE001
+            logger.warning("MERT cleanup raised (suppressed): %s", e)
+
+    # --- per-track analysis ------------------------------------------------
+
+    def analyze(
+        self,
+        audio: np.ndarray,
+        sr: int,
+        sessions: Optional[Dict[str, Any]],
+        *,
+        file_basename: str,
+        mood_labels: List[str],
+    ) -> Optional[Tuple[np.ndarray, Dict[str, float]]]:
+        if sessions is None:
+            sessions = self.load_sessions()
+            owns_sessions = True
+        else:
+            owns_sessions = False
+
+        try:
+            mert_emb = self._embed_with_mert(audio, sr, sessions, file_basename)
+            if mert_emb is None:
+                return None
+
+            # MusiCNN expects 16 kHz; we either have it (orchestrator
+            # passes 16 kHz when MusicNN is the only backend) or have to
+            # resample down from the MERT-target rate.
+            if sr == 16000:
+                musicnn_audio, musicnn_sr = audio, sr
+            else:
+                _lazy_imports()
+                musicnn_audio = _librosa.resample(
+                    audio.astype(np.float32, copy=False), orig_sr=sr, target_sr=16000,
+                )
+                musicnn_sr = 16000
+
+            tagging = _run_musicnn(
+                audio=musicnn_audio, sr=musicnn_sr,
+                sessions=sessions["musicnn"], model_paths=self._musicnn_paths,
+                file_basename=file_basename,
+            )
+            if tagging is None:
+                return None
+            _, mood_logits = tagging
+            from .. import analysis_helper as _ah
+            mood_probs_per_patch = _ah.sigmoid(mood_logits)
+            final_mood_predictions = _ah.sigmoid(np.mean(mood_probs_per_patch, axis=0))
+            moods = {
+                label: float(score)
+                for label, score in zip(mood_labels, final_mood_predictions)
+            }
+            return mert_emb.astype(np.float32, copy=False), moods
+        finally:
+            if owns_sessions:
+                self.cleanup_sessions(sessions, context=file_basename)
+
+    # --- internals ---------------------------------------------------------
+
+    def _resolve_device(self) -> str:
+        _lazy_imports()
+        pref = (self._device_pref or "auto").lower()
+        if pref == "cuda" or (pref == "auto" and _torch.cuda.is_available()):
+            return "cuda" if _torch.cuda.is_available() else "cpu"
+        return "cpu"
+
+    def _embed_with_mert(
+        self,
+        audio: np.ndarray,
+        sr: int,
+        sessions: Dict[str, Any],
+        file_basename: str,
+    ) -> Optional[np.ndarray]:
+        _lazy_imports()
+        torch = _torch
+        processor = sessions["mert_processor"]
+        model = sessions["mert_model"]
+        device = sessions["mert_device"]
+        target_sr = sessions.get("mert_sr") or self.target_sr
+
+        if sr != target_sr:
+            audio = _librosa.resample(
+                audio.astype(np.float32, copy=False),
+                orig_sr=sr, target_sr=target_sr,
+            )
+
+        if audio.size == 0:
+            logger.warning("MERT got empty audio for %s", file_basename)
+            return None
+
+        inputs = processor(
+            audio, sampling_rate=target_sr, return_tensors="pt",
+        )
+        # Move tensor inputs to the model's device. ``processor`` returns
+        # a BatchFeature dict-like.
+        inputs = {k: v.to(device) for k, v in inputs.items() if hasattr(v, "to")}
+
+        with torch.no_grad():
+            outputs = model(**inputs, output_hidden_states=True)
+        hidden_states = outputs.hidden_states  # tuple of (B, T, D), len = num_layers+1
+        layer = self._layer if isinstance(self._layer, int) else -1
+        layer_out = hidden_states[layer]  # (1, T, D)
+        # Mean-pool over the time axis to get a single fixed-dim vector.
+        track_vec = layer_out.mean(dim=1).squeeze(0)
+        return track_vec.detach().cpu().numpy()
+
+
+register(MERTBackend())

--- a/tasks/sonic_backends/mert.py
+++ b/tasks/sonic_backends/mert.py
@@ -109,7 +109,6 @@ class MERTBackend(SonicBackend):
 
     def load_sessions(self) -> Dict[str, Any]:
         _lazy_imports()
-        torch = _torch
         device = self._resolve_device()
         logger.info(
             "Loading MERT model '%s' on %s (layer=%s)",

--- a/tasks/sonic_backends/musicnn.py
+++ b/tasks/sonic_backends/musicnn.py
@@ -1,0 +1,165 @@
+# tasks/sonic_backends/musicnn.py
+"""Default sonic backend: MusiCNN embedding + MusiCNN-prediction tag head.
+
+This is the historical AudioMuse path lifted out of ``tasks/analysis.py``
+so existing Voyager indexes, ``embedding`` table rows and
+``score.mood_vector`` strings remain valid when this backend is
+selected. It is the default — set ``SONIC_BACKEND=musicnn`` or leave the
+variable unset to keep behavior unchanged.
+
+The OOM-fallback dance (drop the OOM'd GPU session, allocate a CPU
+session, rewire the shared album-level dict so subsequent tracks pick
+up the fallback) lives here rather than in the orchestrator because it
+is MusiCNN-specific: MERT-style backends do their fallback inside
+``torch`` instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+
+from .. import analysis_helper as _ah
+from .base import SonicBackend, register
+
+logger = logging.getLogger(__name__)
+
+
+class MusiCNNBackend(SonicBackend):
+    name = "musicnn"
+    embedding_dim = 200
+    target_sr = 16000
+
+    def __init__(self) -> None:
+        # Defer config import to instance time so unit tests that stub
+        # ``config`` after import still pick up the active values.
+        from config import EMBEDDING_MODEL_PATH, PREDICTION_MODEL_PATH
+        self._model_paths = {
+            "embedding": EMBEDDING_MODEL_PATH,
+            "prediction": PREDICTION_MODEL_PATH,
+        }
+
+    # --- session management ------------------------------------------------
+
+    def load_sessions(self) -> Dict[str, Any]:
+        sessions = _ah.load_musicnn_sessions(self._model_paths)
+        if sessions is None:
+            raise RuntimeError("Failed to load MusiCNN ONNX sessions")
+        return sessions
+
+    def cleanup_sessions(self, sessions: Dict[str, Any], context: str = "") -> None:
+        try:
+            _ah.cleanup_musicnn_sessions(sessions, context=context)
+        except Exception as e:  # noqa: BLE001
+            logger.warning("MusiCNN cleanup raised (suppressed): %s", e)
+
+    # --- per-track analysis ------------------------------------------------
+
+    def analyze(
+        self,
+        audio: np.ndarray,
+        sr: int,
+        sessions: Optional[Dict[str, Any]],
+        *,
+        file_basename: str,
+        mood_labels: List[str],
+    ) -> Optional[Tuple[np.ndarray, Dict[str, float]]]:
+        embeddings_per_patch = _run_musicnn(
+            audio=audio, sr=sr,
+            sessions=sessions, model_paths=self._model_paths,
+            file_basename=file_basename,
+        )
+        if embeddings_per_patch is None:
+            return None
+        embeddings_per_patch, mood_logits = embeddings_per_patch
+        # Replicate the historical "double sigmoid" mood pipeline (see
+        # tasks.analysis comment block — old Essentia ONNX baked sigmoid
+        # in; the new prediction ONNX outputs raw logits, and downstream
+        # code is calibrated for sigmoid(mean(sigmoid(logits)))).
+        mood_probs_per_patch = _ah.sigmoid(mood_logits)
+        final_mood_predictions = _ah.sigmoid(np.mean(mood_probs_per_patch, axis=0))
+        moods = {
+            label: float(score)
+            for label, score in zip(mood_labels, final_mood_predictions)
+        }
+        track_embedding = np.mean(embeddings_per_patch, axis=0).astype(np.float32, copy=False)
+        return track_embedding, moods
+
+
+def _run_musicnn(
+    *,
+    audio: np.ndarray,
+    sr: int,
+    sessions: Optional[Dict[str, Any]],
+    model_paths: Dict[str, str],
+    file_basename: str,
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
+    """Inner MusiCNN inference: ``audio -> (embeddings_per_patch, mood_logits)``.
+
+    Returns ``None`` when the track is too short to form a single
+    spectrogram patch (caller should skip the track silently). Raises
+    on hard model failures.
+
+    Exposed as a module-level function (rather than a method) so the
+    MERT backend can reuse it to keep MusiCNN-quality mood tags while
+    substituting only the stored similarity embedding.
+    """
+    try:
+        final_patches = _ah.prepare_spectrogram_patches(audio, sr)
+    except Exception as e:
+        logger.error("Spectrogram creation failed for %s: %s", file_basename, e, exc_info=True)
+        return None
+    if final_patches is None:
+        logger.warning("Track too short to create spectrogram patches: %s", file_basename)
+        return None
+
+    owns_sessions = sessions is None
+    if owns_sessions:
+        provider_options = _ah.get_provider_options()
+        sessions = {
+            "embedding": _ah.create_onnx_session(model_paths["embedding"], provider_options, label="embedding"),
+            "prediction": _ah.create_onnx_session(model_paths["prediction"], provider_options, label="prediction"),
+        }
+
+    try:
+        embedding_sess = sessions["embedding"]
+        prediction_sess = sessions["prediction"]
+
+        original_embedding_sess = embedding_sess
+        original_prediction_sess = prediction_sess
+
+        embedding_feed = {_ah.DEFINED_TENSOR_NAMES["embedding"]["input"]: final_patches}
+        embeddings_per_patch, embedding_sess = _ah.run_inference_with_oom_fallback(
+            embedding_sess, embedding_feed,
+            _ah.DEFINED_TENSOR_NAMES["embedding"]["output"],
+            model_paths["embedding"], "embedding",
+            owns_sessions, file_basename,
+        )
+        if embedding_sess is not original_embedding_sess:
+            sessions["embedding"] = embedding_sess
+            original_embedding_sess = None  # release the OOM'd GPU buffer NOW
+
+        prediction_feed = {_ah.DEFINED_TENSOR_NAMES["prediction"]["input"]: embeddings_per_patch}
+        mood_logits, prediction_sess = _ah.run_inference_with_oom_fallback(
+            prediction_sess, prediction_feed,
+            _ah.DEFINED_TENSOR_NAMES["prediction"]["output"],
+            model_paths["prediction"], "prediction",
+            owns_sessions, file_basename,
+        )
+        if prediction_sess is not original_prediction_sess:
+            sessions["prediction"] = prediction_sess
+            original_prediction_sess = None
+
+        return embeddings_per_patch, mood_logits
+    finally:
+        if owns_sessions:
+            try:
+                _ah.cleanup_musicnn_sessions(sessions, context=file_basename)
+            except Exception as cleanup_error:  # noqa: BLE001
+                logger.warning("Error during single-track MusiCNN cleanup: %s", cleanup_error)
+
+
+register(MusiCNNBackend())

--- a/tasks/sonic_backends/musicnn.py
+++ b/tasks/sonic_backends/musicnn.py
@@ -110,7 +110,7 @@ def _run_musicnn(
     try:
         final_patches = _ah.prepare_spectrogram_patches(audio, sr)
     except Exception as e:
-        logger.error("Spectrogram creation failed for %s: %s", file_basename, e, exc_info=True)
+        logger.exception("Spectrogram creation failed for %s: %s", file_basename, e)
         return None
     if final_patches is None:
         logger.warning("Track too short to create spectrogram patches: %s", file_basename)

--- a/tasks/voyager_manager.py
+++ b/tasks/voyager_manager.py
@@ -22,15 +22,43 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import lru_cache
 import threading
 
-from config import EMBEDDING_DIMENSION, INDEX_NAME, VOYAGER_METRIC, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB, MAX_SONGS_PER_ARTIST, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN, DUPLICATE_DISTANCE_CHECK_LOOKBACK, MOOD_SIMILARITY_THRESHOLD, SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT, MOOD_SIMILARITY_ENABLE
+from config import EMBEDDING_DIMENSION, VOYAGER_METRIC, VOYAGER_QUERY_EF, VOYAGER_MAX_PART_SIZE_MB, MAX_SONGS_PER_ARTIST, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN, DUPLICATE_DISTANCE_CHECK_LOOKBACK, MOOD_SIMILARITY_THRESHOLD, SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT, MOOD_SIMILARITY_ENABLE
+from .sonic_backends import active_backend_name, voyager_index_name
 
 logger = logging.getLogger(__name__)
+
+
+def _backend_sql_literal() -> str:
+    """Active backend as a SQL string literal, validated for identifier shape.
+
+    The result is interpolated directly into the WHERE clauses passed
+    to :func:`iter_embedding_batches` (which doesn't accept parameter
+    binding). Backend names come from the controlled ``SONIC_BACKEND``
+    env var; we still gate on ``^[a-z_][a-z0-9_]*$`` so a typo doesn't
+    silently turn into a SQL injection vector.
+    """
+    name = active_backend_name()
+    if not re.fullmatch(r"[a-z_][a-z0-9_]*", name):
+        raise ValueError(f"Invalid SONIC_BACKEND name {name!r}")
+    return f"'{name}'"
+
+
+# Active Voyager index primary key. Always namespaced per backend; legacy
+# bare ``music_library`` rows are migrated to the musicnn namespace at
+# init_db time.
+def __getattr__(name):
+    # Lazy attribute so external callers that ``from tasks.voyager_manager
+    # import INDEX_NAME`` keep working AND pick up SONIC_BACKEND changes
+    # without needing the module reloaded.
+    if name == "INDEX_NAME":
+        return voyager_index_name()
+    raise AttributeError(name)
 
 # Optional instrumentation: enable with RADIUS_INSTRUMENTATION=True in env
 INSTRUMENT_BUCKET_SKIPS = os.environ.get("RADIUS_INSTRUMENTATION", "False").lower() == 'true'
 
 # When the serialized Voyager index exceeds this threshold the index
-# will be written into multiple rows as: <INDEX_NAME>_<part_no>_<total_parts>
+# will be written into multiple rows as: <voyager_index_name()>_<part_no>_<total_parts>
 # Configurable via `VOYAGER_MAX_PART_SIZE_MB` in `config.py` (default 50 MB).
 VOYAGER_MAX_PART_SIZE = VOYAGER_MAX_PART_SIZE_MB * 1024 * 1024
 
@@ -149,14 +177,14 @@ def load_voyager_index_for_querying(force_reload=False):
     cur = conn.cursor()
     try:
         # 1) Try the classic single-row index first (backwards compatible)
-        cur.execute("SELECT index_data, id_map_json, embedding_dimension FROM voyager_index_data WHERE index_name = %s", (INDEX_NAME,))
+        cur.execute("SELECT index_data, id_map_json, embedding_dimension FROM voyager_index_data WHERE index_name = %s", (voyager_index_name(),))
         record = cur.fetchone()
 
         if record:
             index_binary_data, id_map_json, db_embedding_dim = record
 
             if not index_binary_data:
-                logger.error(f"Voyager index '{INDEX_NAME}' data in database is empty.")
+                logger.error(f"Voyager index '{voyager_index_name()}' data in database is empty.")
                 voyager_index, id_map, reverse_id_map = None, None, None
                 return
 
@@ -175,20 +203,20 @@ def load_voyager_index_for_querying(force_reload=False):
             logger.info(f"Voyager index with {len(id_map)} items loaded successfully into memory.")
             return
 
-        # 2) If not found, look for segmented rows named INDEX_NAME_<part>_<total>
+        # 2) If not found, look for segmented rows named voyager_index_name()_<part>_<total>
         cur.execute(
             "SELECT index_name, index_data, id_map_json, embedding_dimension FROM voyager_index_data WHERE index_name LIKE %s ESCAPE '\\'",
-            (INDEX_NAME.replace('_', r'\_') + r"\_%\_%",)
+            (voyager_index_name().replace('_', r'\_') + r"\_%\_%",)
         )
         candidates = cur.fetchall()
 
         if not candidates:
-            logger.warning(f"Voyager index '{INDEX_NAME}' not found in the database (single or segmented). Cache will be empty.")
+            logger.warning(f"Voyager index '{voyager_index_name()}' not found in the database (single or segmented). Cache will be empty.")
             voyager_index, id_map, reverse_id_map = None, None, None
             return
 
         # Filter and parse segment suffixes (expect format: name_<part_no>_<total_parts>)
-        seg_pattern = re.compile(rf"^{re.escape(INDEX_NAME)}_(\d+)_(\d+)$")
+        seg_pattern = re.compile(rf"^{re.escape(voyager_index_name())}_(\d+)_(\d+)$")
         parts = []
         total_expected = None
         for row in candidates:
@@ -207,7 +235,7 @@ def load_voyager_index_for_querying(force_reload=False):
             parts.append((part_no, part_data, part_id_map_json, part_dim))
 
         if not parts:
-            logger.error(f"No valid segmented Voyager index rows found for prefix '{INDEX_NAME}'.")
+            logger.error(f"No valid segmented Voyager index rows found for prefix '{voyager_index_name()}'.")
             voyager_index, id_map, reverse_id_map = None, None, None
             return
 
@@ -311,6 +339,7 @@ def build_and_store_voyager_index(db_conn=None):
             table="embedding",
             column="embedding",
             dim=EMBEDDING_DIMENSION,
+            where_clause=f"backend = {_backend_sql_literal()}",
         )
         try:
             index_binary_data, item_ids = build_voyager_index_bytes_streaming(
@@ -329,12 +358,12 @@ def build_and_store_voyager_index(db_conn=None):
 
         local_id_map = build_id_map(item_ids)
 
-        logger.info(f"Storing Voyager index '{INDEX_NAME}' in the database...")
+        logger.info(f"Storing Voyager index '{voyager_index_name()}' in the database...")
         try:
             store_voyager_index_segmented(
                 db_conn,
                 target_table="voyager_index_data",
-                index_name=INDEX_NAME,
+                index_name=voyager_index_name(),
                 index_bytes=index_binary_data,
                 id_map=local_id_map,
                 embedding_dimension=EMBEDDING_DIMENSION,

--- a/templates/cleaning.html
+++ b/templates/cleaning.html
@@ -636,12 +636,7 @@
                     body: JSON.stringify({backend, confirm: true}),
                 });
                 const data = await res.json();
-                if (!res.ok) {
-                    sonicStateResult.innerHTML = `
-                        <h3>❌ Clear failed</h3>
-                        <p>${escapeHtml(data.error || 'Unknown error')}</p>
-                    `;
-                } else {
+                if (res.ok) {
                     const s = data.summary;
                     sonicStateResult.innerHTML = `
                         <h3>✅ Backend <code>${escapeHtml(s.backend)}</code> cleared</h3>
@@ -650,6 +645,11 @@
                         <p><strong>Mood centroid rows deleted:</strong> ${s.deleted_mood_centroids ?? 0}</p>
                     `;
                     renderSonicState(data.state);
+                } else {
+                    sonicStateResult.innerHTML = `
+                        <h3>❌ Clear failed</h3>
+                        <p>${escapeHtml(data.error || 'Unknown error')}</p>
+                    `;
                 }
                 sonicStateResult.style.display = 'block';
             } catch (e) {

--- a/templates/cleaning.html
+++ b/templates/cleaning.html
@@ -94,34 +94,28 @@
 
     <!-- Sonic Backend State Section -->
     <section id="sonic-state-section" style="margin-top: 2rem;">
-        <h2>Sonic Backend State</h2>
+        <h2>Sonic Backend Storage</h2>
         <p>
-            The audio similarity embedding stored per track is produced by
-            the configured <code>SONIC_BACKEND</code>. Different backends
-            emit different-dimensioned vectors (MusiCNN: 200; MERT-95M:
-            768; MERT-330M: 1024), and the Voyager index needs every row
-            to share the active dimension. After switching backends, use
-            the button below to drop stale audio embeddings + the audio
-            Voyager index so a fresh re-analysis can produce a clean,
-            consistent index.
+            Each sonic backend (<code>musicnn</code>, <code>mert</code>, …)
+            stores its audio embeddings and Voyager index under its own
+            namespace, so the data from any backend you've run survives
+            switching to a different one. Use this panel to inspect what
+            each backend has on disk and to free space by dropping a
+            backend you're no longer using.
         </p>
         <p style="font-size: 0.9em; color: var(--muted, #888);">
-            Untouched: CLAP embeddings, lyrics analysis, artist data,
-            playlists, app config, task history. Cleared: every row in
-            <code>embedding</code>, the audio Voyager index rows, and
-            the backend-derived columns on <code>score</code>
-            (tempo / key / scale / energy / mood_vector / other_features).
+            The active backend is read-only here — to clear its data,
+            switch <code>SONIC_BACKEND</code> in your compose / env first
+            and reload. CLAP, lyrics, artist data, score, playlists,
+            app config and task history are never touched by this panel.
         </p>
 
-        <div id="sonic-state-display" class="cleaning-summary" style="margin-bottom: 1rem;">
+        <div id="sonic-state-display" style="margin-bottom: 1rem;">
             <p>Loading current state...</p>
         </div>
 
-        <div class="task-buttons">
+        <div class="task-buttons" style="margin-bottom: 1rem;">
             <button id="refresh-sonic-state-btn">Refresh State</button>
-            <button id="clear-sonic-state-btn" class="danger-button" disabled>
-                Clear stale audio embeddings
-            </button>
         </div>
 
         <div id="sonic-state-result" style="display: none; margin-top: 1rem;" class="cleaning-summary">
@@ -541,105 +535,129 @@
             console.log('UI completely reset - all timers and intervals cleared');
         }
 
-        // --- Sonic Backend State panel -------------------------------------
+        // --- Sonic Backend Storage panel -----------------------------------
 
         const sonicStateDisplay = document.getElementById('sonic-state-display');
         const refreshSonicStateBtn = document.getElementById('refresh-sonic-state-btn');
-        const clearSonicStateBtn = document.getElementById('clear-sonic-state-btn');
         const sonicStateResult = document.getElementById('sonic-state-result');
 
-        function fmtDim(d) {
-            return (d === null || d === undefined) ? '—' : String(d);
+        function fmtNum(n) { return n === null || n === undefined ? '—' : String(n); }
+        function fmtDim(d) { return d === null || d === undefined ? '—' : String(d); }
+        function escapeHtml(s) {
+            return String(s).replace(/[&<>"']/g, c => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+            }[c]));
         }
 
         function renderSonicState(state) {
             if (state.error) {
                 sonicStateDisplay.innerHTML = `
-                    <p style="color: var(--color-failure, #c33);"><strong>Failed to inspect state:</strong> ${state.error}</p>
+                    <p style="color: var(--color-failure, #c33);"><strong>Failed to inspect state:</strong> ${escapeHtml(state.error)}</p>
                 `;
-                clearSonicStateBtn.disabled = true;
                 return;
             }
-            const mismatchBadge = state.mismatch
-                ? `<span style="color: var(--color-failure, #c33); font-weight: bold;">⚠ MISMATCH</span>`
-                : `<span style="color: var(--color-success, #2a8); font-weight: bold;">✓ consistent</span>`;
+            const rows = (state.backends || []).map(b => {
+                const backendName = escapeHtml(b.backend);
+                const activeBadge = b.is_active
+                    ? `<span style="color: var(--color-success, #2a8); font-weight: bold;">active</span>`
+                    : '';
+                const dimMismatch =
+                    b.is_active &&
+                    ((b.sample_stored_dim !== null && b.sample_stored_dim !== state.active_dim) ||
+                     (b.stored_voyager_dim !== null && b.stored_voyager_dim !== state.active_dim));
+                const mismatchNote = dimMismatch
+                    ? ` <span style="color: var(--color-failure, #c33); font-weight: bold;">⚠ dim mismatch</span>`
+                    : '';
+                const clearBtn = b.is_active
+                    ? `<button class="sonic-clear-btn" disabled title="Switch SONIC_BACKEND first to clear the active backend">Clear (active)</button>`
+                    : `<button class="sonic-clear-btn danger-button" data-backend="${backendName}">Clear this backend</button>`;
+                return `
+                    <tr>
+                        <td><code>${backendName}</code> ${activeBadge}${mismatchNote}</td>
+                        <td style="text-align: right;">${fmtNum(b.embedding_row_count)}</td>
+                        <td style="text-align: right;">${fmtDim(b.sample_stored_dim)}</td>
+                        <td style="text-align: right;">${fmtNum(b.voyager_row_count)}</td>
+                        <td style="text-align: right;">${fmtDim(b.stored_voyager_dim)}</td>
+                        <td>${clearBtn}</td>
+                    </tr>
+                `;
+            }).join('');
+
             sonicStateDisplay.innerHTML = `
-                <p><strong>Active backend:</strong> <code>${state.current_backend}</code>
-                   &nbsp;·&nbsp; <strong>writes dim:</strong> ${state.current_dim}
-                   &nbsp;·&nbsp; ${mismatchBadge}</p>
-                <p><strong>embedding rows:</strong> ${state.embedding_row_count}
-                   &nbsp;·&nbsp; <strong>sampled stored dim:</strong> ${fmtDim(state.sample_stored_dim)}</p>
-                <p><strong>voyager_index_data rows:</strong> ${state.voyager_row_count}
-                   &nbsp;·&nbsp; <strong>stored voyager dim:</strong> ${fmtDim(state.stored_voyager_dim)}</p>
+                <p>
+                    <strong>Active backend:</strong> <code>${escapeHtml(state.active_backend)}</code>
+                    &nbsp;·&nbsp; <strong>writes dim:</strong> ${state.active_dim}
+                </p>
+                <table style="width: 100%; border-collapse: collapse;">
+                    <thead>
+                        <tr style="border-bottom: 1px solid var(--border, #444);">
+                            <th style="text-align: left; padding: 0.4em 0.6em;">Backend</th>
+                            <th style="text-align: right; padding: 0.4em 0.6em;">embedding rows</th>
+                            <th style="text-align: right; padding: 0.4em 0.6em;">sampled dim</th>
+                            <th style="text-align: right; padding: 0.4em 0.6em;">voyager rows</th>
+                            <th style="text-align: right; padding: 0.4em 0.6em;">voyager dim</th>
+                            <th style="padding: 0.4em 0.6em;"></th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
             `;
-            // Enable the clear button whenever there are any audio-embedding
-            // rows to drop — the user might want to wipe even without a
-            // dimension mismatch (e.g. forcing a re-analysis on the same
-            // backend after a model upgrade).
-            const hasRows = state.embedding_row_count > 0 || state.voyager_row_count > 0;
-            clearSonicStateBtn.disabled = !hasRows;
-            if (state.mismatch) {
-                clearSonicStateBtn.classList.add('active-button');
-            } else {
-                clearSonicStateBtn.classList.remove('active-button');
-            }
+            // Re-bind clear buttons after re-render.
+            sonicStateDisplay.querySelectorAll('.sonic-clear-btn[data-backend]').forEach(btn => {
+                btn.addEventListener('click', () => clearBackend(btn.dataset.backend));
+            });
         }
 
         async function loadSonicState() {
             sonicStateDisplay.innerHTML = '<p>Loading current state...</p>';
-            clearSonicStateBtn.disabled = true;
             try {
                 const res = await fetch('/api/cleaning/sonic_state');
                 const data = await res.json();
                 renderSonicState(data);
             } catch (e) {
                 sonicStateDisplay.innerHTML =
-                    `<p style="color: var(--color-failure, #c33);">Failed to load: ${e}</p>`;
+                    `<p style="color: var(--color-failure, #c33);">Failed to load: ${escapeHtml(String(e))}</p>`;
             }
         }
 
-        async function clearSonicState() {
+        async function clearBackend(backend) {
             if (!confirm(
-                'This will DELETE every row in `embedding`, drop the audio Voyager index rows, ' +
-                'and NULL the backend-derived columns on `score`. A full re-analysis is required ' +
-                'afterwards. Continue?'
+                `This will DELETE every embedding row for backend "${backend}" and drop its ` +
+                `Voyager index rows. The score / CLAP / lyrics / artist tables are untouched. ` +
+                `Continue?`
             )) {
                 return;
             }
-            clearSonicStateBtn.disabled = true;
             sonicStateResult.style.display = 'none';
             try {
                 const res = await fetch('/api/cleaning/sonic_state/clear', {
                     method: 'POST',
                     headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify({confirm: true}),
+                    body: JSON.stringify({backend, confirm: true}),
                 });
                 const data = await res.json();
                 if (!res.ok) {
                     sonicStateResult.innerHTML = `
                         <h3>❌ Clear failed</h3>
-                        <p>${data.error || 'Unknown error'}</p>
+                        <p>${escapeHtml(data.error || 'Unknown error')}</p>
                     `;
                 } else {
                     const s = data.summary;
                     sonicStateResult.innerHTML = `
-                        <h3>✅ Sonic audio state cleared</h3>
+                        <h3>✅ Backend <code>${escapeHtml(s.backend)}</code> cleared</h3>
                         <p><strong>Embeddings deleted:</strong> ${s.deleted_embeddings}</p>
                         <p><strong>Voyager rows deleted:</strong> ${s.deleted_voyager_rows}</p>
-                        <p><strong>Score rows nulled:</strong> ${s.score_audio_fields_cleared}</p>
-                        <p>Re-run analysis to populate the new backend's index.</p>
                     `;
                     renderSonicState(data.state);
                 }
                 sonicStateResult.style.display = 'block';
             } catch (e) {
-                sonicStateResult.innerHTML = `<p style="color: var(--color-failure, #c33);">Clear failed: ${e}</p>`;
+                sonicStateResult.innerHTML = `<p style="color: var(--color-failure, #c33);">Clear failed: ${escapeHtml(String(e))}</p>`;
                 sonicStateResult.style.display = 'block';
             }
         }
 
         refreshSonicStateBtn.addEventListener('click', loadSonicState);
-        clearSonicStateBtn.addEventListener('click', clearSonicState);
         document.addEventListener('DOMContentLoaded', loadSonicState);
 </script>
 <script src="{{ url_for('static', filename='menu.js') }}"></script>

--- a/templates/cleaning.html
+++ b/templates/cleaning.html
@@ -91,6 +91,43 @@
             </div>
         </div>
     </section>
+
+    <!-- Sonic Backend State Section -->
+    <section id="sonic-state-section" style="margin-top: 2rem;">
+        <h2>Sonic Backend State</h2>
+        <p>
+            The audio similarity embedding stored per track is produced by
+            the configured <code>SONIC_BACKEND</code>. Different backends
+            emit different-dimensioned vectors (MusiCNN: 200; MERT-95M:
+            768; MERT-330M: 1024), and the Voyager index needs every row
+            to share the active dimension. After switching backends, use
+            the button below to drop stale audio embeddings + the audio
+            Voyager index so a fresh re-analysis can produce a clean,
+            consistent index.
+        </p>
+        <p style="font-size: 0.9em; color: var(--muted, #888);">
+            Untouched: CLAP embeddings, lyrics analysis, artist data,
+            playlists, app config, task history. Cleared: every row in
+            <code>embedding</code>, the audio Voyager index rows, and
+            the backend-derived columns on <code>score</code>
+            (tempo / key / scale / energy / mood_vector / other_features).
+        </p>
+
+        <div id="sonic-state-display" class="cleaning-summary" style="margin-bottom: 1rem;">
+            <p>Loading current state...</p>
+        </div>
+
+        <div class="task-buttons">
+            <button id="refresh-sonic-state-btn">Refresh State</button>
+            <button id="clear-sonic-state-btn" class="danger-button" disabled>
+                Clear stale audio embeddings
+            </button>
+        </div>
+
+        <div id="sonic-state-result" style="display: none; margin-top: 1rem;" class="cleaning-summary">
+            <!-- Result populated by JS -->
+        </div>
+    </section>
 </div>
 {% endblock %}
 
@@ -503,6 +540,107 @@
             cleaningResults.style.display = 'none';
             console.log('UI completely reset - all timers and intervals cleared');
         }
+
+        // --- Sonic Backend State panel -------------------------------------
+
+        const sonicStateDisplay = document.getElementById('sonic-state-display');
+        const refreshSonicStateBtn = document.getElementById('refresh-sonic-state-btn');
+        const clearSonicStateBtn = document.getElementById('clear-sonic-state-btn');
+        const sonicStateResult = document.getElementById('sonic-state-result');
+
+        function fmtDim(d) {
+            return (d === null || d === undefined) ? '—' : String(d);
+        }
+
+        function renderSonicState(state) {
+            if (state.error) {
+                sonicStateDisplay.innerHTML = `
+                    <p style="color: var(--color-failure, #c33);"><strong>Failed to inspect state:</strong> ${state.error}</p>
+                `;
+                clearSonicStateBtn.disabled = true;
+                return;
+            }
+            const mismatchBadge = state.mismatch
+                ? `<span style="color: var(--color-failure, #c33); font-weight: bold;">⚠ MISMATCH</span>`
+                : `<span style="color: var(--color-success, #2a8); font-weight: bold;">✓ consistent</span>`;
+            sonicStateDisplay.innerHTML = `
+                <p><strong>Active backend:</strong> <code>${state.current_backend}</code>
+                   &nbsp;·&nbsp; <strong>writes dim:</strong> ${state.current_dim}
+                   &nbsp;·&nbsp; ${mismatchBadge}</p>
+                <p><strong>embedding rows:</strong> ${state.embedding_row_count}
+                   &nbsp;·&nbsp; <strong>sampled stored dim:</strong> ${fmtDim(state.sample_stored_dim)}</p>
+                <p><strong>voyager_index_data rows:</strong> ${state.voyager_row_count}
+                   &nbsp;·&nbsp; <strong>stored voyager dim:</strong> ${fmtDim(state.stored_voyager_dim)}</p>
+            `;
+            // Enable the clear button whenever there are any audio-embedding
+            // rows to drop — the user might want to wipe even without a
+            // dimension mismatch (e.g. forcing a re-analysis on the same
+            // backend after a model upgrade).
+            const hasRows = state.embedding_row_count > 0 || state.voyager_row_count > 0;
+            clearSonicStateBtn.disabled = !hasRows;
+            if (state.mismatch) {
+                clearSonicStateBtn.classList.add('active-button');
+            } else {
+                clearSonicStateBtn.classList.remove('active-button');
+            }
+        }
+
+        async function loadSonicState() {
+            sonicStateDisplay.innerHTML = '<p>Loading current state...</p>';
+            clearSonicStateBtn.disabled = true;
+            try {
+                const res = await fetch('/api/cleaning/sonic_state');
+                const data = await res.json();
+                renderSonicState(data);
+            } catch (e) {
+                sonicStateDisplay.innerHTML =
+                    `<p style="color: var(--color-failure, #c33);">Failed to load: ${e}</p>`;
+            }
+        }
+
+        async function clearSonicState() {
+            if (!confirm(
+                'This will DELETE every row in `embedding`, drop the audio Voyager index rows, ' +
+                'and NULL the backend-derived columns on `score`. A full re-analysis is required ' +
+                'afterwards. Continue?'
+            )) {
+                return;
+            }
+            clearSonicStateBtn.disabled = true;
+            sonicStateResult.style.display = 'none';
+            try {
+                const res = await fetch('/api/cleaning/sonic_state/clear', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({confirm: true}),
+                });
+                const data = await res.json();
+                if (!res.ok) {
+                    sonicStateResult.innerHTML = `
+                        <h3>❌ Clear failed</h3>
+                        <p>${data.error || 'Unknown error'}</p>
+                    `;
+                } else {
+                    const s = data.summary;
+                    sonicStateResult.innerHTML = `
+                        <h3>✅ Sonic audio state cleared</h3>
+                        <p><strong>Embeddings deleted:</strong> ${s.deleted_embeddings}</p>
+                        <p><strong>Voyager rows deleted:</strong> ${s.deleted_voyager_rows}</p>
+                        <p><strong>Score rows nulled:</strong> ${s.score_audio_fields_cleared}</p>
+                        <p>Re-run analysis to populate the new backend's index.</p>
+                    `;
+                    renderSonicState(data.state);
+                }
+                sonicStateResult.style.display = 'block';
+            } catch (e) {
+                sonicStateResult.innerHTML = `<p style="color: var(--color-failure, #c33);">Clear failed: ${e}</p>`;
+                sonicStateResult.style.display = 'block';
+            }
+        }
+
+        refreshSonicStateBtn.addEventListener('click', loadSonicState);
+        clearSonicStateBtn.addEventListener('click', clearSonicState);
+        document.addEventListener('DOMContentLoaded', loadSonicState);
 </script>
 <script src="{{ url_for('static', filename='menu.js') }}"></script>
 {% endblock %}

--- a/templates/cleaning.html
+++ b/templates/cleaning.html
@@ -647,6 +647,7 @@
                         <h3>✅ Backend <code>${escapeHtml(s.backend)}</code> cleared</h3>
                         <p><strong>Embeddings deleted:</strong> ${s.deleted_embeddings}</p>
                         <p><strong>Voyager rows deleted:</strong> ${s.deleted_voyager_rows}</p>
+                        <p><strong>Mood centroid rows deleted:</strong> ${s.deleted_mood_centroids ?? 0}</p>
                     `;
                     renderSonicState(data.state);
                 }


### PR DESCRIPTION
## AS-IS
Musicnn is the only analysis backend.

## TO-BE
Can swap the analysis backend model with SONIC_BACKEND to mert (95M, cpu/330M, gpu).

Analysis tables are namespaced to the backend used, and unused backend tables are droppable via the cleaning page in the admin panel.

## Test
Tested via switching to the MERT backend and starting a fresh re-analysis of my library. 

## Other useful information
Needed to bump pytorch to 2.6.0 due to a CVE gate. Wrapped up with chunking the audio we infer on after validating everything else works, as that better matches the chunked samples mert was trained on.

## Checklist
<!-- Not all items are mandatory — just check the ones that apply to your case. -->

**Type of change:**
- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [X] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [X] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [X] Documentation
- [ ] Unit test
- [ ] Integration test

**Other:**
- [X] CONTRIBUTING.md read and accepted
- [X] Checked performance on a big library (> 150k songs) works without issues

I have ~250K tracks in my music library, and a fresh analysis is projected to take ~11 days on my 14900K (8 workers, 4 threads each) by my napkin math. Doing so with musicnn took something like, idk, 3 or 4 days, but the hit here is expected as mert is just a bigger model.
