### PR TITLE
Mac numberic fix - #658

### DIFF
--- a/native-build/macos/env.py
+++ b/native-build/macos/env.py
@@ -28,15 +28,12 @@ def build_child_env(role, database_url, redis_url):
         # another thread when fork() was called. Crashing instead." -- so jobs
         # never run. This is the documented opt-out of that fork-safety check.
         "OBJC_DISABLE_INITIALIZE_FORK_SAFETY": "YES",
-        # NumPy converts ints to longdouble via the C library's locale-sensitive
-        # strtold. macOS frameworks (Cocoa/CoreAudio) call setlocale() at startup,
-        # and a concurrent locale change while scipy imports causes an intermittent
-        # "Could not parse python long as longdouble" crash that leaves analysis
-        # tasks stuck pending. Pinning the *numeric* locale to C makes strtold
-        # deterministic with no transition to race against. Kept to LC_NUMERIC only
-        # so LC_CTYPE/UTF-8 (accented file paths) is untouched. The matching
-        # in-process pin lives in native-build/macos/launcher.py (numeric_bootstrap.py); this
-        # is all macOS-only and does not affect the Linux/Docker images.
+        # Locale-churn hygiene only (kept to LC_NUMERIC so LC_CTYPE/UTF-8 for
+        # accented file paths is untouched). The macOS "Could not parse python
+        # long as longdouble" crash (issue #658) is NOT fixed by this -- NumPy's
+        # per-call newlocale ignores the process locale -- it is mitigated by
+        # warmup_scipy_longdouble() in the launcher. See numeric_bootstrap.py.
+        # macOS-only; does not affect the Linux/Docker images.
         "LC_NUMERIC": "C",
         "APP_DATA_DIR": paths.app_support_dir(),
         "AUDIOMUSE_CONTROL_SOCKET": paths.control_socket_path(),

--- a/native-build/macos/launcher.py
+++ b/native-build/macos/launcher.py
@@ -34,7 +34,16 @@ def _run_flask():
     )
 
 
+_NO_LONGDOUBLE_WARMUP_ROLES = {"janitor", "restart-listener"}
+
+
 def _run_role(role):
+    if role not in _NO_LONGDOUBLE_WARMUP_ROLES:
+        try:
+            import numeric_bootstrap
+            numeric_bootstrap.warmup_scipy_longdouble()
+        except Exception:
+            pass
     if role == "flask":
         _run_flask()
     elif role == "worker-high":
@@ -159,12 +168,9 @@ def _run_menubar():
 
 
 def main():
-    # Force a deterministic C *numeric* locale in every frozen process before any
-    # heavy import. NumPy's int->longdouble conversion (used by scipy at import)
-    # goes through the locale-sensitive C strtold; a macOS framework changing the
-    # locale concurrently otherwise causes an intermittent
-    # "Could not parse python long as longdouble" crash. This is macOS-only (the
-    # Linux/Docker workers never run launcher.py), so it cannot affect containers.
+    # Mitigate the macOS NumPy int->longdouble import crash (issue #658). The
+    # decisive fix is warmup_scipy_longdouble() in _run_role(); this pin is only
+    # locale-churn hygiene. See numeric_bootstrap.py for the full mechanism.
     try:
         import numeric_bootstrap
         numeric_bootstrap.pin_numeric_locale()

--- a/native-build/windows/launcher.py
+++ b/native-build/windows/launcher.py
@@ -19,12 +19,12 @@ multi-call launcher:
 """
 
 # --- Windows: force multiprocessing 'spawn' before ANY imports ---
-# Python's ``multiprocessing`` on Windows does not support ``fork`` (only
-# ``spawn``).  RQ's ``scheduler.py`` calls ``get_context('fork')`` at module
-# level, and RQ workers call ``os.fork()`` directly.  The monkey-patch below
-# redirects ``fork`` requests to ``spawn`` so imports succeed.  Actual
-# worker fork() calls will still fail at runtime, so we skip starting
-# RQ workers on Windows (see supervisor.py).
+# Python's ``multiprocessing`` on Windows supports only ``spawn`` (no ``fork``),
+# but RQ's ``scheduler.py`` calls ``get_context('fork')`` at module level. The
+# monkey-patch below redirects those ``fork`` requests to ``spawn`` so imports
+# succeed. The workers themselves run as RQ's ``SimpleWorker`` on Windows (no
+# ``os.fork()``; each job runs in the worker process), so the full worker pool
+# runs here -- see rq_worker.py and supervisor.py.
 import multiprocessing
 _orig_get_context = multiprocessing.get_context
 def _win_get_context(method=None):

--- a/numeric_bootstrap.py
+++ b/numeric_bootstrap.py
@@ -1,33 +1,98 @@
-"""Pin a deterministic C numeric locale for the standalone macOS app.
+"""Work around the macOS-arm64 NumPy int->longdouble crash for the native app.
 
-Works around an intermittent macOS-arm64 NumPy bug: converting a Python int to
-``np.longdouble`` goes through the C library's locale-sensitive ``strtold``, and
-when an Apple framework (Cocoa / CoreAudio, pulled in via pyobjc / onnxruntime)
-changes the process locale at startup, the conversion can fail with::
+Symptom (issue #658): on some Apple-Silicon Macs an analysis task dies with
 
     RuntimeError: Could not parse python long as longdouble: 1 (Invalid argument)
 
-SciPy performs that conversion at *import* time (``scipy/stats/_ksstats.py``), so
-on the affected machines importing scipy/sklearn intermittently crashes the
-analysis worker and leaves the task stuck pending.
+raised while SciPy/scikit-learn is *imported* -- ``scipy/stats/_ksstats.py``
+builds ``np.longdouble`` constants at import time, and ``tasks/paged_ivf.py``
+imports ``sklearn.cluster`` to build the similarity search index.
 
-Pinning ``LC_NUMERIC`` to ``"C"`` makes ``strtold`` deterministic and removes the
-locale transition there is to race against. It is kept narrow -- only the numeric
-category, so ``LC_CTYPE``/UTF-8 (accented file paths) is untouched.
+Mechanism: NumPy converts a Python int to ``np.longdouble`` by formatting it to
+a string and parsing it back through the C library. On macOS that path
+(``NumPyOS_ascii_strtold``, compiled because ``HAVE_STRTOLD_L`` is defined)
+runs, on EVERY conversion::
 
-This module is imported ONLY by the macOS launcher (``native-build/macos/launcher.py``); it is
-never referenced by the Linux/Docker worker entrypoints, so the container images
-are entirely unaffected. The matching env-level pin lives in ``native-build/macos/env.py``.
+    newlocale(LC_ALL_MASK, "C", NULL)
+
+and, when ``newlocale`` returns NULL, it leaves ``errno`` set to EINVAL; NumPy
+then raises the error above. macOS' ``newlocale``/``setlocale`` are not safe to
+run concurrently, so when an Apple framework (Cocoa/CoreAudio, pulled in via
+pyobjc/onnxruntime/PyAV) changes the process locale on another thread at the
+instant of the conversion, ``newlocale`` transiently fails. It is a race, which
+is why other projects hit it only intermittently and "fix" it by retrying.
+
+Why pinning LC_NUMERIC is NOT the fix: NumPy builds its own private "C" locale
+via ``newlocale`` and does NOT consult the process/global locale for this call,
+so ``setlocale(LC_NUMERIC, "C")`` and an ``LC_NUMERIC=C`` env var (kept as cheap
+locale-churn hygiene) cannot stop the failing ``newlocale``. Upgrading NumPy
+does not help either: the code path is unchanged through current releases.
+
+The actual fix (``warmup_scipy_longdouble``): import ``scipy.stats`` and
+``sklearn.cluster`` once, early, in the freshly started worker/Flask process --
+a single-threaded moment before any Apple framework thread exists to race the
+locale -- retrying the documented transient failure. The modules are then
+cached, so:
+
+* the RQ workers fork a child per job and the child INHERITS the already
+  imported modules, so the index-build import in the child is a no-op and never
+  re-runs the fragile conversion;
+* the waitress/Flask request threads likewise reuse the cached import.
+
+macOS-only: imported solely by ``native-build/macos/launcher.py``. The
+Linux/Docker and Windows builds are unaffected -- glibc's built-in C locale
+never fails and there is no Cocoa/CoreAudio racing the locale, while the MSVC
+NumPy build compiles the locale-independent fallback that never calls
+``newlocale`` -- so they neither import this module nor need it.
 """
+import logging
 import os
+import sys
+import time
+
+logger = logging.getLogger(__name__)
 
 
 def pin_numeric_locale():
-    """Force a deterministic C numeric locale (process-wide), best-effort."""
+    """Pin LC_NUMERIC to C process-wide (best-effort locale-churn hygiene)."""
     os.environ["LC_NUMERIC"] = "C"
     try:
         import locale
         locale.setlocale(locale.LC_NUMERIC, "C")
     except Exception:
-        # Never let locale setup abort process startup.
         pass
+
+
+def warmup_scipy_longdouble(attempts=8, delay=0.1):
+    """Import the longdouble-fragile modules once, retrying the macOS race.
+
+    Returns True once ``np.longdouble`` conversion plus ``scipy.stats`` and
+    ``sklearn.cluster`` import cleanly (or were already imported), False if every
+    attempt failed. Best-effort: never raises, so it can never block startup. A
+    genuinely missing module is not the transient race, so it short-circuits the
+    retries; on permanent failure a warning is logged with the last error so a
+    broken install is diagnosable instead of starting up silently.
+    """
+    import importlib
+    last_error = None
+    for _ in range(max(1, int(attempts))):
+        try:
+            import numpy
+            numpy.longdouble(1)
+            importlib.import_module("scipy.stats")
+            importlib.import_module("sklearn.cluster")
+            return True
+        except ModuleNotFoundError as exc:
+            last_error = exc
+            break
+        except Exception as exc:
+            last_error = exc
+            for _name in ("sklearn.cluster", "scipy.stats"):
+                sys.modules.pop(_name, None)
+            time.sleep(delay)
+    logger.warning(
+        "warmup_scipy_longdouble gave up importing scipy.stats/sklearn.cluster "
+        "(last error: %r); analysis tasks may fail when they first use these modules.",
+        last_error,
+    )
+    return False

--- a/test/unit/test_numeric_bootstrap.py
+++ b/test/unit/test_numeric_bootstrap.py
@@ -1,8 +1,24 @@
 import locale
 import os
+import sys
 from unittest.mock import patch
 
+import pytest
+
 import numeric_bootstrap
+
+
+@pytest.fixture
+def _preserve_fragile_modules():
+    saved = {name: sys.modules.get(name) for name in ("scipy.stats", "sklearn.cluster")}
+    try:
+        yield
+    finally:
+        for name, module in saved.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
 
 
 def test_pin_numeric_locale_sets_env_and_calls_setlocale(monkeypatch):
@@ -27,3 +43,38 @@ def test_pin_numeric_locale_generic_exception_still_sets_env_when_unset(monkeypa
     with patch("locale.setlocale", side_effect=Exception("boom")):
         numeric_bootstrap.pin_numeric_locale()
     assert os.environ["LC_NUMERIC"] == "C"
+
+
+def test_warmup_imports_and_caches_fragile_modules():
+    import sys
+    assert numeric_bootstrap.warmup_scipy_longdouble() is True
+    assert "scipy.stats" in sys.modules
+    assert "sklearn.cluster" in sys.modules
+
+
+def test_warmup_retries_transient_longdouble_failure(monkeypatch, _preserve_fragile_modules):
+    import numpy
+    calls = {"n": 0}
+    real = numpy.longdouble
+
+    def flaky(value):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError(
+                "Could not parse python long as longdouble: 1 (Invalid argument)"
+            )
+        return real(value)
+
+    monkeypatch.setattr(numpy, "longdouble", flaky)
+    assert numeric_bootstrap.warmup_scipy_longdouble(attempts=5, delay=0) is True
+    assert calls["n"] == 3
+
+
+def test_warmup_gives_up_and_returns_false_without_raising(monkeypatch, _preserve_fragile_modules):
+    import numpy
+
+    def always_fail(value):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(numpy, "longdouble", always_fail)
+    assert numeric_bootstrap.warmup_scipy_longdouble(attempts=3, delay=0) is False


### PR DESCRIPTION
This PR is to fix an error on Mac build related to numeric bootstrap.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703364/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703319/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703319/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703319/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703319/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27794703391/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-660`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-660-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-660-noavx2`
<!-- pr-test-build:end -->