### PR TITLE
Native deploy - suppress database warning - #650

### DIFF
--- a/tasks/setup_manager.py
+++ b/tasks/setup_manager.py
@@ -40,6 +40,10 @@ class SetupManager:
         if env_url:
             return env_url
 
+        import sys
+        if getattr(sys, "frozen", False):
+            return None
+
         user = os.environ.get("POSTGRES_USER", "audiomuse")
         password = os.environ.get("POSTGRES_PASSWORD", "audiomusepassword")
         host = os.environ.get("POSTGRES_HOST", "postgres-service.playlist")
@@ -55,6 +59,8 @@ class SetupManager:
         return psycopg2.connect(self.database_url, connect_timeout=30)
 
     def ensure_table(self):
+        if self.database_url is None:
+            return
         try:
             with self.get_connection() as conn:
                 with conn.cursor() as cur:
@@ -94,6 +100,8 @@ class SetupManager:
             return False
 
     def get_raw_overrides(self, ensure_table=True):
+        if self.database_url is None:
+            return {}
         try:
             if ensure_table:
                 self.ensure_table()

--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -21,6 +21,7 @@
             }
         })();
     </script>
+    {% include 'includes/reverse_proxy_prefix.html' %}
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='menu.css') }}">
 

--- a/templates/includes/reverse_proxy_prefix.html
+++ b/templates/includes/reverse_proxy_prefix.html
@@ -1,0 +1,16 @@
+<!-- Reverse-proxy subpath support: prefix root-relative fetch() URLs with the proxy script root.
+     No-op when not behind a proxy (script_root is empty), so non-proxy and native builds are unaffected. -->
+<script>
+    (function () {
+        var root = {{ request.script_root | tojson }};
+        if (!root || typeof window.fetch !== "function") { return; }
+        var nativeFetch = window.fetch.bind(window);
+        window.fetch = function (input, init) {
+            if (typeof input === "string" && input.charAt(0) === "/" && input.charAt(1) !== "/"
+                && input !== root && input.slice(0, root.length + 1) !== root + "/") {
+                input = root + input;
+            }
+            return nativeFetch(input, init);
+        };
+    })();
+</script>

--- a/templates/login.html
+++ b/templates/login.html
@@ -15,6 +15,7 @@
             }
         })();
     </script>
+    {% include 'includes/reverse_proxy_prefix.html' %}
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='menu.css') }}">
     <style>


### PR DESCRIPTION
Supprress database warning in Natvie build

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802209/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802303/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802303/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802303/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802303/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27677802192/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-652`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-652-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-652-noavx2`
<!-- pr-test-build:end -->