### PR TITLE
Lyrion lirc call fix - #647

### DIFF
--- a/tasks/mediaserver/lyrion.py
+++ b/tasks/mediaserver/lyrion.py
@@ -1132,12 +1132,12 @@ def get_last_played_time(item_id):
 def get_lyrics(track_id: str, timeout: float = 2.5):
     """Fetch embedded lyrics from Lyrion (LMS) for a given track ID.
 
-    Uses the LMS JSON-RPC ``songinfo`` command with the ``l`` (lyrics) tag.
+    Uses the LMS JSON-RPC ``songinfo`` command with the ``w`` (lyrics) tag.
     Returns plain text or None.
     """
     try:
         result = _jsonrpc_request(
-            'songinfo', [0, 100, f'track_id:{track_id}', 'tags:l'],
+            'songinfo', [0, 100, f'track_id:{track_id}', 'tags:w'],
             timeout=timeout,
         )
         if not result:


### PR DESCRIPTION
Fix on the Lyrion lirics call (w instead of l tags):

```
result = _jsonrpc_request(
'songinfo', [0, 100, f'track_id:{track_id}', 'tags:w'],
timeout=timeout,
)

```

Reference: https://lyrion.org/reference/cli/database/#songinfo

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755492/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755502/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755502/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755502/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755502/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27528755554/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-649`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-649-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-649-noavx2`
<!-- pr-test-build:end -->