### PR TITLE
Hardening & cleanup: reverse-proxy subpath fix (#668), error/XSS/auth

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -160,6 +160,12 @@ jobs:
       run: |
         pytest test/integration/test_app_endpoints_integration.py test/integration/test_auth_users_integration.py test/integration/test_auth_barrier_integration.py -m integration -s -v --tb=short
 
+    - name: Run serializer / batch-fetch / task-status integration tests
+      env:
+        AUDIOMUSE_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/audiomuse_migration_test
+      run: |
+        pytest test/integration/test_neighbor_serialize_integration.py test/integration/test_ivf_batch_fetch_integration.py test/integration/test_task_status_integration.py -m integration -s -v --tb=short
+
     - name: Run lyrics integration test
       run: |
         # On first run test/lyrics_expected_gte_512.json does not exist yet: the

--- a/app.py
+++ b/app.py
@@ -299,7 +299,9 @@ def get_task_status_endpoint(task_id):
         response['progress'] = db_task_info.get('progress', response['progress'])
         raw_details = db_task_info.get('details')
         db_details = {}
-        if raw_details:
+        if isinstance(raw_details, dict):
+            db_details = raw_details
+        elif raw_details:
             try:
                 db_details = json.loads(raw_details)
             except (json.JSONDecodeError, TypeError):

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from config import TEMP_DIR, REDIS_URL, APP_VERSION, ENABLE_PROXY_FIX, JWT_SECRE
 if ENABLE_PROXY_FIX:
   # Werkzeug import for reverse proxy support
   from werkzeug.middleware.proxy_fix import ProxyFix
+  from proxy_prefix import StripDuplicatedScriptName
 
 # --- Flask App Setup ---
 # The Flask instance lives in `flask_app` so RQ task modules can import it
@@ -68,7 +69,10 @@ from app_logging import configure_logging
 configure_logging()
 
 if ENABLE_PROXY_FIX:
-  app.wsgi_app = ProxyFix(app.wsgi_app, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+  # StripDuplicatedScriptName runs after ProxyFix (inner app) to undo a doubled
+  # subpath prefix from a proxy that forwards the full path while also sending
+  # X-Forwarded-Prefix, which otherwise loops redirects to /<prefix>/setup (#668).
+  app.wsgi_app = ProxyFix(StripDuplicatedScriptName(app.wsgi_app), x_for=1, x_proto=1, x_host=1, x_prefix=1)
 
 # Log the application version on startup
 app.logger.info(f"Starting AudioMuse-AI Backend version {APP_VERSION}")
@@ -293,7 +297,13 @@ def get_task_status_endpoint(task_id):
             response['state'] = db_task_info.get('status', response['state']) # Use DB status if RQ is still active
 
         response['progress'] = db_task_info.get('progress', response['progress'])
-        db_details = json.loads(db_task_info.get('details')) if db_task_info.get('details') else {}
+        raw_details = db_task_info.get('details')
+        db_details = {}
+        if raw_details:
+            try:
+                db_details = json.loads(raw_details)
+            except (json.JSONDecodeError, TypeError):
+                db_details = {}
         # Merge details: RQ meta (live) can override DB details (persisted)
         response['details'] = {**db_details, **response['details']}
 
@@ -745,7 +755,7 @@ def listen_for_index_reloads():
               logger.warning(f"SemGrove cache reload failed: {e}")
               sg_success = False
 
-            logger.info(f"In-memory reload complete: IVF ✓, Artist ✓, Maps ✓, CLAP {'✓' if clap_success else '✗'}, Lyrics {'✓' if lyrics_success else '✗'}, SemGrove {'✓' if sg_success else '✗'}")
+            logger.info(f"In-memory reload complete: IVF OK, Artist OK, Maps OK, CLAP {'OK' if clap_success else 'X'}, Lyrics {'OK' if lyrics_success else 'X'}, SemGrove {'OK' if sg_success else 'X'}")
           except Exception as e:
             logger.error(f"Error reloading indexes/maps from background listener: {e}", exc_info=True)
       elif message_data == 'reload-artist':

--- a/app_alchemy.py
+++ b/app_alchemy.py
@@ -191,7 +191,11 @@ def alchemy_api():
     """
     payload = request.get_json() or {}
     items = payload.get('items', [])
-    n = payload.get('n', config.ALCHEMY_DEFAULT_N_RESULTS)
+    try:
+        n = int(payload.get('n', config.ALCHEMY_DEFAULT_N_RESULTS))
+    except (TypeError, ValueError):
+        n = config.ALCHEMY_DEFAULT_N_RESULTS
+    n = max(1, min(n, config.ALCHEMY_MAX_N_RESULTS))
     # Temperature parameter for probabilistic sampling (softmax temperature)
     temperature = payload.get('temperature', config.ALCHEMY_TEMPERATURE)
 

--- a/app_alchemy.py
+++ b/app_alchemy.py
@@ -291,7 +291,8 @@ def create_anchor():
     """
     from database import save_alchemy_anchor
     payload = request.get_json() or {}
-    name = (payload.get('name') or '').strip()
+    raw_name = payload.get('name')
+    name = raw_name.strip() if isinstance(raw_name, str) else ''
     centroid = payload.get('centroid')
     if not name:
         return jsonify({'error': 'Anchor name is required'}), 400
@@ -362,7 +363,8 @@ def rename_anchor(anchor_id):
     """
     from database import update_alchemy_anchor_name
     payload = request.get_json() or {}
-    name = (payload.get('name') or '').strip()
+    raw_name = payload.get('name')
+    name = raw_name.strip() if isinstance(raw_name, str) else ''
     if not name:
         return jsonify({'error': 'Anchor name is required'}), 400
     anchor = update_alchemy_anchor_name(anchor_id, name)

--- a/app_artist_similarity.py
+++ b/app_artist_similarity.py
@@ -79,6 +79,7 @@ def search_artists_endpoint():
     if end is not None and end <= start:
         return jsonify([])
     limit = (end - start) if end is not None else 20
+    limit = min(limit, 100)
     offset = start
 
     try:

--- a/app_auth.py
+++ b/app_auth.py
@@ -38,6 +38,16 @@ from tz_helper import UTC_NOW_SQL, to_local_str
 logger = logging.getLogger(__name__)
 
 
+def _original_request_is_https():
+    """True when the original request was HTTPS, honoring X-Forwarded-Proto from a
+    TLS-terminating reverse proxy even when ProxyFix is disabled. Single source of
+    truth for the Secure cookie flag so the decision can't drift per call site."""
+    if request.is_secure:
+        return True
+    forwarded_proto = request.headers.get('X-Forwarded-Proto', '')
+    return forwarded_proto.split(',')[0].strip().lower() == 'https'
+
+
 # --- User model constants ---------------------------------------------------
 
 USER_ROLE_USER = 'user'
@@ -503,7 +513,7 @@ def check_auth_needed(jwt_secret):
     # Check valid Bearer token (M2M callers) - always admin-equivalent.
     # Use secrets.compare_digest to avoid leaking token contents via timing.
     auth_header = request.headers.get('Authorization', '')
-    if auth_header.startswith('Bearer ') and _cfg.API_TOKEN and secrets.compare_digest(auth_header[7:], _cfg.API_TOKEN):
+    if auth_header.startswith('Bearer ') and _cfg.API_TOKEN and secrets.compare_digest(auth_header[7:].encode('utf-8'), _cfg.API_TOKEN.encode('utf-8')):
         g.auth_role = 'admin'
         g.auth_user = None
         return None
@@ -770,10 +780,9 @@ def auth_endpoint():
         path='/',
         httponly=True,
         samesite='Strict',
-        # Mark the cookie Secure when the request came in over HTTPS so
-        # production deployments get the hardened flag while local HTTP
-        # development still works.
-        secure=request.is_secure,
+        # Secure when the original request was HTTPS, including via a reverse
+        # proxy (X-Forwarded-Proto) even when ProxyFix is disabled.
+        secure=_original_request_is_https(),
         max_age=8 * 3600,
     )
     return resp

--- a/app_chat.py
+++ b/app_chat.py
@@ -95,6 +95,14 @@ def chat_config_defaults_api():
         "default_mistral_model_name": cfg.MISTRAL_MODEL_NAME,
     }), 200
 
+
+def _reject_missing_user_input(data):
+    # Shared guard for both chat endpoints: 400 on non-dict body or blank userInput.
+    if not isinstance(data, dict) or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
+        return jsonify({"error": "Missing userInput in request"}), 400
+    return None
+
+
 @chat_bp.route('/api/chatPlaylist', methods=['POST'])
 @swag_from({
     'tags': ['Chat Interaction'],
@@ -233,8 +241,9 @@ def chat_playlist_api():
     Non-streaming variant: runs the whole pipeline then returns the full JSON.
     """
     data = request.get_json()
-    if not isinstance(data, dict) or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
-        return jsonify({"error": "Missing userInput in request"}), 400
+    err = _reject_missing_user_input(data)
+    if err:
+        return err
     log_messages = []
     resp_obj, status = _drain_pipeline(_run_chat_pipeline(data, log_messages))
     return jsonify({"response": resp_obj}), status
@@ -256,8 +265,9 @@ def chat_playlist_stream_api():
     value (the response object) is delivered as the ``done`` event.
     """
     data = request.get_json()
-    if not isinstance(data, dict) or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
-        return jsonify({"error": "Missing userInput in request"}), 400
+    err = _reject_missing_user_input(data)
+    if err:
+        return err
 
     @stream_with_context
     def generate():

--- a/app_chat.py
+++ b/app_chat.py
@@ -233,7 +233,7 @@ def chat_playlist_api():
     Non-streaming variant: runs the whole pipeline then returns the full JSON.
     """
     data = request.get_json()
-    if not data or 'userInput' not in data:
+    if not data or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
         return jsonify({"error": "Missing userInput in request"}), 400
     log_messages = []
     resp_obj, status = _drain_pipeline(_run_chat_pipeline(data, log_messages))
@@ -256,7 +256,7 @@ def chat_playlist_stream_api():
     value (the response object) is delivered as the ``done`` event.
     """
     data = request.get_json()
-    if not data or 'userInput' not in data:
+    if not data or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
         return jsonify({"error": "Missing userInput in request"}), 400
 
     @stream_with_context
@@ -749,7 +749,7 @@ def create_media_server_playlist_api():
     user_playlist_name = data.get('playlist_name')
     item_ids = data.get('item_ids') # This will be a list of strings
 
-    if not user_playlist_name.strip():
+    if not user_playlist_name or not str(user_playlist_name).strip():
         return jsonify({"message": "Error: Playlist name cannot be empty."}), 400
     if not item_ids:
         return jsonify({"message": "Error: No songs provided to create the playlist."}), 400

--- a/app_chat.py
+++ b/app_chat.py
@@ -233,7 +233,7 @@ def chat_playlist_api():
     Non-streaming variant: runs the whole pipeline then returns the full JSON.
     """
     data = request.get_json()
-    if not data or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
+    if not isinstance(data, dict) or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
         return jsonify({"error": "Missing userInput in request"}), 400
     log_messages = []
     resp_obj, status = _drain_pipeline(_run_chat_pipeline(data, log_messages))
@@ -256,7 +256,7 @@ def chat_playlist_stream_api():
     value (the response object) is delivered as the ``done`` event.
     """
     data = request.get_json()
-    if not data or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
+    if not isinstance(data, dict) or not isinstance(data.get('userInput'), str) or not data['userInput'].strip():
         return jsonify({"error": "Missing userInput in request"}), 400
 
     @stream_with_context

--- a/app_chat.py
+++ b/app_chat.py
@@ -355,7 +355,7 @@ def _run_chat_pipeline(data, log_messages):
     ai_provider = data.get('ai_provider', config.AI_MODEL_PROVIDER).upper()
     ai_model_from_request = data.get('ai_model')
 
-    log_messages.append(f"🎵 NEW MCP-BASED PLAYLIST GENERATION")
+    log_messages.append(f"NEW MCP-BASED PLAYLIST GENERATION")
     log_messages.append(f"Request: '{original_user_input}'")
     log_messages.append(f"AI Provider: {ai_provider}")
 
@@ -460,7 +460,7 @@ def _run_chat_pipeline(data, log_messages):
     # MCP AGENTIC WORKFLOW
     # ====================
 
-    log_messages.append("\n🤖 Using MCP Agentic Workflow for playlist generation")
+    log_messages.append("\nUsing MCP Agentic Workflow for playlist generation")
     log_messages.append("Target: 100 songs")
 
     # Get MCP tools and library context
@@ -538,7 +538,7 @@ def _run_chat_pipeline(data, log_messages):
 
         diversity_removed = len(all_songs) - len(diversified_pool)
         if diversity_removed > 0:
-            log_messages.append(f"\n🎨 Artist diversity: removed {diversity_removed} excess songs from pool (max {max_per_artist}/artist)")
+            log_messages.append(f"\nArtist diversity: removed {diversity_removed} excess songs from pool (max {max_per_artist}/artist)")
 
         # --- Phase 2: Proportional sampling from diversified pool ---
         if len(diversified_pool) <= target_song_count:
@@ -600,7 +600,7 @@ def _run_chat_pipeline(data, log_messages):
 
             final_query_results_list = final_query_results_list[:target_song_count]
 
-        log_messages.append(f"\n📊 Pool: {len(all_songs)} collected → {len(diversified_pool)} after diversity cap → {len(final_query_results_list)} in final playlist")
+        log_messages.append(f"\nPool: {len(all_songs)} collected → {len(diversified_pool)} after diversity cap → {len(final_query_results_list)} in final playlist")
 
         # --- Song Ordering for Smooth Transitions (Phase 3A) ---
         # Only when NO filter drove the result. When a filter/score was applied
@@ -609,7 +609,7 @@ def _run_chat_pipeline(data, log_messages):
         # similarity. Re-sorting by tempo/energy/key here would scramble that and
         # bury the matched songs, so the scored order is preserved instead.
         if filter_applied:
-            log_messages.append(f"\n🎵 Playlist kept in filter-ranked order (matched songs first); smooth-transition reorder skipped")
+            log_messages.append(f"\nPlaylist kept in filter-ranked order (matched songs first); smooth-transition reorder skipped")
         else:
             try:
                 from tasks.playlist_ordering import order_playlist
@@ -621,10 +621,10 @@ def _run_chat_pipeline(data, log_messages):
                 # Rebuild list in new order
                 id_to_song = {s['item_id']: s for s in final_query_results_list}
                 final_query_results_list = [id_to_song[sid] for sid in ordered_ids if sid in id_to_song]
-                log_messages.append(f"\n🎵 Playlist ordered for smooth transitions (tempo/energy/key)")
+                log_messages.append(f"\nPlaylist ordered for smooth transitions (tempo/energy/key)")
             except Exception:
                 logger.warning("Playlist ordering failed (non-fatal)", exc_info=True)
-                log_messages.append("\n⚠️ Playlist ordering skipped due to an internal processing issue")
+                log_messages.append("\nPlaylist ordering skipped due to an internal processing issue")
 
         final_executed_query_str = executed_query_str
 
@@ -638,7 +638,7 @@ def _run_chat_pipeline(data, log_messages):
         log_messages.append(f"   Tools called: {len(tools_used_history)}")
         
         # Show tool contribution breakdown (collected vs final)
-        log_messages.append(f"\n📊 Tool Contribution (Collected → Final Playlist):")
+        log_messages.append(f"\nTool Contribution (Collected → Final Playlist):")
         
         # Count songs in final playlist by tool call
         final_by_call = {}

--- a/app_clustering.py
+++ b/app_clustering.py
@@ -274,13 +274,7 @@ def start_clustering_endpoint():
     data = request.json
     job_id = str(uuid.uuid4())
 
-    # Clean up details of previously successful or stale tasks before starting a new one
-    clean_up_previous_main_tasks()
-    save_task_status(job_id, "main_clustering", TASK_STATUS_PENDING, details={"message": "Task enqueued."})
-
-    job = rq_queue_high.enqueue(
-        'tasks.clustering.run_clustering_task', # Enqueue by string path
-        kwargs={ # Pass all arguments as a dictionary
+    clustering_kwargs = { # Pass all arguments as a dictionary
             "clustering_method": data.get('clustering_method', CLUSTER_ALGORITHM),
             "num_clusters_min": int(data.get('num_clusters_min', NUM_CLUSTERS_MIN)),
             "num_clusters_max": int(data.get('num_clusters_max', NUM_CLUSTERS_MAX)),
@@ -321,7 +315,15 @@ def start_clustering_endpoint():
             "mistral_model_name_param": data.get('mistral_model_name', MISTRAL_MODEL_NAME),
             "top_n_moods_for_clustering_param": int(data.get('top_n_moods', TOP_N_MOODS)),
             "enable_clustering_embeddings_param": data.get('enable_clustering_embeddings', ENABLE_CLUSTERING_EMBEDDINGS),
-        },
+    }
+
+    # Clean up details of previously successful or stale tasks before starting a new one
+    clean_up_previous_main_tasks()
+    save_task_status(job_id, "main_clustering", TASK_STATUS_PENDING, details={"message": "Task enqueued."})
+
+    job = rq_queue_high.enqueue(
+        'tasks.clustering.run_clustering_task', # Enqueue by string path
+        kwargs=clustering_kwargs,
         job_id=job_id,
         description="Main Music Clustering",
         retry=Retry(max=3),

--- a/app_cron.py
+++ b/app_cron.py
@@ -146,14 +146,36 @@ def save_cron_entry():
     return jsonify({'message': 'saved'}), 200
 
 
-def _field_matches(field_expr, value):
-    # very small cron field matcher supporting '*', single number, list (comma), and ranges (a-b)
+def _field_matches(field_expr, value, field_min=0):
+    # very small cron field matcher supporting '*', single number, list (comma), ranges (a-b), and steps (*/N, a-b/N).
+    # field_min is the lowest legal value for this field (0 for minute/hour/dow, 1 for day-of-month/month) so '*/N'
+    # anchors at the field minimum like standard cron instead of at 0.
     if field_expr.strip() == '*':
         return True
     parts = field_expr.split(',')
     for p in parts:
         p = p.strip()
-        if '-' in p:
+        if '/' in p:
+            base, step_s = p.split('/', 1)
+            try:
+                step = int(step_s)
+                if step <= 0:
+                    continue
+                if base.strip() == '*':
+                    if value >= field_min and (value - field_min) % step == 0:
+                        return True
+                elif '-' in base:
+                    a, b = base.split('-', 1)
+                    lo, hi = int(a), int(b)
+                    if lo <= value <= hi and (value - lo) % step == 0:
+                        return True
+                else:
+                    start = int(base)
+                    if value >= start and (value - start) % step == 0:
+                        return True
+            except ValueError:
+                continue
+        elif '-' in p:
             a, b = p.split('-', 1)
             try:
                 if int(a) <= value <= int(b):
@@ -171,7 +193,7 @@ def _field_matches(field_expr, value):
 
 def cron_matches_now(expr, ts=None):
     # expr expected as 'min hour day month dow'
-    t = time.localtime(ts) if ts else time.localtime()
+    t = time.localtime(ts) if ts is not None else time.localtime()
     parts = expr.strip().split()
     if len(parts) < 5:
         return False
@@ -186,15 +208,15 @@ def cron_matches_now(expr, ts=None):
     # the job runs if EITHER matches; otherwise both must match.
     dom_restricted = dom.strip() != '*'
     dow_restricted = dow.strip() != '*'
-    dom_ok = _field_matches(dom, t.tm_mday)
-    dow_ok = _field_matches(dow, py_dow)
+    dom_ok = _field_matches(dom, t.tm_mday, field_min=1)
+    dow_ok = _field_matches(dow, py_dow) or (py_dow == 0 and _field_matches(dow, 7))
     if dom_restricted and dow_restricted:
         if not (dom_ok or dow_ok):
             return False
     else:
         if not dom_ok or not dow_ok:
             return False
-    if not _field_matches(month, t.tm_mon):
+    if not _field_matches(month, t.tm_mon, field_min=1):
         return False
     return True
 

--- a/app_external.py
+++ b/app_external.py
@@ -51,10 +51,9 @@ def get_score_endpoint():
 
     try:
         db = get_db()
-        cur = db.cursor(cursor_factory=DictCursor)
-        cur.execute("SELECT * FROM score WHERE item_id = %s", (item_id,))
-        score_data = cur.fetchone()
-        cur.close()
+        with db.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute("SELECT * FROM score WHERE item_id = %s", (item_id,))
+            score_data = cur.fetchone()
 
         if score_data:
             # Convert DictRow to a standard dictionary for consistent JSON output
@@ -99,10 +98,9 @@ def get_embedding_endpoint():
     
     try:
         db = get_db()
-        cur = db.cursor(cursor_factory=DictCursor)
-        cur.execute("SELECT * FROM embedding WHERE item_id = %s", (item_id,))
-        embedding_data = cur.fetchone()
-        cur.close()
+        with db.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute("SELECT * FROM embedding WHERE item_id = %s", (item_id,))
+            embedding_data = cur.fetchone()
 
         if embedding_data:
             embedding_dict = dict(embedding_data)

--- a/app_helper.py
+++ b/app_helper.py
@@ -101,6 +101,39 @@ def attach_song_features(rows, id_key='item_id'):
     return rows
 
 
+def serialize_neighbor_results(neighbor_results, missing_album='unknown', include_album_artist=True):
+    """Build the similar-tracks JSON list from neighbor dicts carrying item_id + distance.
+
+    Shared by the IVF similarity endpoints and the sonic-fingerprint endpoint so the
+    response shape lives in one place. missing_album / include_album_artist keep each
+    caller's existing output shape.
+    """
+    if not neighbor_results:
+        return []
+    ids = [n['item_id'] for n in neighbor_results]
+    details_map = {d['item_id']: d for d in get_score_data_by_ids(ids)}
+    distance_map = {n['item_id']: n['distance'] for n in neighbor_results}
+    out = []
+    for nid in ids:
+        info = details_map.get(nid)
+        if not info:
+            continue
+        row = {
+            "item_id": info['item_id'],
+            "title": info['title'],
+            "author": info['author'],
+            "album": (info.get('album') or missing_album),
+            "distance": distance_map[nid],
+            "mood_vector": info.get('mood_vector'),
+            "other_features": info.get('other_features'),
+            "top_genre": top_stratified_genre(info.get('mood_vector')),
+        }
+        if include_album_artist:
+            row["album_artist"] = (info.get('album_artist') or 'unknown')
+        out.append(row)
+    return out
+
+
 
 
 

--- a/app_helper.py
+++ b/app_helper.py
@@ -118,11 +118,16 @@ def serialize_neighbor_results(neighbor_results, missing_album='unknown', includ
         info = details_map.get(nid)
         if not info:
             continue
+        # missing_album=None means "no substitution" (sonic fingerprint keeps the
+        # raw album, incl. '') -- only fall back when a sentinel is supplied.
+        album = info.get('album')
+        if missing_album is not None:
+            album = album or missing_album
         row = {
             "item_id": info['item_id'],
             "title": info['title'],
             "author": info['author'],
-            "album": (info.get('album') or missing_album),
+            "album": album,
             "distance": distance_map[nid],
             "mood_vector": info.get('mood_vector'),
             "other_features": info.get('other_features'),

--- a/app_ivf.py
+++ b/app_ivf.py
@@ -7,7 +7,7 @@ import numpy as np
 
 # Import the new config option
 from config import SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT, MOOD_CENTROIDS_FILE
-from app_helper import top_stratified_genre
+from app_helper import serialize_neighbor_results
 from tasks.ivf_manager import (
     find_nearest_neighbors_by_id, 
     find_nearest_neighbors_by_vector,
@@ -19,6 +19,35 @@ from tasks.ivf_manager import (
 
 logger = logging.getLogger(__name__)
 
+
+# Map a neighbor-search exception to the shared JSON error response (one contract,
+# reused by every similarity mode).
+def _neighbor_search_error_response(ctx, exc, is_runtime):
+    if is_runtime:
+        logger.error(f"Runtime error finding neighbors for {ctx}: {exc}", exc_info=True)
+        return jsonify({"error": "The similarity search service is currently unavailable."}), 503
+    logger.error(f"Unexpected error finding neighbors for {ctx}: {exc}", exc_info=True)
+    return jsonify({"error": "An unexpected error occurred."}), 500
+
+
+# Wrap the shared vector-neighbor search + error mapping
+def _vector_neighbors_or_error(vector, num_neighbors, eliminate_duplicates, ctx, empty_msg):
+    try:
+        results = find_nearest_neighbors_by_vector(vector, n=num_neighbors, eliminate_duplicates=eliminate_duplicates)
+    except RuntimeError as e:
+        return None, _neighbor_search_error_response(ctx, e, is_runtime=True)
+    except Exception as e:
+        return None, _neighbor_search_error_response(ctx, e, is_runtime=False)
+    if not results:
+        return None, (jsonify({"error": empty_msg}), 404)
+    return results, None
+
+
+# Build similar-tracks JSON list from neighbor results (shared serializer)
+def _serialize_neighbor_results(neighbor_results):
+    return serialize_neighbor_results(neighbor_results)
+
+
 _MOOD_CENTROIDS_DATA = {}  # mood_name -> list of centroid dicts (with vectors)
 _MOOD_CENTROIDS_META = {}  # mood_name -> list of {cluster_id, top_tags (top 3)} for API
 _mood_centroids_loaded = False
@@ -26,7 +55,7 @@ _mood_centroids_lock = threading.Lock()
 
 def _load_mood_centroids_for_similarity():
     try:
-        with open(MOOD_CENTROIDS_FILE) as f:
+        with open(MOOD_CENTROIDS_FILE, encoding='utf-8') as f:
             data = json.load(f)
         for mood, info in data.items():
             centroids = info.get('centroids', [])
@@ -164,6 +193,7 @@ def search_tracks_endpoint():
     if end is not None and end <= start:
         return jsonify([])
     limit = (end - start) if end is not None else 20
+    limit = min(limit, 500)
     offset = start
 
     try:
@@ -326,44 +356,12 @@ def get_similar_tracks_endpoint():
             return jsonify({"error": f"Invalid centroid_index {centroid_index_param} for mood '{mood_param}' (0-{len(centroids)-1})."}), 400
 
         centroid_vector = np.array(centroids[centroid_index_param]['centroid'], dtype=np.float32)
-        try:
-            neighbor_results = find_nearest_neighbors_by_vector(
-                centroid_vector,
-                n=num_neighbors,
-                eliminate_duplicates=eliminate_duplicates
-            )
-        except RuntimeError as e:
-            logger.error(f"Runtime error finding neighbors for mood centroid: {e}", exc_info=True)
-            return jsonify({"error": "The similarity search service is currently unavailable."}), 503
-        except Exception as e:
-            logger.error(f"Unexpected error finding neighbors for mood centroid: {e}", exc_info=True)
-            return jsonify({"error": "An unexpected error occurred."}), 500
-
-        if not neighbor_results:
-            return jsonify({"error": "No similar tracks found for this mood centroid."}), 404
-
-        from app_helper import get_score_data_by_ids
-        neighbor_ids = [n_item['item_id'] for n_item in neighbor_results]
-        neighbor_details = get_score_data_by_ids(neighbor_ids)
-        details_map = {d['item_id']: d for d in neighbor_details}
-        distance_map = {n_item['item_id']: n_item['distance'] for n_item in neighbor_results}
-
-        final_results = []
-        for neighbor_id in neighbor_ids:
-            if neighbor_id in details_map:
-                track_info = details_map[neighbor_id]
-                final_results.append({
-                    "item_id": track_info['item_id'],
-                    "title": track_info['title'],
-                    "author": track_info['author'],
-                    "album": (track_info.get('album') or 'unknown'),
-                    "album_artist": (track_info.get('album_artist') or 'unknown'),
-                    "distance": distance_map[neighbor_id],
-                    "mood_vector": track_info.get('mood_vector'),
-                    "other_features": track_info.get('other_features'),
-                    "top_genre": top_stratified_genre(track_info.get('mood_vector'))
-                })
-        return jsonify(final_results)
+        neighbor_results, err = _vector_neighbors_or_error(
+            centroid_vector, num_neighbors, eliminate_duplicates,
+            "mood centroid", "No similar tracks found for this mood centroid.")
+        if err:
+            return err
+        return jsonify(_serialize_neighbor_results(neighbor_results))
 
     # --- Anchor mode: use anchor's centroid vector ---
     if anchor_id_param is not None:
@@ -373,44 +371,12 @@ def get_similar_tracks_endpoint():
             return jsonify({"error": f"Anchor with id {anchor_id_param} not found or has no centroid."}), 404
 
         anchor_vector = np.array(anchor['centroid'], dtype=np.float32)
-        try:
-            neighbor_results = find_nearest_neighbors_by_vector(
-                anchor_vector,
-                n=num_neighbors,
-                eliminate_duplicates=eliminate_duplicates
-            )
-        except RuntimeError as e:
-            logger.error(f"Runtime error finding neighbors for anchor {anchor_id_param}: {e}", exc_info=True)
-            return jsonify({"error": "The similarity search service is currently unavailable."}), 503
-        except Exception as e:
-            logger.error(f"Unexpected error finding neighbors for anchor {anchor_id_param}: {e}", exc_info=True)
-            return jsonify({"error": "An unexpected error occurred."}), 500
-
-        if not neighbor_results:
-            return jsonify({"error": "No similar tracks found for this anchor."}), 404
-
-        from app_helper import get_score_data_by_ids
-        neighbor_ids = [n_item['item_id'] for n_item in neighbor_results]
-        neighbor_details = get_score_data_by_ids(neighbor_ids)
-        details_map = {d['item_id']: d for d in neighbor_details}
-        distance_map = {n_item['item_id']: n_item['distance'] for n_item in neighbor_results}
-
-        final_results = []
-        for neighbor_id in neighbor_ids:
-            if neighbor_id in details_map:
-                track_info = details_map[neighbor_id]
-                final_results.append({
-                    "item_id": track_info['item_id'],
-                    "title": track_info['title'],
-                    "author": track_info['author'],
-                    "album": (track_info.get('album') or 'unknown'),
-                    "album_artist": (track_info.get('album_artist') or 'unknown'),
-                    "distance": distance_map[neighbor_id],
-                    "mood_vector": track_info.get('mood_vector'),
-                    "other_features": track_info.get('other_features'),
-                    "top_genre": top_stratified_genre(track_info.get('mood_vector'))
-                })
-        return jsonify(final_results)
+        neighbor_results, err = _vector_neighbors_or_error(
+            anchor_vector, num_neighbors, eliminate_duplicates,
+            f"anchor {anchor_id_param}", "No similar tracks found for this anchor.")
+        if err:
+            return err
+        return jsonify(_serialize_neighbor_results(neighbor_results))
 
     # --- Standard song-based mode ---
     target_item_id = None
@@ -436,37 +402,11 @@ def get_similar_tracks_endpoint():
         if not neighbor_results:
             return jsonify({"error": "Target track not found in index or no similar tracks found."}), 404
 
-        from app_helper import get_score_data_by_ids
-
-        neighbor_ids = [n['item_id'] for n in neighbor_results]
-        neighbor_details = get_score_data_by_ids(neighbor_ids)
-
-        details_map = {d['item_id']: d for d in neighbor_details}
-        distance_map = {n['item_id']: n['distance'] for n in neighbor_results}
-
-        final_results = []
-        for neighbor_id in neighbor_ids:
-            if neighbor_id in details_map:
-                track_info = details_map[neighbor_id]
-                final_results.append({
-                    "item_id": track_info['item_id'],
-                    "title": track_info['title'],
-                    "author": track_info['author'],
-                    "album": (track_info.get('album') or 'unknown'),
-                    "album_artist": (track_info.get('album_artist') or 'unknown'),
-                    "distance": distance_map[neighbor_id],
-                    "mood_vector": track_info.get('mood_vector'),
-                    "other_features": track_info.get('other_features'),
-                    "top_genre": top_stratified_genre(track_info.get('mood_vector'))
-                })
-
-        return jsonify(final_results)
+        return jsonify(_serialize_neighbor_results(neighbor_results))
     except RuntimeError as e:
-        logger.error(f"Runtime error finding neighbors for {target_item_id}: {e}", exc_info=True)
-        return jsonify({"error": "The similarity search service is currently unavailable."}), 503
+        return _neighbor_search_error_response(target_item_id, e, is_runtime=True)
     except Exception as e:
-        logger.error(f"Unexpected error finding neighbors for {target_item_id}: {e}", exc_info=True)
-        return jsonify({"error": "An unexpected error occurred."}), 500
+        return _neighbor_search_error_response(target_item_id, e, is_runtime=False)
 
 
 @ivf_bp.route('/api/max_distance', methods=['GET'])

--- a/app_ivf.py
+++ b/app_ivf.py
@@ -319,6 +319,7 @@ def get_similar_tracks_endpoint():
     title = request.args.get('title')
     artist = request.args.get('artist')
     num_neighbors = request.args.get('n', 10, type=int)
+    num_neighbors = max(1, num_neighbors)
 
     # Optional mood centroid parameters
     mood_param = request.args.get('mood', '', type=str).strip().lower()
@@ -561,8 +562,8 @@ def create_media_server_playlist():
     playlist_name = data.get('playlist_name')
     track_ids_raw = data.get('track_ids', [])
 
-    if not playlist_name:
-        return jsonify({"error": "Missing 'playlist_name'"}), 400
+    if not isinstance(playlist_name, str) or not playlist_name:
+        return jsonify({"error": "Invalid or missing 'playlist_name'"}), 400
 
     final_track_ids = []
     if isinstance(track_ids_raw, list):

--- a/app_path.py
+++ b/app_path.py
@@ -16,7 +16,7 @@ _MOOD_CENTROIDS = {}  # mood_name -> list of np.array centroids
 
 def _load_mood_centroids():
     try:
-        with open(MOOD_CENTROIDS_FILE) as f:
+        with open(MOOD_CENTROIDS_FILE, encoding='utf-8') as f:
             data = json.load(f)
         for mood, info in data.items():
             _MOOD_CENTROIDS[mood] = [np.array(c['centroid'], dtype=np.float32) for c in info['centroids']]

--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -432,12 +432,14 @@ def probe_test():
                         'sample_count': 0, 'warnings': []}), 200
     try:
         result = provider_probe.test_connection(t, creds)
-    except NotImplementedError as e:
-        return jsonify({'ok': False, 'error': str(e), 'path_format': 'none',
-                        'sample_count': 0, 'warnings': []}), 200
-    except Exception as e:
-        return jsonify({'ok': False, 'error': str(e), 'path_format': 'none',
-                        'sample_count': 0, 'warnings': []}), 200
+    except NotImplementedError:
+        logger.warning("test_connection not supported for provider type %s", t)
+        return jsonify({'ok': False, 'error': 'Connection testing is not supported for this provider.',
+                        'path_format': 'none', 'sample_count': 0, 'warnings': []}), 200
+    except Exception:
+        logger.warning("test_connection failed for provider type %s", t, exc_info=True)
+        return jsonify({'ok': False, 'error': 'Connection test failed. Check the container logs for details.',
+                        'path_format': 'none', 'sample_count': 0, 'warnings': []}), 200
     return jsonify(result)
 
 
@@ -504,7 +506,7 @@ def libraries_list():
             'libraries': [],
             'unsupported': False,
             'selected_libraries': selected,
-            'error': str(e),
+            'error': 'Failed to list libraries. Check the container logs for details.',
         }), 200
     return jsonify({
         'libraries': result.get('libraries', []),
@@ -628,8 +630,9 @@ def search_albums():
     target_type, creds = session
     try:
         albums = provider_probe.search_albums(target_type, creds, query)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.warning("search_albums failed for session %s", session_id, exc_info=True)
+        return jsonify({'error': 'Album search failed. Check the container logs for details.'}), 500
     return jsonify({'albums': albums})
 
 
@@ -699,8 +702,9 @@ def source_paths_refresh():
 
     try:
         tracks = provider_probe.fetch_all_tracks(source_type, creds)
-    except Exception as e:
-        return jsonify({'ok': False, 'error': str(e)}), 500
+    except Exception:
+        logger.warning("source path refresh failed for provider %s", source_type, exc_info=True)
+        return jsonify({'ok': False, 'error': 'Failed to refresh source paths. Check the container logs for details.'}), 500
 
     path_format = _detect_path_format(tracks)
     overrides = {
@@ -815,8 +819,9 @@ def dry_run():
 
     try:
         new_tracks = provider_probe.fetch_all_tracks(target_type, creds)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.warning("fetch_all_tracks failed for target type %s", target_type, exc_info=True)
+        return jsonify({'error': 'Failed to fetch target tracks. Check the container logs for details.'}), 500
 
     old_rows = _load_score_rows_as_dicts()
     _apply_source_path_overrides(old_rows, source_overrides)
@@ -932,8 +937,9 @@ def match_album():
 
     try:
         new_tracks = provider_probe.get_album_tracks(target_type, creds, new_album_id)
-    except Exception as e:
-        return jsonify({'error': str(e)}), 500
+    except Exception:
+        logger.warning("get_album_tracks failed for session %s", session_id, exc_info=True)
+        return jsonify({'error': 'Failed to fetch album tracks. Check the container logs for details.'}), 500
 
     import importlib
     matcher = importlib.import_module('tasks.provider_migration_matcher')
@@ -1345,11 +1351,12 @@ def job_status(task_id):
             'id': job.id,
             'status': status,
             'result': job.result if job.is_finished else None,
-            'error': str(job.exc_info) if job.is_failed else None,
+            'error': 'Job failed. Check the container logs for details.' if job.is_failed else None,
             'restart_scheduled': restart_scheduled,
         })
-    except Exception as e:
-        return jsonify({'error': str(e)}), 404
+    except Exception:
+        logger.warning("migration job status fetch failed for task %s", task_id, exc_info=True)
+        return jsonify({'error': 'Job not found.'}), 404
 
 
 @migration_bp.route('/api/migration/dry-run-report/<int:session_id>', methods=['GET'])
@@ -1592,7 +1599,8 @@ def _load_unmatched_for_album(session_id, album_key):
     """Return the set of old rows that live in the given (album_artist, album)
     and were NOT matched by the dry run."""
     state = _load_state(session_id) or {}
-    matched_ids = set((state.get('dry_run') or {}).get('matches', {}).keys())
+    manual_unmatches = set(state.get('manual_unmatches') or [])
+    matched_ids = set((state.get('dry_run') or {}).get('matches', {}).keys()) - manual_unmatches
     matched_ids |= set((state.get('manual_matches') or {}).keys())
     rows = _load_score_rows_as_dicts()
     target_artist, target_album = (album_key[0] if album_key else None,
@@ -1637,7 +1645,7 @@ def _albums_payload(unmatched_by_album):
     to keep the persisted state and the step-4 review page bounded.
     """
     import config
-    limit = int(getattr(config, 'MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT', 200) or 200)
+    limit = config.MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT
     out = []
     for key, rows in unmatched_by_album.items():
         if len(out) >= limit:

--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -703,7 +703,7 @@ def source_paths_refresh():
     try:
         tracks = provider_probe.fetch_all_tracks(source_type, creds)
     except Exception:
-        logger.warning("source path refresh failed during provider probe for provider %s", source_type, exc_info=True)
+        logger.warning("source path refresh failed during provider probe", exc_info=True)
         return jsonify({'ok': False, 'error': 'Failed to refresh source paths. Check the container logs for details.'}), 500
 
     path_format = _detect_path_format(tracks)

--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -703,7 +703,7 @@ def source_paths_refresh():
     try:
         tracks = provider_probe.fetch_all_tracks(source_type, creds)
     except Exception:
-        logger.warning("source path refresh failed for provider %s", source_type, exc_info=True)
+        logger.warning("source path refresh failed during provider probe", exc_info=True)
         return jsonify({'ok': False, 'error': 'Failed to refresh source paths. Check the container logs for details.'}), 500
 
     path_format = _detect_path_format(tracks)

--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -703,7 +703,7 @@ def source_paths_refresh():
     try:
         tracks = provider_probe.fetch_all_tracks(source_type, creds)
     except Exception:
-        logger.warning("source path refresh failed during provider probe", exc_info=True)
+        logger.warning("source path refresh failed during provider probe for provider %s", source_type, exc_info=True)
         return jsonify({'ok': False, 'error': 'Failed to refresh source paths. Check the container logs for details.'}), 500
 
     path_format = _detect_path_format(tracks)

--- a/app_setup.py
+++ b/app_setup.py
@@ -184,7 +184,7 @@ def _test_media_server_connection(filtered_values):
     original_config = _patch_config_for_test(test_config)
     try:
         media_type = test_config.get('MEDIASERVER_TYPE', 'jellyfin')
-        probe_limit = getattr(config, 'PROBE_TOP_PLAYED_LIMIT', 1)
+        probe_limit = config.PROBE_TOP_PLAYED_LIMIT
         items = mediaserver.get_top_played_songs(probe_limit)
         if not items:
             raise AudioMuseError(ERR_MEDIASERVER_UNREACHABLE, f"No top-played songs were returned from {media_type.capitalize()}; check the URL and credentials.")
@@ -715,7 +715,7 @@ def setup_lyrics_api_analyze():
             path_segments.append({'index': idx, 'value': decoded})
 
     # For path-based APIs without artist/title query params, the convention is
-    # ``/.../<artist>/<title>`` — guess the last two surfaced segments accordingly.
+    # ``/.../<artist>/<title>`` -- guess the last two surfaced segments accordingly.
     if not guesses['artist_param'] and not guesses['title_param'] and len(path_segments) >= 2:
         guesses['path_roles'][path_segments[-2]['index']] = 'artist'
         guesses['path_roles'][path_segments[-1]['index']] = 'title'
@@ -766,7 +766,7 @@ def setup_lyrics_api_analyze():
                     _find_lyrics(v, path)
         _find_lyrics(json_obj)
 
-    display_raw = (raw_text or '')[:16384] + ('…' if raw_text and len(raw_text) > 16384 else '')
+    display_raw = (raw_text or '')[:16384] + ('...' if raw_text and len(raw_text) > 16384 else '')
     return jsonify({
         'params':        flat_params,
         'path_segments': path_segments,

--- a/app_sonic_fingerprint.py
+++ b/app_sonic_fingerprint.py
@@ -5,7 +5,7 @@ import logging
 from tasks.sonic_fingerprint_manager import generate_sonic_fingerprint
 from tasks.mediaserver import resolve_emby_jellyfin_user # Import the new resolver function
 from config import MEDIASERVER_TYPE, JELLYFIN_USER_ID, JELLYFIN_TOKEN, NAVIDROME_USER, NAVIDROME_PASSWORD # Import configs
-from app_helper import top_stratified_genre
+from app_helper import serialize_neighbor_results
 
 logger = logging.getLogger(__name__)
 
@@ -128,9 +128,6 @@ def generate_sonic_fingerprint_endpoint():
       500:
         description: Server error during generation.
     """
-    # Local import to prevent circular dependency
-    from app_helper import get_score_data_by_ids
-
     try:
         if request.method == 'POST':
             data = request.get_json()
@@ -180,27 +177,9 @@ def generate_sonic_fingerprint_endpoint():
         if not fingerprint_results:
             return jsonify([])
 
-        result_ids = [r['item_id'] for r in fingerprint_results]
-        details_list = get_score_data_by_ids(result_ids)
-        
-        details_map = {d['item_id']: d for d in details_list}
-        distance_map = {r['item_id']: r['distance'] for r in fingerprint_results}
-
-        final_results = []
-        for res_id in result_ids:
-            if res_id in details_map:
-                track_info = details_map[res_id]
-                final_results.append({
-                    "item_id": track_info['item_id'],
-                    "title": track_info['title'],
-                    "author": track_info['author'],
-                    "album": track_info.get('album'),
-                    "distance": distance_map[res_id],
-                    "mood_vector": track_info.get('mood_vector'),
-                    "other_features": track_info.get('other_features'),
-                    "top_genre": top_stratified_genre(track_info.get('mood_vector'))
-                })
-
+        final_results = serialize_neighbor_results(
+            fingerprint_results, missing_album=None, include_album_artist=False
+        )
         return jsonify(final_results)
     except Exception as e:
         logger.error(f"Error in sonic_fingerprint endpoint: {e}", exc_info=True)

--- a/app_waveform.py
+++ b/app_waveform.py
@@ -2,6 +2,7 @@
 from flask import Blueprint, jsonify, request, render_template
 import logging
 import os
+import shutil
 import tempfile
 import numpy as np
 from concurrent.futures import ThreadPoolExecutor, TimeoutError as FuturesTimeoutError
@@ -91,22 +92,23 @@ def generate_waveform_peaks(file_path, samples_count=500):
             return []
         
         # Vectorized peak extraction
-        samples_per_peak = max(1, len(y) // samples_count)
-        trim_length = samples_count * samples_per_peak
+        n = min(samples_count, len(y))
+        samples_per_peak = max(1, len(y) // n)
+        trim_length = n * samples_per_peak
         y_trimmed = y[:trim_length]
-        
+
         # Reshape and get peak energy
-        chunks = y_trimmed.reshape(samples_count, samples_per_peak)
+        chunks = y_trimmed.reshape(n, samples_per_peak)
         abs_chunks = np.abs(chunks)
         peak_energy = np.max(abs_chunks, axis=1)
-        
+
         # Normalize to -1 to 1 range
         max_val = np.max(peak_energy)
         if max_val > 0:
             peak_energy = peak_energy / max_val
-        
+
         # Create symmetric waveform
-        peaks = np.empty(samples_count * 2, dtype=np.float32)
+        peaks = np.empty(n * 2, dtype=np.float32)
         peaks[0::2] = -peak_energy
         peaks[1::2] = peak_energy
         
@@ -120,15 +122,16 @@ def generate_waveform_peaks(file_path, samples_count=500):
         if len(y) == 0:
             return []
         
-        samples_per_peak = max(1, len(y) // samples_count)
-        trim_length = samples_count * samples_per_peak
+        n = min(samples_count, len(y))
+        samples_per_peak = max(1, len(y) // n)
+        trim_length = n * samples_per_peak
         y_trimmed = y[:trim_length]
-        
-        chunks = y_trimmed.reshape(samples_count, samples_per_peak)
+
+        chunks = y_trimmed.reshape(n, samples_per_peak)
         abs_chunks = np.abs(chunks)
         peak_energy = np.max(abs_chunks, axis=1)
-        
-        peaks = np.empty(samples_count * 2, dtype=np.float32)
+
+        peaks = np.empty(n * 2, dtype=np.float32)
         peaks[0::2] = -peak_energy
         peaks[1::2] = peak_energy
         peaks = np.clip(peaks, -1.0, 1.0)
@@ -201,6 +204,7 @@ def get_waveform_endpoint():
     
     # Download the track to a temporary location
     temp_file = None
+    temp_dir = None
     try:
         import time
         start_time = time.time()
@@ -245,7 +249,7 @@ def get_waveform_endpoint():
             }
         
         fetch_time = time.time() - start_time
-        logger.info(f"⏱️  Fetched track metadata in {fetch_time:.2f}s")
+        logger.info(f"Fetched track metadata in {fetch_time:.2f}s")
         
         # Create a temporary directory for this download
         temp_dir = tempfile.mkdtemp(prefix='waveform_')
@@ -254,13 +258,13 @@ def get_waveform_endpoint():
         download_start = time.time()
         temp_file = download_track(temp_dir, item)
         download_time = time.time() - download_start
-        logger.info(f"⏱️  Downloaded track in {download_time:.2f}s")
+        logger.info(f"Downloaded track in {download_time:.2f}s")
         
         if not temp_file or not os.path.exists(temp_file):
             return jsonify({"error": "Failed to download track from media server"}), 500
         
         # Generate waveform peaks in a thread pool with timeout
-        logger.info(f"🌊 Generating waveform with librosa for song={title}, item_id={item_id}")
+        logger.info(f"Generating waveform with librosa for song={title}, item_id={item_id}")
         
         waveform_start = time.time()
         # Submit to thread pool for parallel execution
@@ -275,7 +279,7 @@ def get_waveform_endpoint():
         
         waveform_time = time.time() - waveform_start
         total_time = time.time() - start_time
-        logger.info(f"✅ Generated {len(peaks)} waveform peaks in {waveform_time:.2f}s (total: {total_time:.2f}s)")
+        logger.info(f"Generated {len(peaks)} waveform peaks in {waveform_time:.2f}s (total: {total_time:.2f}s)")
         
         response = {
             "peaks": peaks,
@@ -287,18 +291,13 @@ def get_waveform_endpoint():
         
     except RuntimeError as e:
         logger.error(f"Runtime error generating waveform for {item_id}: {e}", exc_info=True)
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "An error occurred during waveform generation"}), 500
     except Exception as e:
         logger.error(f"Unexpected error generating waveform for {item_id}: {e}", exc_info=True)
         return jsonify({"error": "An unexpected error occurred during waveform generation"}), 500
     finally:
-        # Clean up temporary file
-        if temp_file and os.path.exists(temp_file):
+        if temp_dir and os.path.exists(temp_dir):
             try:
-                os.remove(temp_file)
-                # Try to remove the temp directory if it's empty
-                temp_dir = os.path.dirname(temp_file)
-                if os.path.exists(temp_dir):
-                    os.rmdir(temp_dir)
+                shutil.rmtree(temp_dir, ignore_errors=True)
             except Exception as cleanup_error:
-                logger.warning(f"Failed to clean up temporary file {temp_file}: {cleanup_error}")
+                logger.warning(f"Failed to clean up temporary directory {temp_dir}: {cleanup_error}")

--- a/app_waveform.py
+++ b/app_waveform.py
@@ -297,7 +297,11 @@ def get_waveform_endpoint():
         return jsonify({"error": "An unexpected error occurred during waveform generation"}), 500
     finally:
         if temp_dir and os.path.exists(temp_dir):
+            # Best-effort: keep removing siblings past a locked file (common on
+            # Windows when a timed-out worker still holds the audio open).
+            def _on_rmtree_error(func, path, exc_info):
+                logger.warning(f"Failed to remove {path} during waveform temp cleanup: {exc_info[1]}")
             try:
-                shutil.rmtree(temp_dir)
+                shutil.rmtree(temp_dir, onerror=_on_rmtree_error)
             except Exception as cleanup_error:
                 logger.warning(f"Failed to clean up temporary directory {temp_dir}: {cleanup_error}")

--- a/app_waveform.py
+++ b/app_waveform.py
@@ -298,6 +298,6 @@ def get_waveform_endpoint():
     finally:
         if temp_dir and os.path.exists(temp_dir):
             try:
-                shutil.rmtree(temp_dir, ignore_errors=True)
+                shutil.rmtree(temp_dir)
             except Exception as cleanup_error:
                 logger.warning(f"Failed to clean up temporary directory {temp_dir}: {cleanup_error}")

--- a/config.py
+++ b/config.py
@@ -118,6 +118,8 @@ MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs p
 SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT = os.environ.get("SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT", "True").lower() == 'true'
 # Default behavior for radius similarity mode. Can be toggled via environment variable.
 SIMILARITY_RADIUS_DEFAULT = os.environ.get("SIMILARITY_RADIUS_DEFAULT", "True").lower() == 'true'
+# Optional radius-walk bucket-skip instrumentation (hidden debug flag, not a wizard param)
+RADIUS_INSTRUMENTATION = os.environ.get("RADIUS_INSTRUMENTATION", "False").lower() == 'true'
 NUM_RECENT_ALBUMS = int(os.getenv("NUM_RECENT_ALBUMS", "0")) # Convert to int
 TOP_N_PLAYLISTS = int(os.environ.get("TOP_N_PLAYLISTS", "8")) # *** NEW: Default for Top N diverse playlists ***
 MIN_PLAYLIST_SIZE_FOR_TOP_N = int(os.environ.get("MIN_PLAYLIST_SIZE_FOR_TOP_N", "20")) # Min songs for a playlist to be considered in the first pass of Top-N selection.
@@ -288,6 +290,11 @@ MISTRAL_MODEL_NAME = os.environ.get("MISTRAL_MODEL_NAME", "ministral-3b-latest")
 # Default: 120 seconds for Ollama (tool calling/instant playlist), 60 seconds for OpenAI/Mistral
 AI_REQUEST_TIMEOUT_SECONDS = int(os.environ.get("AI_REQUEST_TIMEOUT_SECONDS", "300"))
 REDIS_URL = os.environ.get('REDIS_URL', 'redis://localhost:6379/0')
+
+# RQ worker tuning: restart-after-N-jobs (memory-leak guard) and log level.
+RQ_MAX_JOBS = int(os.getenv('RQ_MAX_JOBS', '50'))
+RQ_MAX_JOBS_HIGH = int(os.getenv('RQ_MAX_JOBS_HIGH', '100'))
+RQ_LOGGING_LEVEL = os.getenv('RQ_LOGGING_LEVEL', 'INFO').upper()
 
 # Construct DATABASE_URL from individual components for better security in K8s
 POSTGRES_USER = os.environ.get("POSTGRES_USER", "audiomuse")
@@ -687,6 +694,11 @@ MOOD_SIMILARITY_ENABLE = os.environ.get("MOOD_SIMILARITY_ENABLE", "False").lower
 #   proxy_set_header X-Forwarded-Proto https;
 #   proxy_set_header X-Forwarded-Prefix /audiomuseai;
 # }
+# The trailing slash on BOTH 'location /audiomuseai/' and 'proxy_pass .../' is
+# required: it makes nginx strip the subpath before forwarding. Without it the
+# full path reaches the app while X-Forwarded-Prefix is still sent, doubling the
+# prefix; the app now collapses that duplication (StripDuplicatedScriptName) so
+# it no longer loops to /audiomuseai/setup, but stripping at the proxy is correct.
 ENABLE_PROXY_FIX = os.environ.get("ENABLE_PROXY_FIX", "False").lower() == "true"
 
 # --- Instant Playlist Optimization ---

--- a/config.py
+++ b/config.py
@@ -41,7 +41,7 @@ PROBE_TOP_PLAYED_LIMIT = int(os.environ.get("PROBE_TOP_PLAYED_LIMIT", "1"))
 # unmatched groups (e.g. wrong path format) and the page becomes unusable
 # beyond a couple hundred entries. The full count is still surfaced as a
 # warning so the user knows the list is truncated.
-MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT = int(os.environ.get("MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT", "200"))
+MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT = max(1, int(os.environ.get("MIGRATION_UNMATCHED_ALBUMS_PAYLOAD_LIMIT", "200")))
 # Hard cap on the per-collision detail rows persisted into migration_session.state.
 # collision_details is display-only (it tells the user which albums to re-match),
 # so storing one entry per collision would let this single JSONB field grow with

--- a/database.py
+++ b/database.py
@@ -264,7 +264,6 @@ def save_task_status(task_id, task_type, status=TASK_STATUS_PENDING, parent_task
     Saves or updates a task's status in the database, using Unix timestamps for start and end times.
     """
     db = get_db()
-    cur = db.cursor()
     current_unix_time = time.time()
 
     if details is not None and isinstance(details, dict):
@@ -283,7 +282,8 @@ def save_task_status(task_id, task_type, status=TASK_STATUS_PENDING, parent_task
                 details['log'] = ["Task completed successfully."]
 
     details_json = json.dumps(details) if details is not None else None
-    
+
+    cur = db.cursor()
     try:
         # This query now handles start_time and end_time using Unix timestamps
         cur.execute("""
@@ -326,13 +326,12 @@ def save_task_status(task_id, task_type, status=TASK_STATUS_PENDING, parent_task
         ):
             duration_s = None
             try:
-                hist_cur = db.cursor()
-                hist_cur.execute(
-                    "SELECT start_time, end_time FROM task_status WHERE task_id = %s",
-                    (task_id,),
-                )
-                row = hist_cur.fetchone()
-                hist_cur.close()
+                with db.cursor() as hist_cur:
+                    hist_cur.execute(
+                        "SELECT start_time, end_time FROM task_status WHERE task_id = %s",
+                        (task_id,),
+                    )
+                    row = hist_cur.fetchone()
                 if row and row[0] is not None:
                     end = row[1] if row[1] is not None else current_unix_time
                     duration_s = max(0.0, float(end) - float(row[0]))

--- a/native-build/macos/launcher.py
+++ b/native-build/macos/launcher.py
@@ -131,14 +131,8 @@ def _run_menubar():
                 None,
                 rumps.MenuItem("Quit", callback=self.on_quit),
             ]
-            threading.Thread(target=self._boot, name="boot", daemon=True).start()
+            supervisor.start_in_background()
             rumps.Timer(self._refresh, 3).start()
-
-        def _boot(self):
-            try:
-                supervisor.start_all()
-            except Exception:
-                pass
 
         def on_open_browser(self, _):
             subprocess.Popen(["open", "http://127.0.0.1:8000"])
@@ -147,8 +141,13 @@ def _run_menubar():
             subprocess.Popen(["open", "-a", "Console", paths.log_file()])
 
         def on_toggle(self, _):
-            target = supervisor.stop_all if supervisor.is_running() else supervisor.start_all
-            threading.Thread(target=target, daemon=True).start()
+            # START via start_in_background so the supervisor tracks the boot
+            # thread (_join_workers can then join it on a racing stop/quit and
+            # not leak a child spawned in the Popen->register micro-window).
+            if supervisor.is_running():
+                threading.Thread(target=supervisor.stop_all, daemon=True).start()
+            else:
+                supervisor.start_in_background()
 
         def on_quit(self, _):
             supervisor.stop_all()

--- a/native-build/macos/supervisor.py
+++ b/native-build/macos/supervisor.py
@@ -55,6 +55,12 @@ class ProcessSupervisor:
         self._control = ControlServer(paths.control_socket_path(), self.dispatch_control)
         self._health_thread = None
         self._health_stop = threading.Event()
+        # Set by stop_all() to tell an in-flight start_all() to stop spawning;
+        # _boot_thread lets stop_all() join the boot thread before teardown so a
+        # stop racing a boot can't sweep the child table mid-spawn and leak the
+        # late children as detached (start_new_session) orphans.
+        self._stop_requested = threading.Event()
+        self._boot_thread = None
         self._log = self._setup_logging()
 
     def _setup_logging(self):
@@ -76,25 +82,51 @@ class ProcessSupervisor:
     def state(self):
         return self._state
 
+    def start_in_background(self, on_ready=None, on_error=None):
+        """Boot the stack on a daemon thread the supervisor owns, so stop_all can
+        join it before teardown (a stop racing a boot would otherwise sweep the
+        child table mid-spawn and leak the late children as orphans)."""
+        def _boot():
+            try:
+                self.start_all()
+            except Exception as exc:
+                if on_error is not None:
+                    on_error(exc)
+                return
+            if on_ready is not None and self.is_running():
+                on_ready()
+        self._boot_thread = threading.Thread(target=_boot, name="boot", daemon=True)
+        self._boot_thread.start()
+        return self._boot_thread
+
     def start_all(self):
         with self._lock:
             if self._state in ("running", "starting"):
                 return
             self._state = "starting"
+            self._stop_requested.clear()
         self._log.info("=== AudioMuse-AI starting ===")
         try:
             self._reap_orphans()
             self._control.start()
+            if self._stop_requested.is_set():
+                return  # stop arrived mid-boot; the stopper handles teardown
             self._database_url = database.start_embedded(paths.pgdata_dir())
             self._log.info("Embedded PostgreSQL ready")
+            if self._stop_requested.is_set():
+                return
             self._start_redis()
             self._log.info("Embedded Redis ready")
             for name in BOOT_ORDER:
+                if self._stop_requested.is_set():
+                    return
                 self.start_child(name)
                 if name == "flask":
                     self._wait_http(FLASK_URL, timeout=180)
             self._write_pidfile()
             with self._lock:
+                if self._stop_requested.is_set():
+                    return
                 self._state = "running"
             self._start_health_loop()
             self._log.info("=== AudioMuse-AI running ===")
@@ -106,11 +138,17 @@ class ProcessSupervisor:
 
     def stop_all(self):
         with self._lock:
-            if self._state == "stopped":
+            if self._state in ("stopping", "stopped"):
                 return
             self._state = "stopping"
+            self._stop_requested.set()
             self._desired.clear()
         self._health_stop.set()
+        # Wait for any in-flight boot/health work to stop spawning before we
+        # sweep: a child spawned after the sweep would survive as an orphan in
+        # its own session. Joining guarantees everything they started is
+        # registered in _children and gets torn down below.
+        self._join_workers()
         for name in reversed(BOOT_ORDER):
             self._terminate_named(name)
         self._terminate_named("redis")
@@ -123,6 +161,16 @@ class ProcessSupervisor:
         with self._lock:
             self._state = "stopped"
         self._log.info("=== AudioMuse-AI stopped ===")
+
+    def _join_workers(self):
+        """Wait for the boot and health threads to finish before teardown.
+
+        Skips the current thread so stop_all() called from within start_all()'s
+        failure handler (boot thread) never deadlocks on itself."""
+        current = threading.current_thread()
+        for thread in (self._boot_thread, self._health_thread):
+            if thread is not None and thread is not current and thread.is_alive():
+                thread.join(timeout=30)
 
     def _start_redis(self):
         argv, url = taskqueue.build_embedded_redis_argv(
@@ -148,11 +196,16 @@ class ProcessSupervisor:
         role = ROLE_OF.get(name)
         if role is None:
             return False
+        with self._lock:
+            # Refuse to spawn once a stop is in progress -- otherwise the boot
+            # loop or the health loop could create a child after stop_all's
+            # teardown sweep, leaking it as a detached orphan.
+            if self._state not in ("starting", "running"):
+                return False
+            self._desired.add(name)
         argv = [sys.executable, f"--role={role}"]
         child_env = env_builder.build_child_env(role, self._database_url, self._redis_url)
         self._spawn(name, argv, child_env)
-        with self._lock:
-            self._desired.add(name)
         return True
 
     def stop_child(self, name):

--- a/native-build/macos/supervisor.py
+++ b/native-build/macos/supervisor.py
@@ -333,17 +333,29 @@ class ProcessSupervisor:
             self._log.exception("Failed to restart embedded Redis")
 
     def dispatch_control(self, action, services):
-        results = []
+        """Apply a restart/stop/start request on a daemon thread and acknowledge
+        immediately: restarting several busy workers serially (each up to ~10s to
+        terminate) can outlast the control socket's 15s timeout, which would make
+        the UI report a failure for a restart that actually succeeds."""
+        if action not in ("restart", "stop", "start"):
+            return False
+        threading.Thread(
+            target=self._apply_control, args=(action, list(services)),
+            name=f"control-{action}", daemon=True,
+        ).start()
+        return True
+
+    def _apply_control(self, action, services):
         for svc in services:
-            if action == "stop":
-                results.append(self.stop_child(svc))
-            elif action == "start":
-                results.append(self.start_child(svc))
-            elif action == "restart":
-                results.append(self.restart_child(svc))
-            else:
-                results.append(False)
-        return all(results) if results else False
+            try:
+                if action == "stop":
+                    self.stop_child(svc)
+                elif action == "start":
+                    self.start_child(svc)
+                elif action == "restart":
+                    self.restart_child(svc)
+            except Exception:
+                logger.exception("Control %s failed for %s", action, svc)
 
     def _wait_http(self, url, timeout):
         deadline = time.time() + timeout

--- a/native-build/windows/env.py
+++ b/native-build/windows/env.py
@@ -39,11 +39,9 @@ def build_child_env(role, db_conn, redis_url):
         # shared restart_manager.py. Not a real OS check.
         "AUDIOMUSE_PLATFORM": "macos",
         "APP_DATA_DIR": paths.app_support_dir(),
-        # Windows has no AF_UNIX.  Set the control socket to empty so
-        # restart_manager._send_control bails out safely (logs an error,
-        # returns False) instead of crashing on ``socket.AF_UNIX``.
-        # Restart-on-config-change is a no-op on Windows; users restart
-        # the app manually.
+        # Windows has no AF_UNIX: leave the control socket empty and use
+        # host/port. restart_manager._send_control prefers the TCP path,
+        # so save-config -> restart-workers works on Windows.
         "AUDIOMUSE_CONTROL_SOCKET": "",
         "AUDIOMUSE_CONTROL_HOST": "127.0.0.1",
         "AUDIOMUSE_CONTROL_PORT": str(paths.control_port()),

--- a/native-build/windows/launcher.py
+++ b/native-build/windows/launcher.py
@@ -298,7 +298,7 @@ def _run_tray():
             pass
 
     def _on_start(icon, _item):
-        threading.Thread(target=supervisor.start_all, name="tray-start", daemon=True).start()
+        supervisor.start_in_background()
 
     def _on_stop(icon, _item):
         threading.Thread(target=supervisor.stop_all, name="tray-stop", daemon=True).start()
@@ -321,14 +321,13 @@ def _run_tray():
     image = Image.open(icon_path) if os.path.exists(icon_path) else None
     icon = pystray.Icon("AudioMuse-AI", icon=image, title="AudioMuse-AI", menu=menu)
 
-    def _boot():
-        try:
-            supervisor.start_all()
-            _open_browser(WEB_URL)
-        except Exception as exc:
-            print(f"Startup failed: {exc}", file=sys.stderr)
+    def _on_ready():
+        _open_browser(WEB_URL)
 
-    threading.Thread(target=_boot, name="boot", daemon=True).start()
+    def _on_error(exc):
+        print(f"Startup failed: {exc}", file=sys.stderr)
+
+    supervisor.start_in_background(on_ready=_on_ready, on_error=_on_error)
     try:
         icon.run()
     finally:

--- a/native-build/windows/supervisor.py
+++ b/native-build/windows/supervisor.py
@@ -152,11 +152,14 @@ class ProcessSupervisor:
     def _join_workers(self):
         """Wait for the boot and health threads to finish before teardown.
 
-        Skips the current thread so stop_all() called from within start_all()'s
-        failure handler (boot thread) never deadlocks on itself."""
+        Skips the current thread (so a stop from start_all's failure handler
+        never self-joins) and the main thread: in console `start` mode the boot
+        runs ON the main thread, which then parks forever, so joining it would
+        stall teardown until process exit and orphan the children."""
         current = threading.current_thread()
+        main = threading.main_thread()
         for thread in (self._boot_thread, self._health_thread):
-            if thread is not None and thread is not current and thread.is_alive():
+            if thread is not None and thread is not current and thread is not main and thread.is_alive():
                 thread.join(timeout=30)
 
     def start_child(self, name):
@@ -321,6 +324,10 @@ class ProcessSupervisor:
         raise RuntimeError(f"Timed out waiting for {url}")
 
     def _start_health_loop(self):
+        # Clear the stop event so a restart (stop_all sets it) gets a live loop;
+        # without this the new health thread sees a set event and exits at once.
+        self._health_stop.clear()
+
         def _loop():
             while not self._health_stop.is_set():
                 self._health_stop.wait(30)

--- a/native-build/windows/supervisor.py
+++ b/native-build/windows/supervisor.py
@@ -268,9 +268,8 @@ class ProcessSupervisor:
                         self.start_child(svc)
                 elif action == "stop":
                     self._stop_child(svc)
-                elif action == "start":
-                    if svc not in self._children:
-                        self.start_child(svc)
+                elif action == "start" and svc not in self._children:
+                    self.start_child(svc)
             except Exception:
                 self._log.exception("Control %s failed for %s", action, svc)
 

--- a/native-build/windows/supervisor.py
+++ b/native-build/windows/supervisor.py
@@ -87,16 +87,30 @@ class ProcessSupervisor:
     def state(self):
         return self._state
 
+    def start_in_background(self, on_ready=None, on_error=None):
+        """Boot on a daemon thread the supervisor owns, recording it BEFORE the
+        thread runs so a stop racing the boot can join it (and thus tear down
+        every child it spawned) instead of missing a thread that recorded itself
+        too late and leaking the late children as orphans."""
+        def _boot():
+            try:
+                self.start_all()
+            except Exception as exc:
+                if on_error is not None:
+                    on_error(exc)
+                return
+            if on_ready is not None and self.is_running():
+                on_ready()
+        self._boot_thread = threading.Thread(target=_boot, name="boot", daemon=True)
+        self._boot_thread.start()
+        return self._boot_thread
+
     def start_all(self):
         with self._lock:
             if self._state in ("running", "starting"):
                 return
             self._state = "starting"
             self._stop_requested.clear()
-            # Record the boot thread so stop_all can join it before the teardown
-            # sweep: a stop racing a boot would otherwise sweep _children while
-            # this thread is still spawning, leaking the late children as orphans.
-            self._boot_thread = threading.current_thread()
         self._log.info("=== AudioMuse-AI starting ===")
         try:
             self._reap_orphans()
@@ -231,23 +245,34 @@ class ProcessSupervisor:
                 self._log.exception("Failed to restart %s", name)
 
     def dispatch_control(self, action, services):
-        """Handle a restart/stop/start request from the web UI."""
-        if action == "restart":
-            for svc in services:
-                if svc in self._children:
+        """Apply a restart/stop/start request from the web UI.
+
+        Runs the work on a daemon thread and acknowledges immediately:
+        restarting several busy workers serially (each up to 15s to stop) can
+        outlast the control socket's 15s timeout, which would make the UI report
+        a failure for a restart that actually succeeds."""
+        if action not in ("restart", "stop", "start"):
+            return False
+        threading.Thread(
+            target=self._apply_control, args=(action, list(services)),
+            name=f"control-{action}", daemon=True,
+        ).start()
+        return True
+
+    def _apply_control(self, action, services):
+        for svc in services:
+            try:
+                if action == "restart":
+                    if svc in self._children:
+                        self._stop_child(svc)
+                        self.start_child(svc)
+                elif action == "stop":
                     self._stop_child(svc)
-                    self.start_child(svc)
-            return True
-        elif action == "stop":
-            for svc in services:
-                self._stop_child(svc)
-            return True
-        elif action == "start":
-            for svc in services:
-                if svc not in self._children:
-                    self.start_child(svc)
-            return True
-        return False
+                elif action == "start":
+                    if svc not in self._children:
+                        self.start_child(svc)
+            except Exception:
+                self._log.exception("Control %s failed for %s", action, svc)
 
     # --- embedded Redis ---
 
@@ -339,16 +364,35 @@ class ProcessSupervisor:
         self._health_thread.start()
 
     def _reap_orphans(self):
-        """Kill leftover Postgres/Redis processes from a previous unclean shutdown."""
-        import psutil
-        for proc in psutil.process_iter(["name"]):
+        """Kill leftover embedded Postgres/Redis from a previous unclean run.
+
+        Match by *our* data dirs in the cmdline, not by bare process name -- a
+        name-only match would also kill an unrelated PostgreSQL/Redis the user
+        runs on the same machine."""
+        try:
+            import psutil
+        except Exception:
+            return
+        me = os.getpid()
+        redis_marker = paths.redis_dir().lower()
+        pg_marker = paths.pgdata_dir().lower()
+        for proc in psutil.process_iter(["pid", "name", "cmdline"]):
             try:
-                name = proc.info.get("name", "").lower()
-                if name in ("redis-server.exe", "postgres.exe", "pg_ctl.exe"):
-                    self._log.info("Reaping orphan: %s (pid=%d)", proc.info["name"], proc.pid)
-                    proc.kill()
+                if proc.info["pid"] == me:
+                    continue
+                cmd = " ".join(proc.info.get("cmdline") or []).lower()
+                if not cmd:
+                    continue
+                stale_redis = "redis-server" in cmd and redis_marker in cmd
+                stale_pg = ("postgres" in cmd or "pg_ctl" in cmd) and pg_marker in cmd
+                if stale_redis or stale_pg:
+                    self._log.info("Reaping orphan %s (pid=%d) referencing our data dir",
+                                   proc.info.get("name"), proc.info["pid"])
+                    proc.terminate()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
             except Exception:
-                pass
+                continue
 
     def _write_pidfile(self):
         pids = {name: proc.pid for name, proc in self._children.items()}

--- a/native-build/windows/supervisor.py
+++ b/native-build/windows/supervisor.py
@@ -93,6 +93,10 @@ class ProcessSupervisor:
                 return
             self._state = "starting"
             self._stop_requested.clear()
+            # Record the boot thread so stop_all can join it before the teardown
+            # sweep: a stop racing a boot would otherwise sweep _children while
+            # this thread is still spawning, leaking the late children as orphans.
+            self._boot_thread = threading.current_thread()
         self._log.info("=== AudioMuse-AI starting ===")
         try:
             self._reap_orphans()
@@ -101,14 +105,20 @@ class ProcessSupervisor:
                 return
             self._db_conn = db_backend.start_embedded(paths.pgdata_dir())
             self._log.info("Embedded PostgreSQL ready")
+            if self._stop_requested.is_set():
+                return
             self._start_redis()
             self._log.info("Embedded Redis ready")
             for name in BOOT_ORDER:
+                if self._stop_requested.is_set():
+                    return
                 self.start_child(name)
                 if name == "flask":
                     self._wait_http(FLASK_URL, timeout=180)
             self._write_pidfile()
             with self._lock:
+                if self._stop_requested.is_set():
+                    return
                 self._state = "running"
             self._start_health_loop()
             self._log.info("=== AudioMuse-AI running ===")
@@ -125,6 +135,9 @@ class ProcessSupervisor:
                 return
             self._state = "stopping"
         self._log.info("=== AudioMuse-AI stopping ===")
+        # Wait for any in-flight boot/health work to stop spawning before we
+        # sweep: a child spawned after the sweep would survive as an orphan.
+        self._join_workers()
         self._control.stop()
         for name in list(self._children.keys()):
             self._stop_child(name)
@@ -136,8 +149,27 @@ class ProcessSupervisor:
             self._state = "stopped"
         self._log.info("=== AudioMuse-AI stopped ===")
 
+    def _join_workers(self):
+        """Wait for the boot and health threads to finish before teardown.
+
+        Skips the current thread so stop_all() called from within start_all()'s
+        failure handler (boot thread) never deadlocks on itself."""
+        current = threading.current_thread()
+        for thread in (self._boot_thread, self._health_thread):
+            if thread is not None and thread is not current and thread.is_alive():
+                thread.join(timeout=30)
+
     def start_child(self, name):
-        role = ROLE_OF[name]
+        role = ROLE_OF.get(name)
+        if role is None:
+            return False
+        with self._lock:
+            # Refuse to spawn once a stop is in progress -- otherwise the boot
+            # loop, the restart pump, or a control request could create a child
+            # after stop_all's teardown sweep, leaking it as an orphan.
+            if self._state not in ("starting", "running"):
+                return False
+            self._desired.add(name)
         self._log.info("Starting %s (role=%s)", name, role)
         db_conn = db_backend.ensure_embedded_running(paths.pgdata_dir())
         redis_url = self._ensure_redis_running()
@@ -152,15 +184,18 @@ class ProcessSupervisor:
             stdin=subprocess.DEVNULL,
             creationflags=subprocess.CREATE_NEW_PROCESS_GROUP if sys.platform == "win32" else 0,
             text=True,
+            encoding="utf-8",
+            errors="replace",
         )
         with self._lock:
             self._children[name] = popen
-            self._desired.add(name)
         threading.Thread(target=self._pump, args=(name, popen), name=f"pump-{name}", daemon=True).start()
+        return True
 
     def _stop_child(self, name):
-        popen = self._children.pop(name, None)
-        self._desired.discard(name)
+        with self._lock:
+            popen = self._children.pop(name, None)
+            self._desired.discard(name)
         if popen is None:
             return
         self._log.info("Stopping %s (pid=%d)", name, popen.pid)
@@ -181,8 +216,11 @@ class ProcessSupervisor:
             self._log.info("[%s] %s", name, line.rstrip())
         popen.wait()
         with self._lock:
+            if self._children.get(name) is not popen:
+                return
             self._children.pop(name, None)
-        if name in self._desired and self._state == "running":
+            restart = name in self._desired and self._state == "running"
+        if restart:
             self._log.warning("%s exited unexpectedly -- restarting", name)
             try:
                 self.start_child(name)

--- a/proxy_prefix.py
+++ b/proxy_prefix.py
@@ -1,0 +1,35 @@
+"""WSGI middleware that collapses a duplicated reverse-proxy subpath prefix.
+
+When AudioMuse-AI is served under a subpath (e.g. ``/audiomuseai``) the proxy
+is expected to STRIP that prefix before forwarding (nginx ``location
+/audiomuseai/ { proxy_pass http://upstream/; }`` with both trailing slashes)
+while announcing it via ``X-Forwarded-Prefix``. ProxyFix then puts the prefix
+in ``SCRIPT_NAME`` and ``PATH_INFO`` holds the real route (``/setup``).
+
+A very common misconfiguration forwards the FULL path (``proxy_pass`` without a
+trailing slash, or a regex ``location``) *and still* sends
+``X-Forwarded-Prefix``. The prefix is then counted twice: it lands in
+``SCRIPT_NAME`` (via ProxyFix) while ``PATH_INFO`` also keeps it
+(``/audiomuseai/setup``). Every absolute-path check and ``url_for()`` redirect
+then carries a doubled prefix, producing an infinite redirect loop to
+``/<prefix>/setup`` (issue #668).
+
+This middleware removes a leading ``SCRIPT_NAME`` from ``PATH_INFO`` so the
+duplication collapses to the single, correct form. It must run AFTER ProxyFix
+(i.e. be wrapped as the inner app: ``ProxyFix(StripDuplicatedScriptName(app))``)
+so ``SCRIPT_NAME`` is already populated. It is a no-op for correctly configured
+proxies (``PATH_INFO`` does not start with the prefix) and when no prefix is set.
+"""
+
+
+class StripDuplicatedScriptName:
+    def __init__(self, app):
+        self.app = app
+
+    def __call__(self, environ, start_response):
+        prefix = environ.get('SCRIPT_NAME', '').rstrip('/')
+        if prefix:
+            path_info = environ.get('PATH_INFO', '')
+            if path_info == prefix or path_info.startswith(prefix + '/'):
+                environ['PATH_INFO'] = path_info[len(prefix):] or '/'
+        return self.app(environ, start_response)

--- a/query/brainstorm_real_gmm_080.py
+++ b/query/brainstorm_real_gmm_080.py
@@ -151,7 +151,8 @@ def fit_gmm_bic(X, k_range=GMM_K_RANGE):
     best_k = -1
     bic_values = {}
 
-    for k in k_range:
+    max_k = min(k_range.stop - 1, len(X))
+    for k in range(k_range.start, max_k + 1):
         gmm = GaussianMixture(n_components=k, covariance_type='diag',
                                n_init=3, max_iter=300, reg_covar=1e-5,
                                random_state=42)

--- a/restart_listener.py
+++ b/restart_listener.py
@@ -17,6 +17,8 @@ def main():
     logger.info('Starting restart listener on channel: %s', channel)
 
     while True:
+        redis_conn = None
+        pubsub = None
         try:
             redis_conn = Redis.from_url(
                 redis_url,
@@ -62,6 +64,17 @@ def main():
         except Exception:
             logger.exception('Restart listener connection error, retrying in 5 seconds')
             time.sleep(5)
+        finally:
+            try:
+                if pubsub is not None:
+                    pubsub.close()
+            except Exception:
+                pass
+            try:
+                if redis_conn is not None:
+                    redis_conn.close()
+            except Exception:
+                pass
 
 
 if __name__ == '__main__':

--- a/restart_manager.py
+++ b/restart_manager.py
@@ -95,7 +95,7 @@ def _run_supervisorctl(arguments):
         return _send_control(arguments)
     cmd = [SUPERVISORCTL_CMD, '-c', SUPERVISOR_CONF] + arguments
     try:
-        result = subprocess.run(cmd, capture_output=True, text=True)
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         stdout = result.stdout.strip()
         stderr = result.stderr.strip()
         if result.returncode != 0:
@@ -105,6 +105,9 @@ def _run_supervisorctl(arguments):
         return True
     except FileNotFoundError:
         logger.exception('supervisorctl command not found at %s', SUPERVISORCTL_CMD)
+        return False
+    except subprocess.TimeoutExpired:
+        logger.error('supervisorctl timed out after 30s: %s', cmd)
         return False
     except Exception:
         logger.exception('Failed to run supervisorctl command: %s', cmd)
@@ -181,4 +184,4 @@ def restart_supervisor_workers():
         return True
 
     logger.info('Restarting supervised worker programs via supervisorctl')
-    return _run_supervisorctl(['restart', 'rq-worker-default', 'rq-worker-high', 'rq-janitor'])
+    return _run_supervisorctl(['restart'] + WORKER_SERVICES)

--- a/rq_worker.py
+++ b/rq_worker.py
@@ -30,7 +30,7 @@ WorkerClass = SimpleWorker if sys.platform == 'win32' else Worker
 try:
     from app_helper import redis_conn
     from app_logging import configure_logging
-    from config import APP_VERSION, TEMP_DIR
+    from config import APP_VERSION, TEMP_DIR, RQ_MAX_JOBS, RQ_LOGGING_LEVEL
 except ImportError as e:
     print(f"Error importing worker dependencies: {e}")
     sys.exit(1)
@@ -44,8 +44,7 @@ except OSError as e:
 configure_logging()
 logger = logging.getLogger(__name__)
 
-# The queues the worker will listen on.
-# The order is important! Workers will always check 'high' before 'default'.
+# This worker ONLY listens to the 'default' queue; the 'high' queue is served by rq_worker_high_priority.py.
 queues_to_listen = ['default']
 
 # NOTE: Do NOT preload Whisper / gte / silero ONNX sessions here in
@@ -81,12 +80,12 @@ if __name__ == '__main__':
     # Memory leak prevention: restart after N jobs
     # RQ will automatically respawn via supervisord
     # Balance: High enough to avoid frequent CLAP reloads, low enough to prevent memory leaks
-    max_jobs_before_restart = int(os.getenv('RQ_MAX_JOBS', '50'))
+    max_jobs_before_restart = RQ_MAX_JOBS
 
     # Start the worker.
     # You can set logging_level for more verbose output.
     # Common levels: DEBUG, INFO, WARNING, ERROR, CRITICAL
-    logging_level = os.getenv("RQ_LOGGING_LEVEL", "INFO").upper()
+    logging_level = RQ_LOGGING_LEVEL
     logger.info(f"RQ Worker logging level set to: {logging_level}")
     logger.info(f"Worker will restart after {max_jobs_before_restart} jobs to prevent memory leaks")
 

--- a/rq_worker_high_priority.py
+++ b/rq_worker_high_priority.py
@@ -28,7 +28,7 @@ WorkerClass = SimpleWorker if sys.platform == 'win32' else Worker
 try:
     from app_helper import redis_conn
     from app_logging import configure_logging
-    from config import APP_VERSION
+    from config import APP_VERSION, RQ_MAX_JOBS_HIGH, RQ_LOGGING_LEVEL
 except ImportError as e:
     print(f"Error importing from app.py: {e}")
     print("Please ensure app.py is in the Python path and does not have top-level errors.")
@@ -61,9 +61,9 @@ if __name__ == '__main__':
 
     # Memory leak prevention: restart after N jobs
     # Higher than default worker since this doesn't load CLAP model
-    max_jobs_before_restart = int(os.getenv('RQ_MAX_JOBS_HIGH', '100'))
+    max_jobs_before_restart = RQ_MAX_JOBS_HIGH
 
-    logging_level = os.getenv("RQ_LOGGING_LEVEL", "INFO").upper()
+    logging_level = RQ_LOGGING_LEVEL
     logger.info(f"RQ Worker logging level set to: {logging_level}")
     logger.info(f"Worker will restart after {max_jobs_before_restart} jobs to prevent memory leaks")
 

--- a/static/script.js
+++ b/static/script.js
@@ -514,7 +514,7 @@ function showMessageBox(title, message) {
     const messageBox = document.createElement('div');
     messageBox.id = boxId;
     messageBox.style.cssText = 'position: fixed; top: 20px; right: 20px; background-color: #fff; color: #1F2937; padding: 20px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 1000; border: 1px solid #E5E7EB; max-width: 400px; text-align: left;';
-    messageBox.innerHTML = `<h3 style="font-weight: 600; margin-top:0; margin-bottom: 10px; color: #111827;">${title}</h3><p style="margin:0;">${message}</p><button style="position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: #9CA3AF; cursor: pointer;" onclick="this.parentNode.remove()">&times;</button>`;
+    messageBox.innerHTML = `<h3 style="font-weight: 600; margin-top:0; margin-bottom: 10px; color: #111827;">${escapeHtml(title)}</h3><p style="margin:0;">${escapeHtml(message)}</p><button style="position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: #9CA3AF; cursor: pointer;" onclick="this.parentNode.remove()">&times;</button>`;
     
     setTimeout(() => {
         messageBox.remove();

--- a/static/setup.js
+++ b/static/setup.js
@@ -1026,7 +1026,7 @@ setupForm.addEventListener('submit', function(event) {
                 saveFeedback.textContent = 'Configuration saved. Redirecting in ' + countdown + ' seconds...';
             } else {
                 clearInterval(countdownInterval);
-                window.location.href = '/';
+                if (window.appRedirect) { window.appRedirect('/'); } else { window.location.href = '/'; }
             }
         }, 1000);
     }).catch(function(err) {
@@ -1048,6 +1048,25 @@ document.getElementById('test-button').addEventListener('click', testConnection)
 serverConfigFields.addEventListener('input', updateTestButtonState);
 document.getElementById('MEDIASERVER_TYPE').addEventListener('change', updateServerFields);
 document.getElementById('AUTH_ENABLED').addEventListener('change', updateAuthVisibility);
+
+// Advisory-only admin password length recommendation (never blocks saving).
+var RECOMMENDED_ADMIN_PASSWORD_LENGTH = 15;
+function updateAdminPasswordHint() {
+    var input = document.getElementById('AUDIOMUSE_PASSWORD');
+    var hint = document.getElementById('admin-password-hint');
+    if (!input || !hint) { return; }
+    var value = input.value;
+    if (value && value !== '********' && value.length < RECOMMENDED_ADMIN_PASSWORD_LENGTH) {
+        hint.textContent = 'For better security we recommend at least ' + RECOMMENDED_ADMIN_PASSWORD_LENGTH + ' characters. You can still save a shorter password.';
+        hint.style.display = 'block';
+    } else {
+        hint.style.display = 'none';
+    }
+}
+var adminPasswordInput = document.getElementById('AUDIOMUSE_PASSWORD');
+if (adminPasswordInput) {
+    adminPasswordInput.addEventListener('input', updateAdminPasswordHint);
+}
 
 var advancedExpandAll = document.getElementById('advanced-expand-all');
 if (advancedExpandAll) {

--- a/static/setup.js
+++ b/static/setup.js
@@ -1050,12 +1050,12 @@ document.getElementById('MEDIASERVER_TYPE').addEventListener('change', updateSer
 document.getElementById('AUTH_ENABLED').addEventListener('change', updateAuthVisibility);
 
 // Advisory-only admin password length recommendation (never blocks saving).
-var RECOMMENDED_ADMIN_PASSWORD_LENGTH = 15;
+const RECOMMENDED_ADMIN_PASSWORD_LENGTH = 15;
 function updateAdminPasswordHint() {
-    var input = document.getElementById('AUDIOMUSE_PASSWORD');
-    var hint = document.getElementById('admin-password-hint');
+    const input = document.getElementById('AUDIOMUSE_PASSWORD');
+    const hint = document.getElementById('admin-password-hint');
     if (!input || !hint) { return; }
-    var value = input.value;
+    const value = input.value;
     if (value && value !== '********' && value.length < RECOMMENDED_ADMIN_PASSWORD_LENGTH) {
         hint.textContent = 'For better security we recommend at least ' + RECOMMENDED_ADMIN_PASSWORD_LENGTH + ' characters. You can still save a shorter password.';
         hint.style.display = 'block';
@@ -1063,7 +1063,7 @@ function updateAdminPasswordHint() {
         hint.style.display = 'none';
     }
 }
-var adminPasswordInput = document.getElementById('AUDIOMUSE_PASSWORD');
+const adminPasswordInput = document.getElementById('AUDIOMUSE_PASSWORD');
 if (adminPasswordInput) {
     adminPasswordInput.addEventListener('input', updateAdminPasswordHint);
 }

--- a/tasks/ai/providers/mistral.py
+++ b/tasks/ai/providers/mistral.py
@@ -5,6 +5,8 @@ import os
 import time
 from typing import Dict, List, Optional
 
+import config
+
 logger = logging.getLogger(__name__)
 
 try:
@@ -61,7 +63,7 @@ def generate_text(
         complete_kwargs = {
             "model": model_name,
             "temperature": 0.9 if temperature is None else float(temperature),
-            "timeout_ms": 960,
+            "timeout_ms": config.AI_REQUEST_TIMEOUT_SECONDS * 1000,
             "messages": [{"role": "user", "content": full_prompt}],
         }
         if max_tokens is not None:

--- a/tasks/ai/providers/openai.py
+++ b/tasks/ai/providers/openai.py
@@ -383,7 +383,7 @@ def call_with_tools(
         timeout = config.AI_REQUEST_TIMEOUT_SECONDS
         logger.warning(f"OpenAI request timed out after {timeout} seconds")
         log_messages.append(
-            f"\u23f1\ufe0f Request timed out after {timeout} seconds. Consider increasing AI_REQUEST_TIMEOUT_SECONDS environment variable."
+            f"Request timed out after {timeout} seconds. Consider increasing AI_REQUEST_TIMEOUT_SECONDS environment variable."
         )
         return {
             "error": f"Request timed out after {timeout} seconds. Increase AI_REQUEST_TIMEOUT_SECONDS for slower hardware or larger models."
@@ -391,7 +391,7 @@ def call_with_tools(
     except httpx.TimeoutException:
         timeout = config.AI_REQUEST_TIMEOUT_SECONDS
         logger.warning("OpenAI request timed out", exc_info=True)
-        log_messages.append(f"\u23f1\ufe0f Request timed out after {timeout} seconds.")
+        log_messages.append(f"Request timed out after {timeout} seconds.")
         return {
             "error": f"Request timed out after {timeout} seconds. Increase AI_REQUEST_TIMEOUT_SECONDS for slower hardware or larger models."
         }
@@ -475,7 +475,7 @@ def call_with_tools_ollama(
 
             if cleaned.startswith("{") and '"type"' in cleaned and '"array"' in cleaned:
                 log_messages.append(
-                    "\u26a0\ufe0f Ollama returned schema instead of tool calls, using fallback"
+                    "WARN: Ollama returned schema instead of tool calls, using fallback"
                 )
                 return {"error": "Ollama returned schema definition instead of tool calls"}
 
@@ -485,24 +485,24 @@ def call_with_tools_ollama(
             if isinstance(parsed, dict) and "tool_calls" in parsed:
                 tool_calls = parsed["tool_calls"]
                 log_messages.append(
-                    f"\u2713 Extracted tool_calls array with {len(tool_calls) if isinstance(tool_calls, list) else 1} items"
+                    f"OK: Extracted tool_calls array with {len(tool_calls) if isinstance(tool_calls, list) else 1} items"
                 )
             elif isinstance(parsed, list):
                 tool_calls = parsed
-                log_messages.append("\u26a0\ufe0f Got array directly (expected object with tool_calls field)")
+                log_messages.append("WARN: Got array directly (expected object with tool_calls field)")
             elif isinstance(parsed, dict) and "name" in parsed:
                 tool_calls = [parsed]
                 log_messages.append(
-                    "\u26a0\ufe0f Got single tool call object (expected object with tool_calls array)"
+                    "WARN: Got single tool call object (expected object with tool_calls array)"
                 )
             elif isinstance(parsed, dict) and "tool" in parsed and "arguments" in parsed:
                 tool_calls = [{"name": parsed["tool"], "arguments": parsed["arguments"]}]
                 log_messages.append(
-                    "\u26a0\ufe0f Remapped {'tool','arguments'} -> {'name','arguments'} format"
+                    "WARN: Remapped {'tool','arguments'} -> {'name','arguments'} format"
                 )
             else:
                 log_messages.append(
-                    f"\u26a0\ufe0f Unexpected JSON structure: {type(parsed)}, keys: {list(parsed.keys()) if isinstance(parsed, dict) else 'N/A'}"
+                    f"WARN: Unexpected JSON structure: {type(parsed)}, keys: {list(parsed.keys()) if isinstance(parsed, dict) else 'N/A'}"
                 )
                 return {"error": "Ollama response missing 'tool_calls' field"}
 
@@ -528,22 +528,22 @@ def call_with_tools_ollama(
                             keys_to_remove.append(k)
                     for k in keys_to_remove:
                         log_messages.append(
-                            f"   \U0001f9f9 Stripped empty/default arg '{k}={args[k]}' from {tc['name']}"
+                            f"   Stripped empty/default arg '{k}={args[k]}' from {tc['name']}"
                         )
                         del args[k]
                     valid_calls.append(tc)
                 else:
-                    log_messages.append(f"\u26a0\ufe0f Skipping invalid tool call: {tc}")
+                    log_messages.append(f"WARN: Skipping invalid tool call: {tc}")
 
             if not valid_calls:
                 return {"error": "No valid tool calls found in Ollama response"}
 
-            log_messages.append(f"\u2705 Ollama returned {len(valid_calls)} valid tool calls")
+            log_messages.append(f"OK: Ollama returned {len(valid_calls)} valid tool calls")
             return {"tool_calls": valid_calls}
 
         except json.JSONDecodeError:
             logger.exception("JSON decode error while parsing Ollama tool response")
-            log_messages.append("\u274c Failed to parse Ollama JSON response.")
+            log_messages.append("X: Failed to parse Ollama JSON response.")
             log_messages.append(f"Attempted to parse: {cleaned[:300]}")
             return {
                 "error": "Failed to parse Ollama JSON response.",
@@ -559,10 +559,10 @@ def call_with_tools_ollama(
         timeout = config.AI_REQUEST_TIMEOUT_SECONDS
         logger.warning(f"Ollama request timed out after {timeout} seconds")
         log_messages.append(
-            f"\u23f1\ufe0f Ollama request timed out after {timeout} seconds. Your model or hardware may be too slow."
+            f"Ollama request timed out after {timeout} seconds. Your model or hardware may be too slow."
         )
         log_messages.append(
-            "\U0001f4a1 Solution: Set AI_REQUEST_TIMEOUT_SECONDS environment variable to a higher value (e.g., 600 for 10 minutes)"
+            "TIP: Set AI_REQUEST_TIMEOUT_SECONDS environment variable to a higher value (e.g., 600 for 10 minutes)"
         )
         return {
             "error": f"Ollama timed out after {timeout} seconds. Increase AI_REQUEST_TIMEOUT_SECONDS for slower hardware or larger models."
@@ -570,9 +570,9 @@ def call_with_tools_ollama(
     except httpx.TimeoutException:
         timeout = config.AI_REQUEST_TIMEOUT_SECONDS
         logger.warning("Ollama request timed out", exc_info=True)
-        log_messages.append(f"\u23f1\ufe0f Ollama request timed out after {timeout} seconds.")
+        log_messages.append(f"Ollama request timed out after {timeout} seconds.")
         log_messages.append(
-            "\U0001f4a1 Solution: Set AI_REQUEST_TIMEOUT_SECONDS environment variable to a higher value"
+            "TIP: Set AI_REQUEST_TIMEOUT_SECONDS environment variable to a higher value"
         )
         return {
             "error": f"Ollama timed out after {timeout} seconds. Increase AI_REQUEST_TIMEOUT_SECONDS for slower hardware or larger models."

--- a/tasks/ai/tool_impl.py
+++ b/tasks/ai/tool_impl.py
@@ -68,7 +68,7 @@ def _reroute_other_feature_labels(genres, moods, other_features):
         parts.append(f"from genres: {', '.join(rerouted_from_genres)}")
     if rerouted_from_moods:
         parts.append(f"from moods: {', '.join(rerouted_from_moods)}")
-    msg = "\u26a0\ufe0f Rerouted to other_features (" + "; ".join(parts) + ")"
+    msg = "WARN: Rerouted to other_features (" + "; ".join(parts) + ")"
     return new_genres, new_moods, new_other, msg
 
 
@@ -93,7 +93,7 @@ def _reroute_mood_labels_from_genres(genres, moods):
         if canonical not in existing_lower:
             new_moods.append(canonical)
             existing_lower.add(canonical)
-    msg = f"\u26a0\ufe0f Rerouted from genres to moods (not real genres): {', '.join(rerouted)}"
+    msg = f"WARN: Rerouted from genres to moods (not real genres): {', '.join(rerouted)}"
     return kept, new_moods, msg
 
 

--- a/tasks/analysis.py
+++ b/tasks/analysis.py
@@ -251,7 +251,7 @@ def robust_load_audio_with_fallback(file_path, target_sr=16000):
 
 def rebuild_all_indexes_task():
     """Rebuild all indexes as a standalone RQ task (enqueued on default queue)."""
-    logger.info("🔨 Starting index rebuild task (enqueued as subtask)...")
+    logger.info("Starting index rebuild task (enqueued as subtask)...")
     with app.app_context():
         try:
             _run_all_index_builds()
@@ -691,11 +691,11 @@ def run_analysis_task(num_recent_albums, top_n_moods):
             save_task_status(current_task_id, "main_analysis", task_state, progress=progress, details=details)
 
         try:
-            log_and_update_main("🚀 Starting main analysis process...", 0)
+            log_and_update_main("Starting main analysis process...", 0)
             clean_temp(TEMP_DIR)
             all_albums = get_recent_albums(num_recent_albums)
             if not all_albums:
-                log_and_update_main("⚠️ No new albums to analyze.", 100, albums_found=0, task_state=TASK_STATUS_SUCCESS)
+                log_and_update_main("No new albums to analyze.", 100, albums_found=0, task_state=TASK_STATUS_SUCCESS)
                 return {"status": "SUCCESS", "message": "No new albums to analyze."}
 
             total_albums_to_check = len(all_albums)

--- a/tasks/clap_text_search.py
+++ b/tasks/clap_text_search.py
@@ -377,7 +377,7 @@ def ensure_text_search_queries_table():
     Called automatically at startup.
     """
     from app_helper import get_db
-    
+    conn = None
     try:
         conn = get_db()
         with conn.cursor() as cur:

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -63,31 +63,31 @@ def identify_and_clean_orphaned_albums_task():
             save_task_status(current_task_id, "cleaning", task_state, progress=progress, details=details)
 
         try:
-            log_and_update_main("🔍 Starting orphaned album identification...", 5)
+            log_and_update_main("Starting orphaned album identification...", 5)
             
             # Step 1: Get all albums from media server (fetch all albums with limit=0)
-            log_and_update_main("📡 Fetching all albums from media server...", 10)
+            log_and_update_main("Fetching all albums from media server...", 10)
             all_media_server_albums = get_recent_albums(0)  # 0 means fetch all albums
             
             if not all_media_server_albums:
-                log_and_update_main("⚠️ No albums found on media server.", 95, task_state=TASK_STATUS_PROGRESS)
-                log_and_update_main(f"🔄 Rebuilding all indexes and maps...", 96)
+                log_and_update_main("No albums found on media server.", 95, task_state=TASK_STATUS_PROGRESS)
+                log_and_update_main(f"Rebuilding all indexes and maps...", 96)
                 try:
                     from .analysis import _run_all_index_builds
                     _run_all_index_builds(log_fn=None)
                     log_and_update_main(f"✅ All indexes and maps rebuilt successfully.", 99)
                 except Exception as e:
                     logger.warning(f"Failed to rebuild indexes and maps: {e}")
-                    log_and_update_main(f"⚠️ Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
-                
+                    log_and_update_main(f"Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
+
                 summary = {"status": "SUCCESS", "message": "No albums found on media server.", "orphaned_albums": [], "deleted_count": 0}
                 log_and_update_main("✅ Database cleaning completed - no albums on media server!", 100, task_state=TASK_STATUS_SUCCESS, final_summary_details=summary)
                 return summary
             
-            log_and_update_main(f"📊 Found {len(all_media_server_albums)} albums on media server", 20)
+            log_and_update_main(f"Found {len(all_media_server_albums)} albums on media server", 20)
             
             # Step 2: Get all track IDs that exist on the media server
-            log_and_update_main("🎵 Collecting all track IDs from media server...", 25)
+            log_and_update_main("Collecting all track IDs from media server...", 25)
             media_server_track_ids = set()
             albums_processed = 0
             
@@ -102,16 +102,16 @@ def identify_and_clean_orphaned_albums_task():
                     # Update progress every 10 albums
                     if idx % 10 == 0:
                         progress = 25 + int(50 * (idx / float(len(all_media_server_albums))))
-                        log_and_update_main(f"📝 Processed {albums_processed}/{len(all_media_server_albums)} albums...", progress)
+                        log_and_update_main(f"Processed {albums_processed}/{len(all_media_server_albums)} albums...", progress)
                         
                 except Exception as e:
                     logger.warning(f"Failed to get tracks for album {album.get('Name', 'Unknown')}: {e}")
                     continue
             
-            log_and_update_main(f"🎯 Found {len(media_server_track_ids)} total tracks on media server", 75)
+            log_and_update_main(f"Found {len(media_server_track_ids)} total tracks on media server", 75)
             
             # Step 3: Get all track IDs from database
-            log_and_update_main("🗄️ Fetching all track IDs from database...", 80)
+            log_and_update_main("Fetching all track IDs from database...", 80)
             with get_db() as conn, conn.cursor() as cur:
                 cur.execute("""
                     SELECT DISTINCT s.item_id, s.title, s.author 
@@ -121,11 +121,11 @@ def identify_and_clean_orphaned_albums_task():
                 database_tracks = cur.fetchall()
             
             database_track_ids = {row[0] for row in database_tracks}
-            log_and_update_main(f"📚 Found {len(database_track_ids)} tracks in database", 85)
+            log_and_update_main(f"Found {len(database_track_ids)} tracks in database", 85)
             
             # Step 4: Identify orphaned tracks (in database but not on media server)
             orphaned_track_ids = database_track_ids - media_server_track_ids
-            log_and_update_main(f"🧹 Identified {len(orphaned_track_ids)} orphaned tracks", 90)
+            log_and_update_main(f"Identified {len(orphaned_track_ids)} orphaned tracks", 90)
             
             # Step 5: Group orphaned tracks by artist/album for better presentation
             orphaned_albums_info = defaultdict(lambda: {"tracks": [], "track_count": 0})
@@ -158,7 +158,7 @@ def identify_and_clean_orphaned_albums_task():
             safety_limit_applied = False
             if total_orphaned_albums > CLEANING_SAFETY_LIMIT:
                 safety_limit_applied = True
-                log_and_update_main(f"⚠️ Safety limit: Found {total_orphaned_albums} orphaned albums, limiting to first {CLEANING_SAFETY_LIMIT} for safety", 92)
+                log_and_update_main(f"Safety limit: Found {total_orphaned_albums} orphaned albums, limiting to first {CLEANING_SAFETY_LIMIT} for safety", 92)
                 # Keep only first CLEANING_SAFETY_LIMIT albums
                 orphaned_albums_list = orphaned_albums_list[:CLEANING_SAFETY_LIMIT]
                 # Recalculate track IDs for limited albums
@@ -170,14 +170,14 @@ def identify_and_clean_orphaned_albums_task():
             
             if len(orphaned_track_ids) == 0:
                 log_and_update_main("✅ No orphaned tracks found. Database is clean!", 95, task_state=TASK_STATUS_PROGRESS)
-                log_and_update_main(f"🔄 Rebuilding all indexes and maps...", 96)
+                log_and_update_main(f"Rebuilding all indexes and maps...", 96)
                 try:
                     from .analysis import _run_all_index_builds
                     _run_all_index_builds(log_fn=None)
                     log_and_update_main(f"✅ All indexes and maps rebuilt successfully.", 99)
                 except Exception as e:
                     logger.warning(f"Failed to rebuild indexes and maps: {e}")
-                    log_and_update_main(f"⚠️ Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
+                    log_and_update_main(f"Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
                 
                 summary = {
                     "total_media_server_albums": len(all_media_server_albums),
@@ -195,7 +195,7 @@ def identify_and_clean_orphaned_albums_task():
                     **summary
                 }
             
-            log_and_update_main(f"🧹 Starting automatic deletion of {len(orphaned_track_ids)} orphaned tracks...", 93)
+            log_and_update_main(f"Starting automatic deletion of {len(orphaned_track_ids)} orphaned tracks...", 93)
             
             # Step 6: Automatically delete all orphaned tracks
             deletion_result = delete_orphaned_albums_sync(list(orphaned_track_ids))
@@ -215,14 +215,14 @@ def identify_and_clean_orphaned_albums_task():
             if deletion_result["status"] == "SUCCESS":
                 log_and_update_main(f"✅ Successfully deleted {deletion_result['deleted_count']} orphaned tracks.", 96)
 
-                log_and_update_main(f"🔄 Rebuilding all indexes and maps after cleaning...", 97)
+                log_and_update_main(f"Rebuilding all indexes and maps after cleaning...", 97)
                 try:
                     from .analysis import _run_all_index_builds
                     _run_all_index_builds(log_fn=None)
                     log_and_update_main(f"✅ All indexes and maps rebuilt successfully after cleaning.", 99)
                 except Exception as e:
                     logger.warning(f"Failed to rebuild indexes and maps after cleaning: {e}")
-                    log_and_update_main(f"⚠️ Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
+                    log_and_update_main(f"Warning: Failed to rebuild indexes and maps: {str(e)}", 99)
                 
                 safety_message = f" (Safety limit: deleted {len(orphaned_albums_list)} out of {total_orphaned_albums} albums)" if safety_limit_applied else ""
                 
@@ -237,7 +237,7 @@ def identify_and_clean_orphaned_albums_task():
                 if safety_limit_applied:
                     remaining_count = total_orphaned_albums - len(orphaned_albums_list) 
                     if remaining_count > 0:
-                        log_and_update_main(f"ℹ️ Safety note: {remaining_count} additional orphaned albums remain. Run cleaning again to process more.", 100, task_state=TASK_STATUS_SUCCESS)
+                        log_and_update_main(f"Safety note: {remaining_count} additional orphaned albums remain. Run cleaning again to process more.", 100, task_state=TASK_STATUS_SUCCESS)
                 
                 return {
                     "status": "SUCCESS", 
@@ -246,7 +246,7 @@ def identify_and_clean_orphaned_albums_task():
                 }
             else:
                 log_and_update_main(
-                    f"⚠️ Cleaning partially failed. Deletion error: {deletion_result.get('message', 'Unknown error')}", 
+                    f"Cleaning partially failed. Deletion error: {deletion_result.get('message', 'Unknown error')}",
                     100, 
                     task_state=TASK_STATUS_FAILURE,
                     final_summary_details=summary

--- a/tasks/clustering.py
+++ b/tasks/clustering.py
@@ -223,7 +223,7 @@ def run_clustering_batch_task(
                 "full_best_result_from_batch": best_result_in_batch,
                 "final_subset_track_ids": current_sampled_track_ids
             }
-            _log_and_update(f"Batch complete. Best score: {best_score_in_batch or -1:.2f}", 100, details=final_details, state=TASK_STATUS_SUCCESS)
+            _log_and_update(f"Batch complete. Best score: {best_score_in_batch:.2f}", 100, details=final_details, state=TASK_STATUS_SUCCESS)
             return {
                 "status": "SUCCESS",
                 "iterations_completed_in_batch": iterations_completed,

--- a/tasks/ivf_manager.py
+++ b/tasks/ivf_manager.py
@@ -105,6 +105,7 @@ _thread_pool_lock = threading.Lock()
 MAX_WORKER_THREADS = max(1, (os.cpu_count() or 1) - 1)  # Use cpu_count - 1, minimum 1
 BATCH_SIZE_VECTOR_OPS = 50  # Process vectors in batches
 BATCH_SIZE_DB_OPS = 100     # Process database operations in batches
+SCORE_DETAIL_COLUMNS = 'title, author'
 
 def _get_thread_pool():
     """Get or create the global thread pool for parallel operations."""
@@ -123,16 +124,13 @@ def _shutdown_thread_pool():
             _thread_pool = None
 
 
-# Run fetch_batch_fn over BATCH_SIZE_DB_OPS chunks, fanning out when >1 batch
+# Run fetch_batch_fn over BATCH_SIZE_DB_OPS chunks sequentially
+# (batches share one db connection, which psycopg2 cannot use concurrently)
 def _fetch_in_batches(item_ids, fetch_batch_fn):
     id_batches = [item_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(item_ids), BATCH_SIZE_DB_OPS)]
-    if len(id_batches) <= 1:
-        return fetch_batch_fn(item_ids)
-    executor = _get_thread_pool()
-    future_to_batch = {executor.submit(fetch_batch_fn, b): b for b in id_batches}
     merged = {}
-    for future in as_completed(future_to_batch):
-        merged.update(future.result())
+    for batch in id_batches:
+        merged.update(fetch_batch_fn(batch))
     return merged
 
 
@@ -393,7 +391,7 @@ def _filter_by_distance(song_results: list, db_conn):
         return []
 
     item_ids = [s['item_id'] for s in song_results]
-    details_map = _fetch_details_map(db_conn, item_ids, 'title, author')
+    details_map = _fetch_details_map(db_conn, item_ids, SCORE_DETAIL_COLUMNS)
 
     threshold = DUPLICATE_DISTANCE_THRESHOLD_COSINE if IVF_METRIC == 'angular' else DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN
     metric_name = 'Angular' if IVF_METRIC == 'angular' else 'Euclidean'
@@ -440,7 +438,7 @@ def _deduplicate_and_filter_neighbors(song_results: list, db_conn, original_song
         return []
 
     item_ids = [r['item_id'] for r in song_results]
-    item_details = _fetch_details_map(db_conn, item_ids, 'title, author')
+    item_details = _fetch_details_map(db_conn, item_ids, SCORE_DETAIL_COLUMNS)
 
     unique_songs = []
 
@@ -517,15 +515,15 @@ def _filter_by_mood_similarity(song_results: list, target_item_id: str, db_conn,
             target_row = cur.fetchone()
             target_other_features = target_row['other_features'] if target_row else None
     if not target_other_features:
-        logger.warning(f"No mood features found for target song {target_item_id}. Skipping mood filtering.")
+        logger.warning("No mood features found for target song. Skipping mood filtering.")
         return song_results
 
     target_mood_features = _parse_mood_features(target_other_features)
     if not target_mood_features:
-        logger.warning(f"Could not parse mood features for target song {target_item_id}. Skipping mood filtering.")
+        logger.warning("Could not parse mood features for target song. Skipping mood filtering.")
         return song_results
 
-    logger.info(f"Target song {target_item_id} mood features: {target_mood_features}")
+    logger.info("Target mood features parsed (%d features).", len(target_mood_features))
 
     # Get mood features for all candidate songs in batches
     candidate_ids = [s['item_id'] for s in song_results]
@@ -959,7 +957,7 @@ def find_nearest_neighbors_by_vector(query_vector: np.ndarray, n: int = 100, eli
     distance_filtered_results = _filter_by_distance(initial_results, db_conn)
 
     item_ids = [r['item_id'] for r in distance_filtered_results]
-    item_details = _fetch_details_map(db_conn, item_ids, 'title, author')
+    item_details = _fetch_details_map(db_conn, item_ids, SCORE_DETAIL_COLUMNS)
 
     unique_songs_by_content = []
     added_songs_details = []

--- a/tasks/ivf_manager.py
+++ b/tasks/ivf_manager.py
@@ -8,12 +8,12 @@ from psycopg2.extras import DictCursor
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading
 
-from config import EMBEDDING_DIMENSION, INDEX_NAME, IVF_METRIC, MAX_SONGS_PER_ARTIST, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN, DUPLICATE_DISTANCE_CHECK_LOOKBACK, MOOD_SIMILARITY_THRESHOLD, SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT, MOOD_SIMILARITY_ENABLE, IVF_RESULT_CACHE_SECONDS, IVF_RESULT_CACHE_MAX
+from config import EMBEDDING_DIMENSION, INDEX_NAME, IVF_METRIC, MAX_SONGS_PER_ARTIST, DUPLICATE_DISTANCE_THRESHOLD_COSINE, DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN, DUPLICATE_DISTANCE_CHECK_LOOKBACK, MOOD_SIMILARITY_THRESHOLD, SIMILARITY_ELIMINATE_DUPLICATES_DEFAULT, SIMILARITY_RADIUS_DEFAULT, MOOD_SIMILARITY_ENABLE, IVF_RESULT_CACHE_SECONDS, IVF_RESULT_CACHE_MAX, RADIUS_INSTRUMENTATION
 
 logger = logging.getLogger(__name__)
 
 # Optional instrumentation: enable with RADIUS_INSTRUMENTATION=True in env
-INSTRUMENT_BUCKET_SKIPS = os.environ.get("RADIUS_INSTRUMENTATION", "False").lower() == 'true'
+INSTRUMENT_BUCKET_SKIPS = RADIUS_INSTRUMENTATION
 
 # --- Global cache for the loaded index ---
 ivf_index = None
@@ -121,6 +121,33 @@ def _shutdown_thread_pool():
         if _thread_pool is not None:
             _thread_pool.shutdown(wait=True)
             _thread_pool = None
+
+
+# Run fetch_batch_fn over BATCH_SIZE_DB_OPS chunks, fanning out when >1 batch
+def _fetch_in_batches(item_ids, fetch_batch_fn):
+    id_batches = [item_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(item_ids), BATCH_SIZE_DB_OPS)]
+    if len(id_batches) <= 1:
+        return fetch_batch_fn(item_ids)
+    executor = _get_thread_pool()
+    future_to_batch = {executor.submit(fetch_batch_fn, b): b for b in id_batches}
+    merged = {}
+    for future in as_completed(future_to_batch):
+        merged.update(future.result())
+    return merged
+
+
+# Batched score-table metadata fetch keyed by item_id
+def _fetch_details_map(db_conn, item_ids, columns):
+    column_keys = [c.strip() for c in columns.split(',')]
+    def fetch_batch(id_batch):
+        out = {}
+        with db_conn.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute(f"SELECT item_id, {columns} FROM score WHERE item_id = ANY(%s)", (id_batch,))
+            for row in cur.fetchall():
+                out[row['item_id']] = {c: row.get(c) for c in column_keys}
+        return out
+    return _fetch_in_batches(item_ids, fetch_batch)
+
 
 def _get_cached_vector(item_id: str) -> np.ndarray | None:
     """Return the stored vector for ``item_id`` from the loaded IVF index.
@@ -322,43 +349,36 @@ def _is_same_song(title1, artist1, title2, artist2):
     
     return norm_title1 == norm_title2 and norm_artist1 == norm_artist2
 
+# True if current_vector is within threshold of any vector in window_songs
+def _is_too_close(current_song, current_vector, window_songs, threshold, metric_name, details_map):
+    for recent_song in window_songs:
+        recent_vector = _get_cached_vector(recent_song['item_id'])
+        if recent_vector is None:
+            continue
+        direct_dist = get_direct_distance(current_vector, recent_vector)
+        if direct_dist < threshold:
+            current_details = details_map.get(current_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
+            recent_details = details_map.get(recent_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
+            logger.info(
+                f"Filtering song (DISTANCE FILTER) with {metric_name} distance: '{current_details['title']}' by '{current_details['author']}' "
+                f"due to direct distance of {direct_dist:.4f} from "
+                f"'{recent_details['title']}' by '{recent_details['author']}' (Threshold: {threshold})."
+            )
+            return True
+    return False
+
+
 def _compute_distance_batch(song_batch, lookback_songs, threshold, metric_name, details_map):
     """Compute distances for a batch of songs in parallel."""
     batch_results = []
-    
     for current_song in song_batch:
-        is_too_close = False
         current_vector = _get_cached_vector(current_song['item_id'])
         if current_vector is None:
             continue
-        
-        # Check against lookback window
-        # Build an effective comparison window that includes the provided lookback
-        # plus any songs already accepted in this batch. This avoids the case where
-        # two near-duplicate songs fall into the same batch and both slip through
-        # because they weren't compared to each other.
+        # Window = provided lookback plus songs already accepted in this batch.
         combined_recent = list(lookback_songs) + list(batch_results)
-        for recent_song in combined_recent:
-            recent_vector = _get_cached_vector(recent_song['item_id'])
-            if recent_vector is None:
-                continue
-
-            direct_dist = get_direct_distance(current_vector, recent_vector)
-            
-            if direct_dist < threshold:
-                current_details = details_map.get(current_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
-                recent_details = details_map.get(recent_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
-                logger.info(
-                    f"Filtering song (DISTANCE FILTER) with {metric_name} distance: '{current_details['title']}' by '{current_details['author']}' "
-                    f"due to direct distance of {direct_dist:.4f} from "
-                    f"'{recent_details['title']}' by '{recent_details['author']}' (Threshold: {threshold})."
-                )
-                is_too_close = True
-                break
-        
-        if not is_too_close:
+        if not _is_too_close(current_song, current_vector, combined_recent, threshold, metric_name, details_map):
             batch_results.append(current_song)
-    
     return batch_results
 
 def _filter_by_distance(song_results: list, db_conn):
@@ -372,34 +392,8 @@ def _filter_by_distance(song_results: list, db_conn):
     if not song_results:
         return []
 
-    # Fetch all song details in parallel batches
     item_ids = [s['item_id'] for s in song_results]
-    details_map = {}
-    
-    # Process DB queries in batches
-    def fetch_details_batch(id_batch):
-        batch_details = {}
-        with db_conn.cursor(cursor_factory=DictCursor) as cur:
-            cur.execute("SELECT item_id, title, author FROM score WHERE item_id = ANY(%s)", (id_batch,))
-            rows = cur.fetchall()
-            for row in rows:
-                batch_details[row['item_id']] = {'title': row['title'], 'author': row['author']}
-        return batch_details
-    
-    # Split item_ids into batches for parallel DB queries
-    id_batches = [item_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(item_ids), BATCH_SIZE_DB_OPS)]
-    
-    if len(id_batches) > 1:
-        # Use parallel DB queries for large datasets
-        executor = _get_thread_pool()
-        future_to_batch = {executor.submit(fetch_details_batch, batch): batch for batch in id_batches}
-        
-        for future in as_completed(future_to_batch):
-            batch_details = future.result()
-            details_map.update(batch_details)
-    else:
-        # Use single query for small datasets
-        details_map = fetch_details_batch(item_ids)
+    details_map = _fetch_details_map(db_conn, item_ids, 'title, author')
 
     threshold = DUPLICATE_DISTANCE_THRESHOLD_COSINE if IVF_METRIC == 'angular' else DUPLICATE_DISTANCE_THRESHOLD_EUCLIDEAN
     metric_name = 'Angular' if IVF_METRIC == 'angular' else 'Euclidean'
@@ -412,32 +406,11 @@ def _filter_by_distance(song_results: list, db_conn):
     # code path as ivf and produces identical results.
     if len(song_results) <= BATCH_SIZE_VECTOR_OPS:
         for current_song in song_results:
-            is_too_close = False
             current_vector = _get_cached_vector(current_song['item_id'])
             if current_vector is None:
                 continue
-
-            # Check against the last N songs in the filtered list
             lookback_window = filtered_songs[-DUPLICATE_DISTANCE_CHECK_LOOKBACK:]
-            for recent_song in lookback_window:
-                recent_vector = _get_cached_vector(recent_song['item_id'])
-                if recent_vector is None:
-                    continue
-
-                direct_dist = get_direct_distance(current_vector, recent_vector)
-                
-                if direct_dist < threshold:
-                    current_details = details_map.get(current_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
-                    recent_details = details_map.get(recent_song['item_id'], {'title': 'N/A', 'author': 'N/A'})
-                    logger.info(
-                        f"Filtering song (DISTANCE FILTER) with {metric_name} distance: '{current_details['title']}' by '{current_details['author']}' "
-                        f"due to direct distance of {direct_dist:.4f} from "
-                        f"'{recent_details['title']}' by '{recent_details['author']}' (Threshold: {threshold})."
-                    )
-                    is_too_close = True
-                    break
-            
-            if not is_too_close:
+            if not _is_too_close(current_song, current_vector, lookback_window, threshold, metric_name, details_map):
                 filtered_songs.append(current_song)
     else:
         # For larger datasets, use parallel processing with rolling lookback
@@ -466,33 +439,8 @@ def _deduplicate_and_filter_neighbors(song_results: list, db_conn, original_song
     if not song_results:
         return []
 
-    # Fetch song details in parallel batches
     item_ids = [r['item_id'] for r in song_results]
-    item_details = {}
-    
-    def fetch_details_batch(id_batch):
-        batch_details = {}
-        with db_conn.cursor(cursor_factory=DictCursor) as cur:
-            cur.execute("SELECT item_id, title, author, album, album_artist FROM score WHERE item_id = ANY(%s)", (id_batch,))
-            rows = cur.fetchall()
-            for row in rows:
-                batch_details[row['item_id']] = {'title': row['title'], 'author': row['author'], 'album': row.get('album'), 'album_artist': row.get('album_artist')}
-        return batch_details
-    
-    # Split item_ids into batches for parallel DB queries
-    id_batches = [item_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(item_ids), BATCH_SIZE_DB_OPS)]
-    
-    if len(id_batches) > 1:
-        # Use parallel DB queries for large datasets
-        executor = _get_thread_pool()
-        future_to_batch = {executor.submit(fetch_details_batch, batch): batch for batch in id_batches}
-        
-        for future in as_completed(future_to_batch):
-            batch_details = future.result()
-            item_details.update(batch_details)
-    else:
-        # Use single query for small datasets
-        item_details = fetch_details_batch(item_ids)
+    item_details = _fetch_details_map(db_conn, item_ids, 'title, author')
 
     unique_songs = []
 
@@ -526,33 +474,30 @@ def _deduplicate_and_filter_neighbors(song_results: list, db_conn, original_song
 
     return unique_songs
 
+# Normalized sum of abs mood-feature diffs
+def _mood_distance(target_mood_features, candidate_features, mood_features):
+    total = sum(
+        abs(target_mood_features.get(feature, 0.0) - candidate_features.get(feature, 0.0))
+        for feature in mood_features
+    )
+    return total / len(mood_features)
+
+
 def _compute_mood_distances_batch(song_batch, target_mood_features, candidate_mood_features, mood_features, mood_threshold):
     """Compute mood distances for a batch of songs in parallel."""
     batch_results = []
-    
     for song in song_batch:
         candidate_features = candidate_mood_features.get(song['item_id'])
         if not candidate_features:
-            continue  # Skip songs without mood features
-
-        # Calculate mood distance (sum of absolute differences)
-        mood_distance = sum(
-            abs(target_mood_features.get(feature, 0.0) - candidate_features.get(feature, 0.0))
-            for feature in mood_features
-        )
-        
-        # Normalize by number of features
-        normalized_mood_distance = mood_distance / len(mood_features)
-        
+            continue
+        normalized_mood_distance = _mood_distance(target_mood_features, candidate_features, mood_features)
         if normalized_mood_distance <= mood_threshold:
-            # Add mood distance info to the song result
             song_with_mood = song.copy()
             song_with_mood['mood_distance'] = normalized_mood_distance
             batch_results.append(song_with_mood)
-    
     return batch_results
 
-def _filter_by_mood_similarity(song_results: list, target_item_id: str, db_conn, mood_threshold: float = None):
+def _filter_by_mood_similarity(song_results: list, target_item_id: str, db_conn, mood_threshold: float = None, target_other_features=None):
     """
     Filters songs by mood similarity using the other_features stored in the database.
     Keeps songs with similar mood features (danceability, aggressive, happy, party, relaxed, sad).
@@ -565,52 +510,39 @@ def _filter_by_mood_similarity(song_results: list, target_item_id: str, db_conn,
     if mood_threshold is None:
         mood_threshold = MOOD_SIMILARITY_THRESHOLD
 
-    # Get target song mood features
-    with db_conn.cursor(cursor_factory=DictCursor) as cur:
-        cur.execute("SELECT other_features FROM score WHERE item_id = %s", (target_item_id,))
-        target_row = cur.fetchone()
-        if not target_row or not target_row['other_features']:
-            logger.warning(f"No mood features found for target song {target_item_id}. Skipping mood filtering.")
-            return song_results
+    # Target mood features: reuse a caller-prefetched other_features when present, else fetch it.
+    if target_other_features is None:
+        with db_conn.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute("SELECT other_features FROM score WHERE item_id = %s", (target_item_id,))
+            target_row = cur.fetchone()
+            target_other_features = target_row['other_features'] if target_row else None
+    if not target_other_features:
+        logger.warning(f"No mood features found for target song {target_item_id}. Skipping mood filtering.")
+        return song_results
 
-        target_mood_features = _parse_mood_features(target_row['other_features'])
-        if not target_mood_features:
-            logger.warning(f"Could not parse mood features for target song {target_item_id}. Skipping mood filtering.")
-            return song_results
+    target_mood_features = _parse_mood_features(target_other_features)
+    if not target_mood_features:
+        logger.warning(f"Could not parse mood features for target song {target_item_id}. Skipping mood filtering.")
+        return song_results
 
-        logger.info(f"Target song {target_item_id} mood features: {target_mood_features}")
+    logger.info(f"Target song {target_item_id} mood features: {target_mood_features}")
 
-        # Get mood features for all candidate songs in batches
-        candidate_ids = [s['item_id'] for s in song_results]
-        candidate_mood_features = {}
-        
-        # Process DB queries in batches for better performance
-        def fetch_mood_features_batch(id_batch):
-            batch_features = {}
-            with db_conn.cursor(cursor_factory=DictCursor) as cur:
-                cur.execute("SELECT item_id, other_features FROM score WHERE item_id = ANY(%s)", (id_batch,))
-                rows = cur.fetchall()
-                for row in rows:
-                    if row['other_features']:
-                        parsed_features = _parse_mood_features(row['other_features'])
-                        if parsed_features:
-                            batch_features[row['item_id']] = parsed_features
-            return batch_features
-        
-        # Split candidate_ids into batches
-        id_batches = [candidate_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(candidate_ids), BATCH_SIZE_DB_OPS)]
-        
-        if len(id_batches) > 1:
-            # Use parallel DB queries for large datasets
-            executor = _get_thread_pool()
-            future_to_batch = {executor.submit(fetch_mood_features_batch, batch): batch for batch in id_batches}
-            
-            for future in as_completed(future_to_batch):
-                batch_features = future.result()
-                candidate_mood_features.update(batch_features)
-        else:
-            # Use single query for small datasets
-            candidate_mood_features = fetch_mood_features_batch(candidate_ids)
+    # Get mood features for all candidate songs in batches
+    candidate_ids = [s['item_id'] for s in song_results]
+
+    def fetch_mood_features_batch(id_batch):
+        batch_features = {}
+        with db_conn.cursor(cursor_factory=DictCursor) as cur:
+            cur.execute("SELECT item_id, other_features FROM score WHERE item_id = ANY(%s)", (id_batch,))
+            rows = cur.fetchall()
+            for row in rows:
+                if row['other_features']:
+                    parsed_features = _parse_mood_features(row['other_features'])
+                    if parsed_features:
+                        batch_features[row['item_id']] = parsed_features
+        return batch_features
+
+    candidate_mood_features = _fetch_in_batches(candidate_ids, fetch_mood_features_batch)
 
     # Filter by mood similarity
     mood_features = ['danceable', 'aggressive', 'happy', 'party', 'relaxed', 'sad']
@@ -626,15 +558,8 @@ def _filter_by_mood_similarity(song_results: list, target_item_id: str, db_conn,
                 logger.debug(f"Skipping song {song['item_id']}: no mood features found")
                 continue
 
-            # Calculate mood distance (sum of absolute differences)
-            mood_distance = sum(
-                abs(target_mood_features.get(feature, 0.0) - candidate_features.get(feature, 0.0))
-                for feature in mood_features
-            )
-            
-            # Normalize by number of features
-            normalized_mood_distance = mood_distance / len(mood_features)
-            
+            normalized_mood_distance = _mood_distance(target_mood_features, candidate_features, mood_features)
+
             logger.debug(f"Song {song['item_id']} mood distance: {normalized_mood_distance:.4f}, features: {candidate_features}")
             
             if normalized_mood_distance <= mood_threshold:
@@ -737,7 +662,7 @@ def _radius_walk_get_candidates(
         effective_mood = MOOD_SIMILARITY_ENABLE if mood_similarity is None else mood_similarity
         if effective_mood:
             before_mood = len(unique_results_by_song)
-            unique_results_by_song = _filter_by_mood_similarity(unique_results_by_song, target_item_id, db_conn)
+            unique_results_by_song = _filter_by_mood_similarity(unique_results_by_song, target_item_id, db_conn, target_other_features=original_song_details.get('other_features'))
             after_mood = len(unique_results_by_song)
             logger.info(f"Radius walk: mood-based filtering reduced candidates {before_mood} -> {after_mood}")
         else:
@@ -947,7 +872,7 @@ def find_nearest_neighbors_by_id(target_item_id: str, n: int = 10, eliminate_dup
         effective_mood_nonradius = MOOD_SIMILARITY_ENABLE if mood_similarity is None else mood_similarity
         if effective_mood_nonradius:
             logger.info(f"Mood similarity filtering requested/enabled for target_item_id: {target_item_id}")
-            unique_results_by_song = _filter_by_mood_similarity(unique_results_by_song, target_item_id, db_conn)
+            unique_results_by_song = _filter_by_mood_similarity(unique_results_by_song, target_item_id, db_conn, target_other_features=target_song_details.get('other_features'))
         else:
             logger.info(f"Mood filtering skipped (mood_similarity={mood_similarity}, MOOD_SIMILARITY_ENABLE={MOOD_SIMILARITY_ENABLE})")
         
@@ -1033,34 +958,9 @@ def find_nearest_neighbors_by_vector(query_vector: np.ndarray, n: int = 100, eli
 
     distance_filtered_results = _filter_by_distance(initial_results, db_conn)
 
-    # Fetch item details in parallel batches
     item_ids = [r['item_id'] for r in distance_filtered_results]
-    item_details = {}
-    
-    def fetch_details_batch(id_batch):
-        batch_details = {}
-        with db_conn.cursor(cursor_factory=DictCursor) as cur:
-            cur.execute("SELECT item_id, title, author, album, album_artist FROM score WHERE item_id = ANY(%s)", (id_batch,))
-            rows = cur.fetchall()
-            for row in rows:
-                batch_details[row['item_id']] = {'title': row['title'], 'author': row['author'], 'album': row.get('album'), 'album_artist': row.get('album_artist')}
-        return batch_details
-    
-    # Split item_ids into batches for parallel DB queries
-    id_batches = [item_ids[i:i + BATCH_SIZE_DB_OPS] for i in range(0, len(item_ids), BATCH_SIZE_DB_OPS)]
-    
-    if len(id_batches) > 1:
-        # Use parallel DB queries for large datasets
-        executor = _get_thread_pool()
-        future_to_batch = {executor.submit(fetch_details_batch, batch): batch for batch in id_batches}
-        
-        for future in as_completed(future_to_batch):
-            batch_details = future.result()
-            item_details.update(batch_details)
-    else:
-        # Use single query for small datasets
-        item_details = fetch_details_batch(item_ids)
-            
+    item_details = _fetch_details_map(db_conn, item_ids, 'title, author')
+
     unique_songs_by_content = []
     added_songs_details = []
     for song in distance_filtered_results:

--- a/tasks/mediaserver/__init__.py
+++ b/tasks/mediaserver/__init__.py
@@ -105,7 +105,7 @@ def download_track(temp_dir, item):
 
             detected_ext = _detect_audio_format(downloaded_path)
             if detected_ext and detected_ext != '.tmp':
-                new_path = downloaded_path.replace('.tmp', detected_ext)
+                new_path = downloaded_path[:-len('.tmp')] + detected_ext
                 # Check if target file already exists (avoid overwriting)
                 if os.path.exists(new_path):
                     logger.warning(f"Target file already exists, keeping .tmp: {new_path}")

--- a/tasks/mediaserver/emby.py
+++ b/tasks/mediaserver/emby.py
@@ -856,7 +856,7 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
 
         headers = {"X-Emby-Token": token}
 
-        # ✅ 5. No JSON body should be sent — Emby expects query parameters only
+        # 5. No JSON body should be sent — Emby expects query parameters only
         r = requests.post(url, headers=headers, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
 
@@ -1003,7 +1003,7 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         if rest and not _add_items_to_playlist(new_id, rest, user_id, headers):
             logger.error(f"Emby create_or_replace_playlist: created '{playlist_name}' but failed to add overflow tracks")
 
-        logger.info(f"✅ Emby: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
+        logger.info(f"OK Emby: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
         return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
 
     playlist_id = existing.get("Id")
@@ -1023,6 +1023,6 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         logger.error(f"Emby create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
         return None
 
-    logger.info(f"✅ Emby: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
+    logger.info(f"OK Emby: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
     return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}
 

--- a/tasks/mediaserver/jellyfin.py
+++ b/tasks/mediaserver/jellyfin.py
@@ -424,7 +424,7 @@ def create_playlist(base_name, item_ids):
     body = {"Name": base_name, "Ids": item_ids, "UserId": config.JELLYFIN_USER_ID}
     try:
         r = requests.post(url, headers=config.HEADERS, json=body, timeout=REQUESTS_TIMEOUT)
-        if r.ok: logger.info("✅ Created Jellyfin playlist '%s'", base_name)
+        if r.ok: logger.info("Created Jellyfin playlist '%s'", base_name)
     except Exception as e:
         logger.error("Exception creating Jellyfin playlist '%s': %s", base_name, e, exc_info=True)
 
@@ -651,7 +651,7 @@ def _create_fresh_playlist(playlist_name, item_ids):
     if rest and not _add_items_to_playlist(new_id, rest):
         logger.error(f"Jellyfin _create_fresh_playlist: created '{playlist_name}' but failed to add overflow tracks")
 
-    logger.info(f"✅ Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
+    logger.info(f"Jellyfin: created playlist '{playlist_name}' (Id={new_id}) with {len(item_ids)} tracks")
     return {**created, 'Id': new_id, 'Name': created.get('Name', playlist_name)}
 
 
@@ -702,6 +702,6 @@ def create_or_replace_playlist(playlist_name, item_ids, user_creds=None):
         logger.error(f"Jellyfin create_or_replace_playlist: failed to add tracks to playlist {playlist_id}")
         return None
 
-    logger.info(f"✅ Jellyfin: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
+    logger.info(f"Jellyfin: replaced contents of playlist '{playlist_name}' (Id={playlist_id}, tracks={len(item_ids)})")
     return {**existing, 'Id': playlist_id, 'Name': existing.get('Name', playlist_name)}
 

--- a/tasks/mediaserver/lyrion.py
+++ b/tasks/mediaserver/lyrion.py
@@ -894,7 +894,7 @@ def _add_to_playlist(playlist_id, item_ids):
         if save_response and "__playlist_id" in save_response:
             final_playlist_id = save_response["__playlist_id"]
             if str(final_playlist_id) == str(playlist_id):
-                logger.info(f"✅ Successfully updated original playlist {playlist_id} with {total_added} tracks")
+                logger.info(f"Successfully updated original playlist {playlist_id} with {total_added} tracks")
                 return True
             else:
                 logger.warning(f"Created new playlist {final_playlist_id} instead of updating {playlist_id}")
@@ -907,7 +907,7 @@ def _add_to_playlist(playlist_id, item_ids):
                     logger.error(f"Error handling new playlist: {e}")
                     return False
         elif total_added > 0:
-            logger.info(f"✅ Successfully added {total_added} tracks (save response: {save_response})")
+            logger.info(f"Successfully added {total_added} tracks (save response: {save_response})")
             return True
         else:
             logger.warning("No tracks were added to the playlist")
@@ -933,12 +933,12 @@ def _create_playlist_batched(playlist_name, item_ids):
             )
             
             if playlist_id:
-                logger.info(f"✅ Created Lyrion playlist '{playlist_name}' (ID: {playlist_id}).")
+                logger.info(f"Created Lyrion playlist '{playlist_name}' (ID: {playlist_id}).")
                 
                 # Step 2: Add tracks using the web interface method
                 if item_ids:
                     if _add_to_playlist(playlist_id, item_ids):
-                        logger.info(f"✅ Successfully added {len(item_ids)} tracks to playlist '{playlist_name}'.")
+                        logger.info(f"Successfully added {len(item_ids)} tracks to playlist '{playlist_name}'.")
                     else:
                         logger.warning(f"Playlist '{playlist_name}' created but some tracks may not have been added.")
                 
@@ -973,7 +973,7 @@ def delete_playlist(playlist_id):
     # used to mis-treat as failure.
     response = _jsonrpc_request("playlists", ["delete", f"playlist_id:{playlist_id}"])
     if response is not None:
-        logger.info(f"🗑️ Deleted Lyrion playlist ID: {playlist_id}")
+        logger.info(f"Deleted Lyrion playlist ID: {playlist_id}")
         return True
     logger.error(f"Failed to delete playlist ID '{playlist_id}' on Lyrion")
     return False

--- a/tasks/mediaserver/navidrome.py
+++ b/tasks/mediaserver/navidrome.py
@@ -181,9 +181,10 @@ def download_track(temp_dir, item):
         
         response = _navidrome_request("stream", params={"id": track_id}, stream=True)
         if response:
-            with open(local_filename, 'wb') as f:
-                for chunk in response.iter_content(chunk_size=8192):
-                    f.write(chunk)
+            with response:
+                with open(local_filename, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=8192):
+                        f.write(chunk)
             logger.info(f"Downloaded '{item.get('title', 'Unknown')}' to '{local_filename}'")
             return local_filename
     except Exception as e:
@@ -542,7 +543,7 @@ def _create_playlist_batched(playlist_name, item_ids, user_creds=None):
         logger.error(f"Navidrome playlist '{playlist_name}' was created, but the response did not contain an ID.")
         return None
 
-    logger.info(f"✅ Created Navidrome playlist '{playlist_name}' (ID: {new_playlist_id}) with the first {len(ids_for_creation)} songs.")
+    logger.info(f"Created Navidrome playlist '{playlist_name}' (ID: {new_playlist_id}) with the first {len(ids_for_creation)} songs.")
 
     # Immediately update playlist to public (Navidrome requires updatePlaylist for visibility).
     update_response = _navidrome_request(
@@ -583,7 +584,7 @@ def delete_playlist(playlist_id):
     """Deletes a playlist on Navidrome using admin credentials."""
     response = _navidrome_request("deletePlaylist", {"id": playlist_id}, method='post')
     if response and response.get("status") == "ok":
-        logger.info(f"🗑️ Deleted Navidrome playlist ID: {playlist_id}")
+        logger.info(f"Deleted Navidrome playlist ID: {playlist_id}")
         return True
     logger.error(f"Failed to delete playlist ID '{playlist_id}' on Navidrome")
     return False

--- a/tasks/paged_ivf.py
+++ b/tasks/paged_ivf.py
@@ -678,27 +678,70 @@ def _note_mmap_activity(index=None) -> None:
             t.start()
 
 
-def _drop_resident_mmap_pages(indexes=None) -> int:
-    """MADV_DONTNEED each given index's cell-file mapping; return how many were advised.
+_WIN_VIRTUAL_UNLOCK = None
+_WIN_ERROR_NOT_LOCKED = 158
 
-    ``indexes`` defaults to every live index. Drops the resident (RSS) pages of the
-    disk-cache working set WITHOUT unmapping: the mapping stays valid and a later
-    query re-faults the cells it needs from the file. Unlike close()/munmap this
-    never races an in-flight zero-copy read -- a concurrent reader simply takes a
-    page fault and re-reads identical bytes from the read-only file (the mapping is
-    opened read-only, so there are no dirty pages to lose on any platform). Runs
-    where mmap.madvise + MADV_DONTNEED exist (Linux and macOS); a no-op where they
-    do not (e.g. Windows), mirroring release_memory_to_os(). Skips (with a debug
-    line) any mapping it cannot reach so a numpy layout change degrades to "no
-    reclaim" instead of silent breakage.
+
+def _win_virtual_unlock():
+    """Lazily resolve ``(VirtualUnlock, get_last_error)`` from kernel32 (Windows only).
+
+    Returns the error reader bound to the same ``use_last_error=True`` context so
+    the drop loop never references the Windows-only ``ctypes.get_last_error``
+    attribute directly (keeps it testable off-Windows). Cached for reuse.
     """
-    # madvise(MADV_DONTNEED) is POSIX (Linux/macOS); absent on Windows.
-    if platform.system() == "Windows":
+    global _WIN_VIRTUAL_UNLOCK
+    if _WIN_VIRTUAL_UNLOCK is None:
+        import ctypes
+        from ctypes import wintypes
+        fn = ctypes.WinDLL("kernel32", use_last_error=True).VirtualUnlock
+        fn.argtypes = [wintypes.LPVOID, ctypes.c_size_t]
+        fn.restype = wintypes.BOOL
+        _WIN_VIRTUAL_UNLOCK = (fn, ctypes.get_last_error)
+    return _WIN_VIRTUAL_UNLOCK
+
+
+def _drop_pages_windows(targets) -> int:
+    """Drop each index's read-only file pages from the working set via VirtualUnlock.
+
+    VirtualUnlock on pages that were never VirtualLock'd returns FALSE with
+    ERROR_NOT_LOCKED (158) but still removes them from the process working set
+    (documented behavior), so the file-backed pages move to the standby cache and
+    a later query soft-faults only the cells it probes (sub-millisecond). This is
+    the Windows analog of MADV_DONTNEED: surgical, per-index, no unmap, no dirty
+    pages to lose. ``np.memmap.ctypes.data``/``.nbytes`` give the mapping base and
+    length directly.
+    """
+    try:
+        unlock, last_error = _win_virtual_unlock()
+    except Exception as e:
+        logger.debug("IVF idle page-drop: VirtualUnlock unavailable (%s).", e)
         return 0
+    dropped = 0
+    for idx in targets:
+        mm = getattr(idx, "_mmap", None)
+        if mm is None:
+            continue
+        try:
+            addr = int(mm.ctypes.data)
+            size = int(mm.nbytes)
+        except Exception:
+            continue
+        if not addr or size <= 0:
+            continue
+        ok = unlock(addr, size)
+        err = last_error()
+        if ok or err == _WIN_ERROR_NOT_LOCKED:
+            dropped += 1
+        else:
+            logger.debug("IVF idle page-drop: VirtualUnlock failed (err=%s).", err)
+    return dropped
+
+
+def _drop_pages_posix(targets) -> int:
+    """MADV_DONTNEED each mapping (Linux drops RSS; macOS deactivates pages)."""
     advise = getattr(mmap, "MADV_DONTNEED", None)
     if advise is None:
         return 0
-    targets = list(_LIVE_INDEXES) if indexes is None else list(indexes)
     dropped = 0
     skipped = 0
     for idx in targets:
@@ -718,6 +761,25 @@ def _drop_resident_mmap_pages(indexes=None) -> int:
     if skipped:
         logger.debug("IVF idle page-drop skipped %d live mapping(s) it could not reach.", skipped)
     return dropped
+
+
+def _drop_resident_mmap_pages(indexes=None) -> int:
+    """Drop each given index's cell-file pages from RSS; return how many were dropped.
+
+    ``indexes`` defaults to every live index. Drops the resident pages of the
+    disk-cache working set WITHOUT unmapping: the mapping stays valid and a later
+    query re-faults the cells it needs from the file. This never races an in-flight
+    zero-copy read -- a concurrent reader simply takes a page fault and re-reads
+    identical bytes from the read-only file (no dirty pages to lose on any
+    platform). Uses VirtualUnlock on Windows and madvise(MADV_DONTNEED) on
+    Linux/macOS.
+    """
+    targets = list(_LIVE_INDEXES) if indexes is None else list(indexes)
+    if not targets:
+        return 0
+    if platform.system() == "Windows":
+        return _drop_pages_windows(targets)
+    return _drop_pages_posix(targets)
 
 
 def _collect_idle_mmap_indexes(now: float, idle_seconds: float):
@@ -918,6 +980,17 @@ class PagedIvfIndex:
         vecs = sub[4 * n:].view(np.float32).reshape(n, self._dim)
         return ids, vecs
 
+    def _iter_db_cells(self, cur, cell_ids):
+        """Yield ``(cid, ids, vecs)`` decoded from ivf_cell for ``cell_ids``."""
+        cur.execute(
+            f"SELECT cell_id, cell_data FROM {IVF_CELL_TABLE} "
+            f"WHERE index_name = %s AND cell_id = ANY(%s)",
+            (self._index_name, list(cell_ids)),
+        )
+        for cell_id, blob in cur.fetchall():
+            ids, vecs = unpack_cell(bytes(blob), self._dim)
+            yield int(cell_id), ids, vecs
+
     def _read_cells(self, cell_ids: List[int], cache: _CellLruCache) -> Dict[int, Tuple[np.ndarray, np.ndarray]]:
         """Decode ``cell_ids`` and return ``{cell_id: (ids, vecs)}``.
 
@@ -959,30 +1032,32 @@ class PagedIvfIndex:
         if db_needed:
             conn = self._conn_factory()
             with conn.cursor() as cur:
-                cur.execute(
-                    f"SELECT cell_id, cell_data FROM {IVF_CELL_TABLE} "
-                    f"WHERE index_name = %s AND cell_id = ANY(%s)",
-                    (self._index_name, db_needed),
-                )
-                for cell_id, blob in cur.fetchall():
-                    cid = int(cell_id)
-                    ids, vecs = unpack_cell(bytes(blob), self._dim)
+                for cid, ids, vecs in self._iter_db_cells(cur, db_needed):
                     cache.add_cell(cid, ids, vecs)
                     gcache.put_cell(self._index_name, cid, ids, vecs)
                     out[cid] = (ids, vecs)
         return out
 
-    def _distances(self, q: np.ndarray, vecs: np.ndarray) -> np.ndarray:
+    def _prep_query(self, q: np.ndarray) -> np.ndarray:
+        """Per-query precompute reused across every probed cell (angular: normalize once)."""
+        if self._metric == "angular":
+            return q / (float(np.linalg.norm(q)) + 1e-12)
+        return q
+
+    def _cell_distances(self, qp: np.ndarray, vecs: np.ndarray) -> np.ndarray:
+        """Distances for one cell from a prepared query ``qp`` (smaller = nearer)."""
         if self._metric == "euclidean":
-            diffs = vecs - q[None, :]
+            diffs = vecs - qp[None, :]
             return np.sqrt(np.einsum("ij,ij->i", diffs, diffs)).astype(np.float32)
         if self._metric == "dot":
-            return (-(vecs @ q)).astype(np.float32)
-        qn = q / (float(np.linalg.norm(q)) + 1e-12)
+            return (-(vecs @ qp)).astype(np.float32)
         if self._normalized:
-            return (1.0 - np.clip(vecs @ qn, -1.0, 1.0)).astype(np.float32)
+            return (1.0 - np.clip(vecs @ qp, -1.0, 1.0)).astype(np.float32)
         vn = vecs / (np.linalg.norm(vecs, axis=1, keepdims=True).astype(np.float32) + 1e-12)
-        return (1.0 - np.clip(vn @ qn, -1.0, 1.0)).astype(np.float32)
+        return (1.0 - np.clip(vn @ qp, -1.0, 1.0)).astype(np.float32)
+
+    def _distances(self, q: np.ndarray, vecs: np.ndarray) -> np.ndarray:
+        return self._cell_distances(self._prep_query(q), vecs)
 
     def _distances_over_cells(self, q: np.ndarray, vecs_list: List[np.ndarray]) -> List[np.ndarray]:
         """Per-cell distance arrays for ``vecs_list``, aligned with the input order.
@@ -998,8 +1073,9 @@ class PagedIvfIndex:
         never worse than before.
         """
         n_cells = len(vecs_list)
+        qp = self._prep_query(q)
         if n_cells <= 1:
-            return [self._distances(q, v) for v in vecs_list]
+            return [self._cell_distances(qp, v) for v in vecs_list]
         total = 0
         for v in vecs_list:
             total += int(v.shape[0])
@@ -1007,13 +1083,13 @@ class PagedIvfIndex:
         if total >= config.IVF_QUERY_PARALLEL_MIN_VECTORS and not _in_query_pool_thread():
             pool = _query_thread_pool()
         if pool is None:
-            return [self._distances(q, v) for v in vecs_list]
+            return [self._cell_distances(qp, v) for v in vecs_list]
 
         n_groups = min(_query_worker_count(), n_cells)
         bounds = [(i * n_cells) // n_groups for i in range(n_groups)] + [n_cells]
 
         def _score_slice(lo: int, hi: int) -> List[np.ndarray]:
-            return [self._distances(q, vecs_list[j]) for j in range(lo, hi)]
+            return [self._cell_distances(qp, vecs_list[j]) for j in range(lo, hi)]
 
         try:
             futures = [pool.submit(_score_slice, bounds[i], bounds[i + 1]) for i in range(n_groups)]
@@ -1023,7 +1099,7 @@ class PagedIvfIndex:
             return out
         except Exception as e:
             logger.warning("IVF '%s' parallel cell scan failed (%s); using serial scan.", self._index_name, e)
-            return [self._distances(q, v) for v in vecs_list]
+            return [self._cell_distances(qp, v) for v in vecs_list]
 
     def query(self, vector, k: int):
         """Return ``(ids, distances)`` for the ``k`` nearest items."""
@@ -1160,11 +1236,12 @@ class PagedIvfIndex:
         else:
             cell_ids = [int(c) for c in self._farthest_cells(q, k)]
         state = {"max_d": float("-inf"), "far_id": None}
+        qp = self._prep_query(q)
 
         def _consume(ids: np.ndarray, vecs: np.ndarray) -> None:
             if vecs.shape[0] == 0:
                 return
-            dists = self._distances(q, vecs)
+            dists = self._cell_distances(qp, vecs)
             mask = ids != int(int_id)
             if not mask.any():
                 return
@@ -1197,13 +1274,7 @@ class PagedIvfIndex:
                 with conn.cursor() as cur:
                     for start in range(0, len(db_needed), self._read_batch):
                         chunk = db_needed[start:start + self._read_batch]
-                        cur.execute(
-                            f"SELECT cell_data FROM {IVF_CELL_TABLE} "
-                            f"WHERE index_name = %s AND cell_id = ANY(%s)",
-                            (self._index_name, chunk),
-                        )
-                        for (blob,) in cur.fetchall():
-                            ids, vecs = unpack_cell(bytes(blob), self._dim)
+                        for _cid, ids, vecs in self._iter_db_cells(cur, chunk):
                             _consume(ids, vecs)
         if state["max_d"] == float("-inf"):
             return 0.0, None
@@ -1227,14 +1298,8 @@ class PagedIvfIndex:
         with conn.cursor() as cur:
             for start in range(0, len(cell_ids), self._read_batch):
                 chunk = cell_ids[start:start + self._read_batch]
-                cur.execute(
-                    f"SELECT cell_id, cell_data FROM {IVF_CELL_TABLE} "
-                    f"WHERE index_name = %s AND cell_id = ANY(%s)",
-                    (self._index_name, chunk),
-                )
-                for cell_id, blob in cur.fetchall():
-                    ids, vecs = unpack_cell(bytes(blob), self._dim)
-                    gcache.put_cell(self._index_name, int(cell_id), ids, vecs)
+                for cid, ids, vecs in self._iter_db_cells(cur, chunk):
+                    gcache.put_cell(self._index_name, cid, ids, vecs)
                     loaded += 1
         return loaded
 
@@ -1411,7 +1476,7 @@ def build_and_store_paged_ivf(
         sample_keys = np.fromiter(
             (
                 int.from_bytes(
-                    hashlib.blake2b(str(iid).encode("utf-8"), digest_size=8).digest(),
+                    hashlib.blake2b(str(iid).encode("utf-8"), digest_size=8, usedforsecurity=False).digest(),
                     "big",
                 )
                 for iid in item_ids

--- a/tasks/path_manager.py
+++ b/tasks/path_manager.py
@@ -1,8 +1,6 @@
 # tasks/path_manager.py
 import logging
 import numpy as np
-import os
-from concurrent.futures import ThreadPoolExecutor
 
 # Imports from the project
 from .ivf_manager import get_vector_by_id, find_nearest_neighbors_by_vector, find_nearest_neighbors_by_id
@@ -11,9 +9,6 @@ from config import PATH_CANDIDATES_PER_STEP, PATH_DEFAULT_LENGTH, PATH_DISTANCE_
 from config import MAX_SONGS_PER_ARTIST
 
 logger = logging.getLogger(__name__)
-
-# small shared thread pool in case of parallel vector fetch needs
-_PATH_THREAD_POOL = ThreadPoolExecutor(max_workers=max(1, (os.cpu_count() or 1) - 1), thread_name_prefix="path")
 
 
 def get_euclidean_distance(v1, v2):

--- a/tasks/radius_walk_helper.py
+++ b/tasks/radius_walk_helper.py
@@ -19,10 +19,11 @@ mood filtering) and for preparing candidate_data in the expected format.
 
 import logging
 import math
-import os
 from typing import Callable, Dict, List, Optional
 
 import numpy as np
+
+from config import RADIUS_INSTRUMENTATION
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,7 @@ logger = logging.getLogger(__name__)
 # Configurable constants (kept small so the module stays self-contained)
 # ---------------------------------------------------------------------------
 BUCKET_SIZE = 50
-INSTRUMENT_BUCKET_SKIPS = os.environ.get("RADIUS_INSTRUMENTATION", "False").lower() == "true"
+INSTRUMENT_BUCKET_SKIPS = RADIUS_INSTRUMENTATION
 
 
 # ---------------------------------------------------------------------------

--- a/tasks/sem_grove_manager.py
+++ b/tasks/sem_grove_manager.py
@@ -45,8 +45,8 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 def _get_weights():
     """Read current weights from config (supports hot-reload via setup wizard)."""
-    wl = max(0.0, float(getattr(config, 'SEM_GROVE_WEIGHT_LYRICS', 0.75)))
-    wa = max(0.0, float(getattr(config, 'SEM_GROVE_WEIGHT_AUDIO',  0.25)))
+    wl = max(0.0, float(config.SEM_GROVE_WEIGHT_LYRICS))
+    wa = max(0.0, float(config.SEM_GROVE_WEIGHT_AUDIO))
     return math.sqrt(wl), math.sqrt(wa)
 
 # Module-level defaults used at build time

--- a/tasks/song_alchemy.py
+++ b/tasks/song_alchemy.py
@@ -1,4 +1,6 @@
+import json
 import logging
+import threading
 from typing import List, Tuple
 import numpy as np
 
@@ -66,6 +68,21 @@ def _get_artist_gmm_vectors_and_weights(artist_identifier: str) -> Tuple[List[np
     return [means[i] for i in range(len(means))], weights.tolist()
 
 
+_mood_centroids_cache = None
+_mood_centroids_lock = threading.Lock()
+
+
+def _load_mood_centroids_data():
+    """Load and cache the ~1MB mood-centroids JSON once (read by every alchemy request)."""
+    global _mood_centroids_cache
+    if _mood_centroids_cache is None:
+        with _mood_centroids_lock:
+            if _mood_centroids_cache is None:
+                with open(config.MOOD_CENTROIDS_FILE, encoding='utf-8') as _f:
+                    _mood_centroids_cache = json.load(_f)
+    return _mood_centroids_cache
+
+
 def _get_mood_centroid_vector(item_id: str):
     """Parse 'mood_name:centroid_index' and return the centroid vector as np.ndarray, or None."""
     parts = str(item_id).split(':', 1)
@@ -74,9 +91,7 @@ def _get_mood_centroid_vector(item_id: str):
     mood_name, idx_str = parts[0].strip().lower(), parts[1].strip()
     try:
         cidx = int(idx_str)
-        import json as _json
-        with open(config.MOOD_CENTROIDS_FILE) as _f:
-            _mcdata = _json.load(_f)
+        _mcdata = _load_mood_centroids_data()
         centroids_list = _mcdata.get(mood_name, {}).get('centroids', [])
         if 0 <= cidx < len(centroids_list):
             vec = centroids_list[cidx].get('centroid')
@@ -629,15 +644,11 @@ def song_alchemy(add_items=None, subtract_items=None, add_ids=None, subtract_ids
             coord = id_to_coord.get(str(item_id))
             if coord is not None:
                 proj_map[pid] = coord
-            else:
-                missing_ids.append(pid)
         elif isinstance(pid, str) and pid.startswith('__sub_id__'):
             item_id = pid.replace('__sub_id__', '')
             coord = id_to_coord.get(str(item_id))
             if coord is not None:
                 proj_map[pid] = coord
-            else:
-                missing_ids.append(pid)
         elif pid in ('__add_centroid__', '__subtract_centroid__'):
             # compute centroid coords later (from member point coords) if possible
             continue
@@ -646,8 +657,6 @@ def song_alchemy(add_items=None, subtract_items=None, add_ids=None, subtract_ids
             coord = id_to_coord.get(str(pid))
             if coord is not None:
                 proj_map[pid] = coord
-            else:
-                missing_ids.append(pid)
     
     # Now add artist component projections from precomputed cache
     # Note: Artist components are NOT in proj_ids because we didn't add their vectors

--- a/templates/artist_similarity.html
+++ b/templates/artist_similarity.html
@@ -243,6 +243,13 @@
 {% block bodyAdditions %}
 <script>
     (() => {
+        // Escape data interpolated into innerHTML (track/artist names come from
+        // library metadata and may contain HTML meta-characters).
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, (c) => ({
+                '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+            })[c]);
+        }
         let currentArtist = null;
         let similarArtists = [];
         let selectedArtist = null;
@@ -322,7 +329,7 @@
                     const itemDiv = document.createElement('div');
                     itemDiv.className = 'autocomplete-item';
                     itemDiv.innerHTML = `
-                        <span class="artist-name">${artist.artist}</span>
+                        <span class="artist-name">${escapeHtml(artist.artist)}</span>
                         <span class="track-count">(${artist.track_count} tracks)</span>
                     `;
                     itemDiv.addEventListener('click', () => selectArtist(artist.artist));
@@ -457,17 +464,17 @@
                         </thead>
                         <tbody>
                             ${data.map((item, idx) => `
-                                <tr class="artist-row" data-artist="${item.artist}" data-index="${idx}">
-                                    <td>${item.artist}</td>
+                                <tr class="artist-row" data-artist="${escapeHtml(item.artist)}" data-index="${idx}">
+                                    <td>${escapeHtml(item.artist)}</td>
                                     <td>${item.divergence.toFixed(4)}</td>
                                     <td>
-                                        <button class="btn btn-primary btn-sm expand-btn" data-artist="${item.artist}" data-mode="full">
+                                        <button class="btn btn-primary btn-sm expand-btn" data-artist="${escapeHtml(item.artist)}" data-mode="full">
                                             Show All Songs
                                         </button>
                                     </td>
                                     ${showComponentMatches ? `
                                         <td>
-                                            <button class="btn btn-primary btn-sm expand-btn" data-artist="${item.artist}" data-mode="components">
+                                            <button class="btn btn-primary btn-sm expand-btn" data-artist="${escapeHtml(item.artist)}" data-mode="components">
                                                 Show Matches
                                             </button>
                                         </td>
@@ -547,7 +554,7 @@
                 // Show playlist creator
                 playlistCreator.classList.remove('hidden');
                 selectedArtistInfo.innerHTML = `
-                    <p><strong>Selected Artist:</strong> ${artistName} (${tracks.length} tracks) - <em>Full artist tracks</em></p>
+                    <p><strong>Selected Artist:</strong> ${escapeHtml(artistName)} (${tracks.length} tracks) - <em>Full artist tracks</em></p>
                 `;
                 document.getElementById('playlist_name').value = `Best of ${artistName}`;
                 playlistStatusDiv.textContent = '';
@@ -555,9 +562,9 @@
                 // Add track list to results
                 const trackListHTML = `
                     <div class="track-list">
-                        <h4>All Tracks by ${artistName}:</h4>
+                        <h4>All Tracks by ${escapeHtml(artistName)}:</h4>
                         ${tracks.map(t => `
-                            <div class="track-list-item">${t.title}</div>
+                            <div class="track-list-item">${escapeHtml(t.title)}</div>
                         `).join('')}
                     </div>
                 `;
@@ -637,7 +644,7 @@
                 // Show playlist creator
                 playlistCreator.classList.remove('hidden');
                 selectedArtistInfo.innerHTML = `
-                    <p><strong>Component Matches:</strong> ${currentArtist} × ${artistName}</p>
+                    <p><strong>Component Matches:</strong> ${escapeHtml(currentArtist)} × ${escapeHtml(artistName)}</p>
                     <p><em>${allSongs.length} total songs from ${songsByMatch.length} component matches</em></p>
                 `;
                 document.getElementById('playlist_name').value = `${currentArtist} × ${artistName} Matches`;
@@ -653,18 +660,18 @@
                     matchHTML += `
                         <div class="component-match-songs">
                             <div class="component-match-header">
-                                Component Match: ${currentArtist} C${comp1} ↔ ${artistName} C${comp2}
+                                Component Match: ${escapeHtml(currentArtist)} C${comp1} ↔ ${escapeHtml(artistName)} C${comp2}
                             </div>
                             <div style="margin-top: 0.5rem;">
-                                <strong>${currentArtist}:</strong>
+                                <strong>${escapeHtml(currentArtist)}:</strong>
                                 ${match.artist1_representative_songs.map(s => `
-                                    <div class="song-item">${s.title}</div>
+                                    <div class="song-item">${escapeHtml(s.title)}</div>
                                 `).join('')}
                             </div>
                             <div style="margin-top: 0.5rem;">
-                                <strong>${artistName}:</strong>
+                                <strong>${escapeHtml(artistName)}:</strong>
                                 ${match.artist2_representative_songs.map(s => `
-                                    <div class="song-item">${s.title}</div>
+                                    <div class="song-item">${escapeHtml(s.title)}</div>
                                 `).join('')}
                             </div>
                         </div>

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -241,7 +241,7 @@ document.addEventListener('DOMContentLoaded', () => {
                                 + 'redirecting in ' + countdown + ' seconds…';
                         } else {
                             clearInterval(countdownInterval);
-                            window.location.href = '/';
+                            if (window.appRedirect) { window.appRedirect('/'); } else { window.location.href = '/'; }
                         }
                     }, 1000);
                     return;

--- a/templates/includes/reverse_proxy_prefix.html
+++ b/templates/includes/reverse_proxy_prefix.html
@@ -1,15 +1,27 @@
-<!-- Reverse-proxy subpath support: prefix root-relative fetch() URLs with the proxy script root.
+<!-- Reverse-proxy subpath support: prefix root-relative URLs with the proxy script root.
+     Exposes window.SCRIPT_ROOT and window.appUrl() (used for fetch() and for
+     window.location redirects), plus a fetch() wrapper that auto-prefixes.
      No-op when not behind a proxy (script_root is empty), so non-proxy and native builds are unaffected. -->
 <script>
     (function () {
         var root = {{ request.script_root | tojson }};
-        if (!root || root.charAt(0) !== "/" || root.charAt(1) === "/" || typeof window.fetch !== "function") { return; }
+        if (typeof root !== "string" || root.charAt(0) !== "/" || root.charAt(1) === "/") { root = ""; }
+        window.SCRIPT_ROOT = root;
+        // Prefix a root-relative path with the script root; leave others untouched.
+        window.appUrl = function (path) {
+            if (!root || typeof path !== "string" || path.charAt(0) !== "/" || path.charAt(1) === "/"
+                || path === root || path.slice(0, root.length + 1) === root + "/") {
+                return path;
+            }
+            return root + path;
+        };
+        // Centralized redirect: build the target through appUrl so a root-relative
+        // redirect survives a subpath proxy without a guard at every call site.
+        window.appRedirect = function (path) { window.location.href = window.appUrl(path); };
+        if (!root || typeof window.fetch !== "function") { return; }
         var nativeFetch = window.fetch.bind(window);
         window.fetch = function (input, init) {
-            if (typeof input === "string" && input.charAt(0) === "/" && input.charAt(1) !== "/"
-                && input !== root && input.slice(0, root.length + 1) !== root + "/") {
-                input = root + input;
-            }
+            if (typeof input === "string") { input = window.appUrl(input); }
             return nativeFetch(input, init);
         };
     })();

--- a/templates/login.html
+++ b/templates/login.html
@@ -96,7 +96,7 @@
     <div class="login-container">
         <h1>AudioMuse-AI</h1>
         <p class="subtitle">Sign in to continue</p>
-        <form id="login-form" action="/auth" method="post">
+        <form id="login-form" action="{{ url_for('auth_endpoint') }}" method="post">
             <input type="text" id="login-user" name="user" placeholder="Username" autocomplete="username" required>
             <input type="password" id="login-password" name="password" placeholder="Password" autocomplete="current-password" required>
             <button type="submit">Sign In</button>

--- a/templates/provider_migration.html
+++ b/templates/provider_migration.html
@@ -1521,7 +1521,7 @@
                         } else {
                             countdownHost.textContent = 'Redirecting...';
                             clearInterval(cdInterval);
-                            window.location.href = '/login';
+                            if (window.appRedirect) { window.appRedirect('/login'); } else { window.location.href = '/login'; }
                         }
                     }, 1000);
                     return;

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -236,7 +236,7 @@
                     <p style="margin:0; padding:0.75rem 1rem; border-radius:6px; background:var(--card-bg, #f5f5f5); border:1px solid var(--border-color, #ccc);">
                         An admin account already exists. To add, remove, or change
                         admin and normal user accounts, go to the
-                        <a href="/users">Users</a> page.
+                        <a href="{{ url_for('users_bp.users_page') }}">Users</a> page.
                     </p>
                 </div>
                 <div id="auth-credentials" class="field-grid">

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -259,6 +259,7 @@
                             </span>
                         </label>
                         <input id="AUDIOMUSE_PASSWORD" name="AUDIOMUSE_PASSWORD" type="password" placeholder="secret123">
+                        <p id="admin-password-hint" class="inline-feedback status-pending" style="display:none; margin:6px 0 0; width:100%;"></p>
                     </div>
                     <div class="auth-admin-credential">
                         <label for="AUDIOMUSE_PASSWORD_CONFIRM" class="label-with-tooltip">

--- a/test/integration/test_ivf_batch_fetch_integration.py
+++ b/test/integration/test_ivf_batch_fetch_integration.py
@@ -1,0 +1,151 @@
+"""Real-Postgres integration test for the cross-thread psycopg2 fix.
+
+Proves tasks.ivf_manager._fetch_details_map (driving _fetch_in_batches) returns
+a complete, correct map when the id list spans several BATCH_SIZE_DB_OPS chunks
+over a single real psycopg2 connection.
+
+The regression: the old code fanned the per-chunk fetches over a
+ThreadPoolExecutor that shared one connection. psycopg2 forbids concurrent use of
+a single connection across threads, so the multi-batch fetch could raise or
+return a partial/corrupt map. The sequential fix must read all chunks in one
+shot off the shared connection and return every requested id.
+
+Database selection mirrors test_app_endpoints_integration.py:
+  * AUDIOMUSE_TEST_DATABASE_URL -- a throwaway DB the test fully owns, or
+  * an ephemeral instance via the optional ``pgserver`` package, or
+  * the module is skipped.
+
+Run locally:
+    pip install pgserver
+    pytest test/integration/test_ivf_batch_fetch_integration.py -m integration -s -v --tb=short
+"""
+import importlib.util
+import os
+import sys
+import tempfile
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+try:
+    import psycopg2
+except Exception:  # pragma: no cover - psycopg2 is in test/requirements.txt
+    psycopg2 = None
+
+
+_SCORE_DDL = (
+    "CREATE TABLE score (item_id TEXT PRIMARY KEY, title TEXT, author TEXT, "
+    "album TEXT, album_artist TEXT, tempo REAL, key TEXT, scale TEXT, "
+    "mood_vector TEXT, energy REAL, other_features TEXT, year INTEGER, "
+    "rating INTEGER, file_path TEXT)"
+)
+
+_ROW_COUNT = 250
+
+
+def _load_ivf_manager():
+    """Load tasks.ivf_manager by file path, bypassing tasks/__init__ (pydub)."""
+    mod_name = 'tasks.ivf_manager'
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    mod_path = os.path.join(_REPO_ROOT, 'tasks', 'ivf_manager.py')
+    spec = importlib.util.spec_from_file_location(mod_name, mod_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope='session')
+def pg_dsn():
+    if psycopg2 is None:
+        pytest.skip("psycopg2 not importable")
+    dsn = os.environ.get('AUDIOMUSE_TEST_DATABASE_URL')
+    if dsn:
+        try:
+            psycopg2.connect(dsn).close()
+        except Exception as e:
+            pytest.skip(f"AUDIOMUSE_TEST_DATABASE_URL not reachable: {e}")
+        yield dsn
+        return
+    try:
+        import pgserver
+    except Exception:
+        pytest.skip(
+            "No test database. Set AUDIOMUSE_TEST_DATABASE_URL to a disposable "
+            "DB, or `pip install pgserver` for an ephemeral local instance."
+        )
+    data_dir = tempfile.mkdtemp(prefix='audiomuse_pg_')
+    server = pgserver.get_server(data_dir)
+    try:
+        yield server.get_uri()
+    finally:
+        server.cleanup()
+
+
+@pytest.fixture
+def batch_db(pg_dsn):
+    """One real connection with a freshly seeded 250-row score table."""
+    conn = psycopg2.connect(pg_dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS embedding")
+        cur.execute("DROP TABLE IF EXISTS score CASCADE")
+        cur.execute(_SCORE_DDL)
+        rows = [
+            (f"item-{i:04d}", f"Title {i}", f"Author {i}")
+            for i in range(_ROW_COUNT)
+        ]
+        cur.executemany(
+            "INSERT INTO score (item_id, title, author) VALUES (%s, %s, %s)",
+            rows,
+        )
+    yield conn
+    conn.close()
+
+
+@pytest.mark.integration
+class TestFetchDetailsMapRealDb:
+    def test_multi_batch_fetch_is_complete_and_correct(self, batch_db):
+        ivf = _load_ivf_manager()
+        all_ids = [f"item-{i:04d}" for i in range(_ROW_COUNT)]
+
+        # > BATCH_SIZE_DB_OPS so the fetch spans at least 3 batches over the
+        # single shared connection -- the exact case the cross-thread bug broke.
+        assert _ROW_COUNT > ivf.BATCH_SIZE_DB_OPS
+        n_batches = (_ROW_COUNT + ivf.BATCH_SIZE_DB_OPS - 1) // ivf.BATCH_SIZE_DB_OPS
+        assert n_batches >= 3
+
+        details = ivf._fetch_details_map(batch_db, all_ids, ivf.SCORE_DETAIL_COLUMNS)
+
+        assert isinstance(details, dict)
+        assert len(details) == _ROW_COUNT
+        assert set(details.keys()) == set(all_ids)
+        for i, item_id in enumerate(all_ids):
+            entry = details[item_id]
+            assert entry['title'] == f"Title {i}"
+            assert entry['author'] == f"Author {i}"
+
+    def test_spot_checked_ids(self, batch_db):
+        ivf = _load_ivf_manager()
+        all_ids = [f"item-{i:04d}" for i in range(_ROW_COUNT)]
+        details = ivf._fetch_details_map(batch_db, all_ids, ivf.SCORE_DETAIL_COLUMNS)
+
+        # First, a mid-batch boundary id, and the last id all present + correct.
+        assert details["item-0000"] == {"title": "Title 0", "author": "Author 0"}
+        assert details["item-0100"] == {"title": "Title 100", "author": "Author 100"}
+        assert details["item-0249"] == {"title": "Title 249", "author": "Author 249"}
+
+    def test_partial_id_subset_spanning_batches(self, batch_db):
+        ivf = _load_ivf_manager()
+        # 150 ids -> 2 batches; includes ids absent from the table (skipped).
+        requested = [f"item-{i:04d}" for i in range(150)] + ["missing-a", "missing-b"]
+        details = ivf._fetch_details_map(batch_db, requested, ivf.SCORE_DETAIL_COLUMNS)
+
+        assert len(details) == 150
+        assert "missing-a" not in details
+        assert "missing-b" not in details
+        assert details["item-0149"]["author"] == "Author 149"

--- a/test/integration/test_neighbor_serialize_integration.py
+++ b/test/integration/test_neighbor_serialize_integration.py
@@ -1,0 +1,197 @@
+"""Real-Postgres integration test for the shared similarity-response serializer.
+
+Proves serialize_neighbor_results (app_helper.py, PR.md theme #8) preserves the
+missing_album sentinel contract when the details_map comes from REAL SQL rather
+than a hand-built dict. The serializer fetches details through
+database.get_score_data_by_ids -> get_db(); we monkeypatch get_db to a live
+psycopg2 connection so the production SELECT (... FROM score WHERE item_id IN %s)
+runs against a real seeded ``score`` table holding NULL and empty-string albums.
+
+Database selection mirrors test_app_endpoints_integration.py:
+  * AUDIOMUSE_TEST_DATABASE_URL — a throwaway DB the test fully owns, or
+  * an ephemeral instance via the optional ``pgserver`` package, or
+  * the module is skipped.
+
+Run locally:
+    pip install pgserver
+    pytest test/integration/test_neighbor_serialize_integration.py -m integration -s -v --tb=short
+"""
+import os
+import sys
+import tempfile
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+try:
+    import psycopg2
+except Exception:  # pragma: no cover - psycopg2 is in test/requirements.txt
+    psycopg2 = None
+
+
+_SCORE_DDL = (
+    "CREATE TABLE score (item_id TEXT PRIMARY KEY, title TEXT, author TEXT, "
+    "album TEXT, album_artist TEXT, tempo REAL, key TEXT, scale TEXT, "
+    "mood_vector TEXT, energy REAL, other_features TEXT, year INTEGER, "
+    "rating INTEGER, file_path TEXT)"
+)
+
+_INJECTION_ID = "x'; DROP TABLE score; --"
+
+
+@pytest.fixture(scope='session')
+def pg_dsn():
+    if psycopg2 is None:
+        pytest.skip("psycopg2 not importable")
+    dsn = os.environ.get('AUDIOMUSE_TEST_DATABASE_URL')
+    if dsn:
+        try:
+            psycopg2.connect(dsn).close()
+        except Exception as e:
+            pytest.skip(f"AUDIOMUSE_TEST_DATABASE_URL not reachable: {e}")
+        yield dsn
+        return
+    try:
+        import pgserver
+    except Exception:
+        pytest.skip(
+            "No test database. Set AUDIOMUSE_TEST_DATABASE_URL to a disposable "
+            "DB, or `pip install pgserver` for an ephemeral local instance."
+        )
+    data_dir = tempfile.mkdtemp(prefix='audiomuse_pg_')
+    server = pgserver.get_server(data_dir)
+    try:
+        yield server.get_uri()
+    finally:
+        server.cleanup()
+
+
+@pytest.fixture
+def serialize_db(pg_dsn):
+    conn = psycopg2.connect(pg_dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS score CASCADE")
+        cur.execute(_SCORE_DDL)
+        rows = [
+            # item_id, title, author, album, album_artist, mood_vector
+            ('null-album', 'No Album Track', 'Artist A', None, 'AA', 'rock:0.9'),
+            ('empty-album', 'Empty Album Track', 'Artist B', '', 'BB', 'pop:0.8'),
+            ('normal-1', 'Real Title One', 'Real Author One', 'Real Album One', 'RA1', 'jazz:0.7'),
+            ('normal-2', 'Real Title Two', 'Real Author Two', 'Real Album Two', 'RA2', 'metal:0.6'),
+        ]
+        for item_id, title, author, album, album_artist, mood in rows:
+            cur.execute(
+                "INSERT INTO score (item_id, title, author, album, album_artist, mood_vector) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                (item_id, title, author, album, album_artist, mood),
+            )
+    yield conn
+    conn.close()
+
+
+def _bind_real_db(monkeypatch, conn):
+    """Make get_score_data_by_ids run its REAL SELECT against ``conn``."""
+    import database
+    monkeypatch.setattr(database, 'get_db', lambda: conn)
+
+
+def _by_id(out):
+    return {row['item_id']: row for row in out}
+
+
+def _table_exists(conn, name):
+    with conn.cursor() as cur:
+        cur.execute("SELECT to_regclass(%s)", (f'public.{name}',))
+        return cur.fetchone()[0] is not None
+
+
+def _score_count(conn):
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM score")
+        return cur.fetchone()[0]
+
+
+@pytest.mark.integration
+class TestSerializeNeighborResultsRealDb:
+    def test_missing_album_sentinel_substitutes_null_and_empty(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        neighbors = [
+            {'item_id': 'null-album', 'distance': 0.10},
+            {'item_id': 'empty-album', 'distance': 0.20},
+            {'item_id': 'normal-1', 'distance': 0.30},
+        ]
+        out = _by_id(app_helper.serialize_neighbor_results(neighbors, missing_album='unknown'))
+        assert out['null-album']['album'] == 'unknown'
+        assert out['empty-album']['album'] == 'unknown'
+        assert out['normal-1']['album'] == 'Real Album One'
+
+    def test_missing_album_none_preserves_raw_album(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        neighbors = [
+            {'item_id': 'null-album', 'distance': 0.10},
+            {'item_id': 'empty-album', 'distance': 0.20},
+            {'item_id': 'normal-1', 'distance': 0.30},
+        ]
+        out = _by_id(app_helper.serialize_neighbor_results(neighbors, missing_album=None))
+        assert out['null-album']['album'] is None
+        assert out['empty-album']['album'] == ''
+        assert out['normal-1']['album'] == 'Real Album One'
+
+    def test_title_author_come_from_real_rows(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        neighbors = [
+            {'item_id': 'normal-1', 'distance': 0.30},
+            {'item_id': 'normal-2', 'distance': 0.40},
+        ]
+        out = _by_id(app_helper.serialize_neighbor_results(neighbors))
+        assert out['normal-1']['title'] == 'Real Title One'
+        assert out['normal-1']['author'] == 'Real Author One'
+        assert out['normal-1']['album_artist'] == 'RA1'
+        assert out['normal-1']['distance'] == 0.30
+        assert out['normal-2']['title'] == 'Real Title Two'
+        assert out['normal-2']['author'] == 'Real Author Two'
+
+    def test_unknown_id_absent_from_db_is_skipped(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        neighbors = [
+            {'item_id': 'normal-1', 'distance': 0.30},
+            {'item_id': 'ghost-not-in-db', 'distance': 0.99},
+        ]
+        out = app_helper.serialize_neighbor_results(neighbors)
+        ids = {row['item_id'] for row in out}
+        assert 'normal-1' in ids
+        assert 'ghost-not-in-db' not in ids
+        assert len(out) == 1
+
+    def test_include_album_artist_flag_omits_field(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        neighbors = [{'item_id': 'normal-1', 'distance': 0.30}]
+        out = app_helper.serialize_neighbor_results(neighbors, include_album_artist=False)
+        assert out
+        assert 'album_artist' not in out[0]
+
+    def test_injection_style_id_through_real_select_is_safe(self, serialize_db, monkeypatch):
+        import app_helper
+        _bind_real_db(monkeypatch, serialize_db)
+        before = _score_count(serialize_db)
+        neighbors = [
+            {'item_id': _INJECTION_ID, 'distance': 0.50},
+            {'item_id': 'normal-1', 'distance': 0.30},
+        ]
+        # The real parameterized SELECT must treat the metacharacter id as a
+        # plain (non-matching) literal: no SQL error, table untouched.
+        out = app_helper.serialize_neighbor_results(neighbors)
+        ids = {row['item_id'] for row in out}
+        assert _INJECTION_ID not in ids
+        assert 'normal-1' in ids
+        assert _table_exists(serialize_db, 'score')
+        assert _score_count(serialize_db) == before

--- a/test/integration/test_neighbor_serialize_integration.py
+++ b/test/integration/test_neighbor_serialize_integration.py
@@ -154,7 +154,7 @@ class TestSerializeNeighborResultsRealDb:
         assert out['normal-1']['title'] == 'Real Title One'
         assert out['normal-1']['author'] == 'Real Author One'
         assert out['normal-1']['album_artist'] == 'RA1'
-        assert out['normal-1']['distance'] == 0.30
+        assert out['normal-1']['distance'] == pytest.approx(0.30)
         assert out['normal-2']['title'] == 'Real Title Two'
         assert out['normal-2']['author'] == 'Real Author Two'
 

--- a/test/integration/test_task_status_integration.py
+++ b/test/integration/test_task_status_integration.py
@@ -1,0 +1,263 @@
+"""Real-Postgres integration test for the task-status details parse fix.
+
+PR.md theme #13: ``app.py get_task_status_endpoint`` reads ``details`` from the
+DB and must NOT double-parse it::
+
+    raw_details = db_task_info.get('details')
+    if isinstance(raw_details, dict):
+        db_details = raw_details
+    elif raw_details:
+        db_details = json.loads(raw_details)
+
+The real ``task_status.details`` column is TEXT and ``database.save_task_status``
+stores ``json.dumps(details)``, so the real getter
+(``database.get_task_info_from_db``) returns ``details`` as a JSON *string* (the
+``elif`` branch). A JSON/JSONB column instead makes psycopg2 hand back a Python
+*dict* (the ``isinstance`` branch). This test exercises BOTH real round-trips and
+applies the exact endpoint branch to the real returned values, proving no
+double-parse and no error in either case.
+
+Importing ``app.py`` end-to-end is infeasible here (module import pulls in
+redis/RQ connections, every blueprint, and full runtime config), so we drive the
+REAL database getter ``get_task_info_from_db`` against a live connection and
+replicate only the tiny isinstance/json.loads branch from the endpoint. The
+value it branches on is a genuine DB round-trip, never a mock.
+
+Database selection mirrors test_app_endpoints_integration.py:
+  * AUDIOMUSE_TEST_DATABASE_URL -- a throwaway DB the test fully owns, or
+  * an ephemeral instance via the optional ``pgserver`` package, or
+  * the module is skipped.
+
+Run locally:
+    pip install pgserver
+    pytest test/integration/test_task_status_integration.py -m integration -s -v --tb=short
+"""
+import json
+import os
+import sys
+import tempfile
+
+import pytest
+
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+try:
+    import psycopg2
+    from psycopg2.extras import DictCursor
+except Exception:  # pragma: no cover - psycopg2 is in test/requirements.txt
+    psycopg2 = None
+    DictCursor = None
+
+
+# Real task_status schema, copied verbatim from database.py init_db: details is
+# TEXT, plus the start_time/end_time DOUBLE PRECISION columns the migration adds.
+_TASK_STATUS_DDL = (
+    "CREATE TABLE task_status ("
+    "id SERIAL PRIMARY KEY, task_id TEXT UNIQUE NOT NULL, parent_task_id TEXT, "
+    "task_type TEXT NOT NULL, sub_type_identifier TEXT, status TEXT, "
+    "progress INTEGER DEFAULT 0, details TEXT, "
+    "timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+    "start_time DOUBLE PRECISION, end_time DOUBLE PRECISION)"
+)
+
+# Variant whose details column is JSONB: psycopg2 decodes JSONB to a Python dict
+# on fetch, which is the real-world source of the endpoint's isinstance() branch.
+_TASK_STATUS_JSONB_DDL = (
+    "CREATE TABLE task_status ("
+    "id SERIAL PRIMARY KEY, task_id TEXT UNIQUE NOT NULL, parent_task_id TEXT, "
+    "task_type TEXT NOT NULL, sub_type_identifier TEXT, status TEXT, "
+    "progress INTEGER DEFAULT 0, details JSONB, "
+    "timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP, "
+    "start_time DOUBLE PRECISION, end_time DOUBLE PRECISION)"
+)
+
+_SAMPLE_DETAILS = {
+    "log": ["Analyzing album", "Done"],
+    "current_album": "Album X",
+    "status_message": "running",
+    "nested": {"a": 1, "b": [2, 3]},
+}
+
+
+def _endpoint_db_details(raw_details):
+    """The exact branch from app.py get_task_status_endpoint, isolated.
+
+    Returns the surfaced details dict for a raw DB value, mirroring the source
+    one-for-one so a regression there (double-parse / wrong type) would fail the
+    real-round-trip assertions below.
+    """
+    db_details = {}
+    if isinstance(raw_details, dict):
+        db_details = raw_details
+    elif raw_details:
+        try:
+            db_details = json.loads(raw_details)
+        except (json.JSONDecodeError, TypeError):
+            db_details = {}
+    return db_details
+
+
+@pytest.fixture(scope='session')
+def pg_dsn():
+    if psycopg2 is None:
+        pytest.skip("psycopg2 not importable")
+    dsn = os.environ.get('AUDIOMUSE_TEST_DATABASE_URL')
+    if dsn:
+        try:
+            psycopg2.connect(dsn).close()
+        except Exception as e:
+            pytest.skip(f"AUDIOMUSE_TEST_DATABASE_URL not reachable: {e}")
+        yield dsn
+        return
+    try:
+        import pgserver
+    except Exception:
+        pytest.skip(
+            "No test database. Set AUDIOMUSE_TEST_DATABASE_URL to a disposable "
+            "DB, or `pip install pgserver` for an ephemeral local instance."
+        )
+    data_dir = tempfile.mkdtemp(prefix='audiomuse_pg_')
+    server = pgserver.get_server(data_dir)
+    try:
+        yield server.get_uri()
+    finally:
+        server.cleanup()
+
+
+@pytest.fixture
+def text_details_db(pg_dsn):
+    """Real connection with the real (TEXT details) task_status table seeded."""
+    conn = psycopg2.connect(pg_dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS task_status CASCADE")
+        cur.execute(_TASK_STATUS_DDL)
+    yield conn
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS task_status CASCADE")
+    conn.close()
+
+
+@pytest.fixture
+def jsonb_details_db(pg_dsn):
+    """Real connection with a JSONB-details task_status table seeded."""
+    conn = psycopg2.connect(pg_dsn)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS task_status CASCADE")
+        cur.execute(_TASK_STATUS_JSONB_DDL)
+    yield conn
+    with conn.cursor() as cur:
+        cur.execute("DROP TABLE IF EXISTS task_status CASCADE")
+    conn.close()
+
+
+def _seed_text(conn, task_id):
+    # Stores details exactly as save_task_status does: json.dumps into TEXT.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO task_status (task_id, task_type, status, progress, "
+            "details, start_time, end_time) VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (task_id, 'main_analysis', 'PROGRESS', 42,
+             json.dumps(_SAMPLE_DETAILS), 1000.0, None),
+        )
+
+
+def _seed_jsonb(conn, task_id):
+    # JSONB column: hand psycopg2 a JSON string and let the DB store it as JSONB.
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO task_status (task_id, task_type, status, progress, "
+            "details, start_time, end_time) VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (task_id, 'main_clustering', 'SUCCESS', 100,
+             json.dumps(_SAMPLE_DETAILS), 1000.0, 1002.5),
+        )
+
+
+@pytest.mark.integration
+class TestTaskStatusDetailsRoundTrip:
+    def test_text_details_returns_json_string(self, text_details_db, monkeypatch):
+        """Real TEXT column -> getter returns a JSON string (elif branch)."""
+        import database
+        _seed_text(text_details_db, 'task-text-1')
+        monkeypatch.setattr(database, 'get_db', lambda: text_details_db)
+
+        row = database.get_task_info_from_db('task-text-1')
+        assert row is not None
+        raw_details = row.get('details')
+        # The real driver hands TEXT back as a Python str, not a dict.
+        assert isinstance(raw_details, str)
+
+        surfaced = _endpoint_db_details(raw_details)
+        assert isinstance(surfaced, dict)
+        assert surfaced == _SAMPLE_DETAILS
+        assert surfaced['current_album'] == 'Album X'
+        assert surfaced['nested'] == {"a": 1, "b": [2, 3]}
+
+    def test_jsonb_details_returns_dict(self, jsonb_details_db, monkeypatch):
+        """Real JSONB column -> getter returns a Python dict (isinstance branch)."""
+        import database
+        _seed_jsonb(jsonb_details_db, 'task-jsonb-1')
+        monkeypatch.setattr(database, 'get_db', lambda: jsonb_details_db)
+
+        row = database.get_task_info_from_db('task-jsonb-1')
+        assert row is not None
+        raw_details = row.get('details')
+        # psycopg2 auto-decodes JSONB to a dict; the endpoint must NOT re-parse.
+        assert isinstance(raw_details, dict)
+
+        surfaced = _endpoint_db_details(raw_details)
+        assert surfaced is raw_details
+        assert surfaced == _SAMPLE_DETAILS
+        assert surfaced['log'] == ["Analyzing album", "Done"]
+
+    def test_no_double_parse_between_paths(self, text_details_db, jsonb_details_db, monkeypatch):
+        """Both real paths surface identical content; neither errors out."""
+        import database
+        _seed_text(text_details_db, 'task-text-2')
+        _seed_jsonb(jsonb_details_db, 'task-jsonb-2')
+
+        monkeypatch.setattr(database, 'get_db', lambda: text_details_db)
+        text_row = database.get_task_info_from_db('task-text-2')
+        text_surfaced = _endpoint_db_details(text_row.get('details'))
+
+        monkeypatch.setattr(database, 'get_db', lambda: jsonb_details_db)
+        jsonb_row = database.get_task_info_from_db('task-jsonb-2')
+        jsonb_surfaced = _endpoint_db_details(jsonb_row.get('details'))
+
+        assert text_surfaced == jsonb_surfaced == _SAMPLE_DETAILS
+        # A double-parse would have raised TypeError on the dict path; reaching
+        # here means the isinstance guard short-circuited correctly.
+        assert isinstance(text_surfaced['log'], list)
+        assert isinstance(jsonb_surfaced['log'], list)
+
+    def test_null_details_surfaces_empty_dict(self, text_details_db, monkeypatch):
+        """NULL details -> getter returns None -> endpoint yields {} (no error)."""
+        import database
+        with text_details_db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO task_status (task_id, task_type, status, details) "
+                "VALUES (%s, %s, %s, %s)",
+                ('task-null', 'main_analysis', 'PENDING', None),
+            )
+        monkeypatch.setattr(database, 'get_db', lambda: text_details_db)
+
+        row = database.get_task_info_from_db('task-null')
+        assert row is not None
+        assert row.get('details') is None
+        assert _endpoint_db_details(row.get('details')) == {}
+
+    def test_real_getter_uses_dictcursor_mapping(self, text_details_db, monkeypatch):
+        """Sanity: the real getter yields a mapping with the expected columns."""
+        import database
+        _seed_text(text_details_db, 'task-text-3')
+        monkeypatch.setattr(database, 'get_db', lambda: text_details_db)
+
+        row = database.get_task_info_from_db('task-text-3')
+        assert row['task_type'] == 'main_analysis'
+        assert row['status'] == 'PROGRESS'
+        assert row['progress'] == 42
+        # running_time_seconds is computed in Python; end_time is NULL -> > 0.
+        assert row['running_time_seconds'] > 0

--- a/test/unit/test_app_auth.py
+++ b/test/unit/test_app_auth.py
@@ -95,7 +95,7 @@ class TestCheckAuthNeededBearer:
             result = app_auth.check_auth_needed('s')
             assert result is None
             assert g.auth_role == 'admin'
-        assert ('tok-123', 'tok-123') in calls
+        assert (b'tok-123', b'tok-123') in calls
 
     def test_bearer_wrong_token_rejected(self, app, monkeypatch):
         import config

--- a/test/unit/test_app_chat_validation.py
+++ b/test/unit/test_app_chat_validation.py
@@ -122,8 +122,7 @@ class TestValidBodyProceeds:
 
         def _fake_run(data, log_messages):
             called['run'] += 1
-            if False:
-                yield
+            yield from ()  # generator marker; never yields
             return ({'message': 'stub', 'query_results': None}, 200)
 
         with patch.object(app_chat_mod, '_run_chat_pipeline', _fake_run):

--- a/test/unit/test_app_chat_validation.py
+++ b/test/unit/test_app_chat_validation.py
@@ -1,0 +1,139 @@
+"""Request-validation coverage for the chat playlist endpoints.
+
+Both /api/chatPlaylist and /api/chatPlaylistStream share the guard:
+    if not isinstance(data, dict)
+       or not isinstance(data.get('userInput'), str)
+       or not data['userInput'].strip():
+        return 400
+
+These tests assert that a body which is NOT a dict (list, number, string,
+null), a missing userInput key, a non-string userInput, and an empty /
+whitespace-only userInput all return HTTP 400 with the missing-userInput
+error -- for BOTH endpoints -- while a valid body proceeds past validation
+into the (patched-out) pipeline.
+"""
+import sys
+import types
+import json
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+
+def _ensure_flasgger():
+    try:
+        import flasgger  # noqa: F401
+        return
+    except ImportError:
+        pass
+    fake = types.ModuleType('flasgger')
+
+    def swag_from(*a, **k):
+        def deco(f):
+            return f
+        return deco
+
+    fake.swag_from = swag_from
+    fake.Swagger = lambda *a, **k: None
+    sys.modules['flasgger'] = fake
+
+
+@pytest.fixture
+def app_chat_mod():
+    _ensure_flasgger()
+    import app_chat
+    return app_chat
+
+
+@pytest.fixture
+def client(app_chat_mod):
+    app = Flask(__name__)
+    app.register_blueprint(app_chat_mod.chat_bp)
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+ENDPOINTS = ['/api/chatPlaylist', '/api/chatPlaylistStream']
+
+# JSON bodies that are valid JSON but NOT a dict -> must 400.
+NON_DICT_BODIES = [
+    ('list', '[]'),
+    ('number', '5'),
+    ('string', '"make me a playlist"'),
+    ('null', 'null'),
+]
+
+
+def _post_raw(client, path, raw_body):
+    return client.post(path, data=raw_body, content_type='application/json')
+
+
+def _assert_missing_user_input(resp):
+    assert resp.status_code == 400
+    payload = json.loads(resp.get_data(as_text=True))
+    assert payload.get('error') == 'Missing userInput in request'
+
+
+class TestNonDictBodyRejected:
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    @pytest.mark.parametrize('label,raw', NON_DICT_BODIES)
+    def test_non_dict_body_returns_400(self, client, path, label, raw):
+        resp = _post_raw(client, path, raw)
+        _assert_missing_user_input(resp)
+
+
+class TestInvalidUserInputRejected:
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    def test_missing_user_input_key(self, client, path):
+        resp = client.post(
+            path, json={'ai_provider': 'NONE'},
+            content_type='application/json')
+        _assert_missing_user_input(resp)
+
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    def test_user_input_not_a_string(self, client, path):
+        resp = client.post(
+            path, json={'userInput': 123},
+            content_type='application/json')
+        _assert_missing_user_input(resp)
+
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    def test_user_input_empty_string(self, client, path):
+        resp = client.post(
+            path, json={'userInput': ''},
+            content_type='application/json')
+        _assert_missing_user_input(resp)
+
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    def test_user_input_whitespace_only(self, client, path):
+        resp = client.post(
+            path, json={'userInput': '   \t  '},
+            content_type='application/json')
+        _assert_missing_user_input(resp)
+
+
+class TestValidBodyProceeds:
+    @pytest.mark.parametrize('path', ENDPOINTS)
+    def test_valid_body_passes_validation(self, app_chat_mod, client, path):
+        # Patch the pipeline so the real AI stack never runs; we only assert
+        # that a valid body gets PAST the 400 guard and into the pipeline.
+        called = {'run': 0}
+
+        def _fake_run(data, log_messages):
+            called['run'] += 1
+            if False:
+                yield
+            return ({'message': 'stub', 'query_results': None}, 200)
+
+        with patch.object(app_chat_mod, '_run_chat_pipeline', _fake_run):
+            resp = client.post(
+                path, json={'userInput': 'make me a playlist'},
+                content_type='application/json')
+            # The streaming endpoint builds a lazy generator; consume the body
+            # inside the patch so _run_chat_pipeline actually runs.
+            body = resp.get_data(as_text=True)
+
+        assert resp.status_code != 400
+        assert called['run'] == 1
+        assert body is not None

--- a/test/unit/test_app_cron_steps.py
+++ b/test/unit/test_app_cron_steps.py
@@ -1,0 +1,137 @@
+"""Tests for the app_cron.py cron matcher step/range refinements.
+
+Covers:
+- '*/N' anchored at the field minimum (month/dom start at 1, minute/hour at 0)
+- range-with-step 'a-b/N'
+- day-of-week 7 treated as Sunday (== 0)
+- a timestamp of 0 (the epoch) evaluated correctly, not skipped as falsy
+
+These exercise the real _field_matches / cron_matches_now functions directly.
+Cases here intentionally do NOT overlap test_app_cron_parsing.py.
+"""
+import os
+import time
+
+import pytest
+
+from app_cron import _field_matches, cron_matches_now
+
+
+requires_tzset = pytest.mark.skipif(
+    not hasattr(time, 'tzset'), reason='time.tzset not available on this platform'
+)
+
+
+@pytest.fixture
+def utc_tz():
+    old = os.environ.get('TZ')
+    os.environ['TZ'] = 'UTC'
+    time.tzset()
+    yield
+    if old is None:
+        os.environ.pop('TZ', None)
+    else:
+        os.environ['TZ'] = old
+    time.tzset()
+
+
+# --- (a) '*/N' anchored at the field minimum --------------------------------
+
+def test_step_month_anchored_at_one():
+    # month '*/3' -> 1,4,7,10 (field_min=1), NOT 0,3,6,9
+    matched = [m for m in range(1, 13) if _field_matches('*/3', m, field_min=1)]
+    assert matched == [1, 4, 7, 10]
+    assert _field_matches('*/3', 0, field_min=1) is False
+    assert _field_matches('*/3', 3, field_min=1) is False
+    assert _field_matches('*/3', 6, field_min=1) is False
+    assert _field_matches('*/3', 9, field_min=1) is False
+
+
+def test_step_day_of_month_anchored_at_one():
+    # dom '*/2' -> odd days 1,3,5,7,... (field_min=1)
+    matched = [d for d in range(1, 32) if _field_matches('*/2', d, field_min=1)]
+    assert matched == list(range(1, 32, 2))
+    assert _field_matches('*/2', 2, field_min=1) is False
+    assert _field_matches('*/2', 1, field_min=1) is True
+
+
+def test_step_minute_anchored_at_zero():
+    # minute '*/15' -> 0,15,30,45 (field_min=0)
+    matched = [m for m in range(0, 60) if _field_matches('*/15', m)]
+    assert matched == [0, 15, 30, 45]
+    assert _field_matches('*/15', 1, field_min=0) is False
+    assert _field_matches('*/15', 14, field_min=0) is False
+
+
+def test_step_hour_anchored_at_zero():
+    # hour '*/6' -> 0,6,12,18 (field_min=0)
+    matched = [h for h in range(0, 24) if _field_matches('*/6', h)]
+    assert matched == [0, 6, 12, 18]
+    assert _field_matches('*/6', 5, field_min=0) is False
+    assert _field_matches('*/6', 23, field_min=0) is False
+
+
+# --- (b) range-with-step 'a-b/N' --------------------------------------------
+
+def test_range_with_step_only_matches_steps_within_range():
+    # '10-20/5' -> 10,15,20 and nothing else in 0..29
+    matched = [v for v in range(0, 30) if _field_matches('10-20/5', v)]
+    assert matched == [10, 15, 20]
+    # boundaries / off-step / out-of-range all excluded
+    assert _field_matches('10-20/5', 11) is False
+    assert _field_matches('10-20/5', 12) is False
+    assert _field_matches('10-20/5', 5) is False
+    assert _field_matches('10-20/5', 25) is False
+
+
+def test_range_with_step_inclusive_upper_bound():
+    # upper bound matches only when on-step from lo
+    assert _field_matches('1-10/3', 1) is True
+    assert _field_matches('1-10/3', 10) is True
+    assert _field_matches('1-10/3', 4) is True
+    assert _field_matches('1-10/3', 7) is True
+    assert _field_matches('1-10/3', 9) is False
+
+
+# --- (c) day-of-week 7 treated as Sunday (== 0) -----------------------------
+
+@requires_tzset
+def test_dow_seven_is_sunday(utc_tz):
+    # 2021-08-15 12:00:00 UTC is a Sunday.
+    sunday_ts = time.mktime(time.strptime(
+        '2021-08-15 12:00:00', '%Y-%m-%d %H:%M:%S'))
+    assert time.localtime(sunday_ts).tm_wday == 6  # Python Sunday
+    # dow '7' should match a Sunday (cron 7 == 0 == Sunday)
+    assert cron_matches_now('0 12 * * 7', sunday_ts) is True
+    # dow '0' should also match the same Sunday
+    assert cron_matches_now('0 12 * * 0', sunday_ts) is True
+
+
+@requires_tzset
+def test_dow_seven_does_not_match_non_sunday(utc_tz):
+    # 2021-08-16 12:00:00 UTC is a Monday.
+    monday_ts = time.mktime(time.strptime(
+        '2021-08-16 12:00:00', '%Y-%m-%d %H:%M:%S'))
+    assert time.localtime(monday_ts).tm_wday == 0  # Python Monday
+    assert cron_matches_now('0 12 * * 7', monday_ts) is False
+    assert cron_matches_now('0 12 * * 0', monday_ts) is False
+
+
+# --- (d) the epoch (ts == 0) is evaluated, not skipped as falsy -------------
+
+@requires_tzset
+def test_epoch_timestamp_is_evaluated(utc_tz):
+    # localtime(0) under UTC = 1970-01-01 00:00:00, a Thursday (py_dow 4).
+    lt = time.localtime(0)
+    assert (lt.tm_min, lt.tm_hour, lt.tm_mday, lt.tm_mon) == (0, 0, 1, 1)
+    # Matching expr for the epoch: Jan 1, 00:00.
+    assert cron_matches_now('0 0 1 1 *', 0) is True
+    # Thursday at midnight also matches via dow (cron Thursday == 4).
+    assert cron_matches_now('0 0 * * 4', 0) is True
+
+
+@requires_tzset
+def test_epoch_timestamp_non_matching_minute(utc_tz):
+    # ts=0 must still be honored (not treated as "use now"): a non-matching
+    # minute returns False rather than silently matching the current time.
+    assert cron_matches_now('30 0 1 1 *', 0) is False

--- a/test/unit/test_auth_https_decision.py
+++ b/test/unit/test_auth_https_decision.py
@@ -1,0 +1,121 @@
+"""Unit tests for app_auth._original_request_is_https and the Bearer token
+secrets.compare_digest-on-encoded-bytes check.
+
+The HTTPS-decision helper drives the Secure cookie flag, so it is exercised
+inside a real Flask test request context (direct HTTPS, plain HTTP, and the
+X-Forwarded-Proto reverse-proxy header in both directions). The token check is
+verified to encode to bytes before compare_digest so a non-ASCII token cannot
+raise. The DB is not touched; only the request context and config matter.
+"""
+import pytest
+from flask import Flask, Blueprint
+
+import app_auth
+
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.add_url_rule('/login', 'login_page', lambda: 'login')
+    dash = Blueprint('dashboard_bp', __name__)
+    dash.add_url_rule('/dashboard', 'dashboard_page', lambda: 'dash')
+    app.register_blueprint(dash)
+    return app
+
+
+class TestOriginalRequestIsHttps:
+    def test_direct_https_request_is_true(self, app):
+        with app.test_request_context(
+            '/auth', base_url='https://example.test'
+        ):
+            assert app_auth._original_request_is_https() is True
+
+    def test_plain_http_no_header_is_false(self, app):
+        with app.test_request_context(
+            '/auth', base_url='http://example.test'
+        ):
+            assert app_auth._original_request_is_https() is False
+
+    def test_forwarded_proto_https_is_true(self, app):
+        with app.test_request_context(
+            '/auth',
+            base_url='http://example.test',
+            headers={'X-Forwarded-Proto': 'https'},
+        ):
+            assert app_auth._original_request_is_https() is True
+
+    def test_forwarded_proto_http_is_false(self, app):
+        with app.test_request_context(
+            '/auth',
+            base_url='http://example.test',
+            headers={'X-Forwarded-Proto': 'http'},
+        ):
+            assert app_auth._original_request_is_https() is False
+
+    def test_forwarded_proto_list_first_value_https_is_true(self, app):
+        with app.test_request_context(
+            '/auth',
+            base_url='http://example.test',
+            headers={'X-Forwarded-Proto': 'https, http'},
+        ):
+            assert app_auth._original_request_is_https() is True
+
+    def test_forwarded_proto_uppercase_is_true(self, app):
+        with app.test_request_context(
+            '/auth',
+            base_url='http://example.test',
+            headers={'X-Forwarded-Proto': 'HTTPS'},
+        ):
+            assert app_auth._original_request_is_https() is True
+
+
+class TestBearerTokenCompareDigest:
+    def test_unicode_token_does_not_raise(self, app, monkeypatch):
+        import config
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(config, 'API_TOKEN', 'tok-123')
+        unicode_token = 'tok-é中'
+        with app.test_request_context(
+            '/api/foo',
+            headers={'Authorization': f'Bearer {unicode_token}'},
+        ):
+            result = app_auth.check_auth_needed('s')
+        assert result is not None
+        assert result[1] == 401
+
+    def test_unicode_token_matches_when_correct(self, app, monkeypatch):
+        import config
+        from flask import g
+        unicode_token = 'tok-é中'
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(config, 'API_TOKEN', unicode_token)
+        with app.test_request_context(
+            '/api/foo',
+            headers={'Authorization': f'Bearer {unicode_token}'},
+        ):
+            result = app_auth.check_auth_needed('s')
+            assert result is None
+            assert g.auth_role == 'admin'
+
+    def test_correct_token_authenticates(self, app, monkeypatch):
+        import config
+        from flask import g
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(config, 'API_TOKEN', 'tok-123')
+        with app.test_request_context(
+            '/api/foo', headers={'Authorization': 'Bearer tok-123'}
+        ):
+            result = app_auth.check_auth_needed('s')
+            assert result is None
+            assert g.auth_role == 'admin'
+
+    def test_wrong_token_rejected(self, app, monkeypatch):
+        import config
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(config, 'API_TOKEN', 'tok-123')
+        with app.test_request_context(
+            '/api/foo', headers={'Authorization': 'Bearer wrong'}
+        ):
+            result = app_auth.check_auth_needed('s')
+        assert result is not None
+        assert result[1] == 401

--- a/test/unit/test_config_centralization.py
+++ b/test/unit/test_config_centralization.py
@@ -1,0 +1,98 @@
+"""Guards for centralized RQ/radius config defaults.
+
+Each of RQ_MAX_JOBS, RQ_MAX_JOBS_HIGH, RQ_LOGGING_LEVEL and
+RADIUS_INSTRUMENTATION must be defined once (with its default) in config.py and
+honored from its environment variable. Importer modules must consume
+config.<NAME> without re-introducing a second default.
+"""
+import importlib
+import os
+import re
+
+import pytest
+
+import config
+
+
+# (attr_name, default_value, env_var, env_value_to_set, expected_after_reload)
+_DEFAULTS = (
+    ('RQ_MAX_JOBS', 50, 'RQ_MAX_JOBS', '7', 7),
+    ('RQ_MAX_JOBS_HIGH', 100, 'RQ_MAX_JOBS_HIGH', '13', 13),
+    ('RQ_LOGGING_LEVEL', 'INFO', 'RQ_LOGGING_LEVEL', 'debug', 'DEBUG'),
+    ('RADIUS_INSTRUMENTATION', False, 'RADIUS_INSTRUMENTATION', 'True', True),
+)
+
+
+@pytest.mark.parametrize(
+    'attr,default', [(d[0], d[1]) for d in _DEFAULTS], ids=[d[0] for d in _DEFAULTS]
+)
+def test_attribute_exists_with_default(attr, default):
+    assert hasattr(config, attr), f"config.{attr} missing"
+    # Reload with the env var unset so we observe the documented default.
+    env_var = next(d[2] for d in _DEFAULTS if d[0] == attr)
+    saved = os.environ.pop(env_var, None)
+    try:
+        reloaded = importlib.reload(config)
+        assert getattr(reloaded, attr) == default
+    finally:
+        if saved is not None:
+            os.environ[env_var] = saved
+        importlib.reload(config)
+
+
+@pytest.mark.parametrize(
+    'attr,_default,env_var,env_value,expected',
+    list(_DEFAULTS),
+    ids=[d[0] for d in _DEFAULTS],
+)
+def test_attribute_honors_env(attr, _default, env_var, env_value, expected, monkeypatch):
+    monkeypatch.setenv(env_var, env_value)
+    try:
+        reloaded = importlib.reload(config)
+        assert getattr(reloaded, attr) == expected
+    finally:
+        monkeypatch.delenv(env_var, raising=False)
+        importlib.reload(config)
+
+
+def _read_source(relative_path):
+    repo_root = os.path.normpath(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+    )
+    with open(os.path.join(repo_root, relative_path), encoding='utf-8') as fh:
+        return fh.read()
+
+
+# module -> names it actually consumes from config
+_IMPORTERS = {
+    'rq_worker.py': ('RQ_MAX_JOBS', 'RQ_LOGGING_LEVEL'),
+    'rq_worker_high_priority.py': ('RQ_MAX_JOBS_HIGH', 'RQ_LOGGING_LEVEL'),
+    'tasks/radius_walk_helper.py': ('RADIUS_INSTRUMENTATION',),
+    'tasks/ivf_manager.py': ('RADIUS_INSTRUMENTATION',),
+}
+
+
+@pytest.mark.parametrize('relative_path,names', sorted(_IMPORTERS.items()))
+def test_importer_references_config_name(relative_path, names):
+    src = _read_source(relative_path)
+    for name in names:
+        assert name in src, f"{relative_path} no longer references {name}"
+
+
+@pytest.mark.parametrize('relative_path,names', sorted(_IMPORTERS.items()))
+def test_importer_has_no_local_default(relative_path, names):
+    src = _read_source(relative_path)
+    for name in names:
+        env_pat = re.compile(
+            r"os\.(?:environ\.get|getenv)\(\s*['\"]" + re.escape(name) + r"['\"]"
+        )
+        assert not env_pat.search(src), (
+            f"{relative_path} re-reads env for {name}; must use config.{name}"
+        )
+        getattr_pat = re.compile(
+            r"getattr\(\s*config\s*,\s*['\"]" + re.escape(name) + r"['\"]\s*,"
+        )
+        assert not getattr_pat.search(src), (
+            f"{relative_path} has a getattr fallback default for {name}; "
+            f"must use config.{name} directly"
+        )

--- a/test/unit/test_input_bound_caps.py
+++ b/test/unit/test_input_bound_caps.py
@@ -88,9 +88,6 @@ class TestIvfSimilarTracksNCoercion:
         assert resp.status_code != 500
         assert backend.call_args.kwargs['n'] == 7
 
-    @pytest.mark.xfail(strict=True, reason="app_ivf get_similar_tracks_endpoint does not clamp "
-                       "a negative 'n'; it is forwarded verbatim to find_nearest_neighbors_by_id "
-                       "(app_ivf.py:321).")
     def test_negative_n_is_clamped_to_a_valid_bound(self, client):
         with patch.object(app_ivf, 'find_nearest_neighbors_by_id', return_value=[]) as backend:
             client.get('/api/similar_tracks', query_string={'item_id': 'x', 'n': -5})
@@ -141,10 +138,6 @@ class TestIvfCreatePlaylistName:
         assert resp.status_code == 400
         backend.assert_not_called()
 
-    @pytest.mark.xfail(strict=True, reason="app_ivf create_media_server_playlist only does "
-                       "'if not playlist_name' (empty check); a non-string truthy name (int/list) "
-                       "passes and is forwarded to create_playlist_from_ids, returning 201 instead "
-                       "of a 4xx (app_ivf.py:564). PR.md theme #5 claims a name type check.")
     def test_non_string_name_rejected_4xx(self, client):
         with patch.object(app_ivf, 'create_playlist_from_ids', return_value='pid') as backend:
             resp = client.post('/api/create_playlist',
@@ -168,10 +161,6 @@ class TestAlchemyAnchorName:
         assert resp.status_code == 400
         backend.assert_not_called()
 
-    @pytest.mark.xfail(strict=True, reason="app_alchemy create_anchor does "
-                       "(payload.get('name') or '').strip() which raises AttributeError on a "
-                       "non-string name, producing a 500 instead of a 4xx validation error "
-                       "(app_alchemy.py:294). rename_anchor (app_alchemy.py:365) shares the bug.")
     def test_non_string_name_rejected_4xx(self, alchemy_client):
         with patch('database.save_alchemy_anchor', return_value={'id': 1, 'name': 'n'}) as backend:
             resp = alchemy_client.post('/api/anchors',

--- a/test/unit/test_input_bound_caps.py
+++ b/test/unit/test_input_bound_caps.py
@@ -1,0 +1,180 @@
+"""Input-validation / bound-cap tests for PR.md theme #5.
+
+Covers the search 'limit' caps (500 tracks in app_ivf, 100 artists in
+app_artist_similarity), 'n' coercion+clamping (app_alchemy /api/alchemy,
+app_ivf /api/similar_tracks), and playlist/anchor name type+empty checks
+(app_ivf /api/create_playlist, app_alchemy /api/anchors).
+
+The backend index/db calls are patched per test so no real backend runs;
+every assertion checks the value actually handed to the (mocked) backend,
+or the HTTP status, so none of them are tautologies.
+"""
+from unittest.mock import patch
+import pytest
+from flask import Flask
+
+import config
+import app_ivf
+import app_artist_similarity
+import app_alchemy
+
+
+@pytest.fixture
+def client():
+    app = Flask(__name__)
+    app.register_blueprint(app_ivf.ivf_bp)
+    app.register_blueprint(app_artist_similarity.artist_similarity_bp)
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+@pytest.fixture
+def alchemy_client():
+    app = Flask(__name__)
+    app.register_blueprint(app_alchemy.alchemy_bp)
+    app.config['TESTING'] = True
+    return app.test_client()
+
+
+class TestIvfSearchLimitCap:
+    def test_huge_end_is_capped_to_500(self, client):
+        with patch.object(app_ivf, 'search_tracks_unified', return_value=[]) as backend:
+            resp = client.get('/api/search_tracks',
+                              query_string={'search_query': 'a', 'start': 0, 'end': 999999})
+        assert resp.status_code == 200
+        used = backend.call_args.kwargs['limit']
+        assert used == 500
+        assert used < 999999
+
+    def test_small_range_is_not_inflated(self, client):
+        with patch.object(app_ivf, 'search_tracks_unified', return_value=[]) as backend:
+            resp = client.get('/api/search_tracks',
+                              query_string={'search_query': 'a', 'start': 0, 'end': 30})
+        assert resp.status_code == 200
+        assert backend.call_args.kwargs['limit'] == 30
+
+
+class TestArtistSearchLimitCap:
+    def test_huge_end_is_capped_to_100(self, client):
+        with patch.object(app_artist_similarity, 'search_artists_by_name', return_value=[]) as backend:
+            resp = client.get('/api/search_artists',
+                              query_string={'query': 'ab', 'start': 0, 'end': 999999})
+        assert resp.status_code == 200
+        used = backend.call_args.kwargs['limit']
+        assert used == 100
+        assert used < 999999
+
+    def test_small_range_is_not_inflated(self, client):
+        with patch.object(app_artist_similarity, 'search_artists_by_name', return_value=[]) as backend:
+            resp = client.get('/api/search_artists',
+                              query_string={'query': 'ab', 'start': 0, 'end': 25})
+        assert resp.status_code == 200
+        assert backend.call_args.kwargs['limit'] == 25
+
+
+class TestIvfSimilarTracksNCoercion:
+    def test_non_numeric_n_falls_back_to_default_not_500(self, client):
+        with patch.object(app_ivf, 'find_nearest_neighbors_by_id', return_value=[]) as backend:
+            resp = client.get('/api/similar_tracks',
+                              query_string={'item_id': 'x', 'n': 'notanint'})
+        # 404 because the (mocked) search found nothing -- never a 500/crash.
+        assert resp.status_code != 500
+        assert backend.call_args.kwargs['n'] == 10
+
+    def test_valid_n_is_passed_through(self, client):
+        with patch.object(app_ivf, 'find_nearest_neighbors_by_id', return_value=[]) as backend:
+            resp = client.get('/api/similar_tracks',
+                              query_string={'item_id': 'x', 'n': 7})
+        assert resp.status_code != 500
+        assert backend.call_args.kwargs['n'] == 7
+
+    @pytest.mark.xfail(strict=True, reason="app_ivf get_similar_tracks_endpoint does not clamp "
+                       "a negative 'n'; it is forwarded verbatim to find_nearest_neighbors_by_id "
+                       "(app_ivf.py:321).")
+    def test_negative_n_is_clamped_to_a_valid_bound(self, client):
+        with patch.object(app_ivf, 'find_nearest_neighbors_by_id', return_value=[]) as backend:
+            client.get('/api/similar_tracks', query_string={'item_id': 'x', 'n': -5})
+        assert backend.call_args.kwargs['n'] >= 1
+
+
+class TestAlchemyNClamp:
+    def test_huge_n_is_clamped_to_max(self, alchemy_client):
+        with patch.object(app_alchemy, 'song_alchemy', return_value={'results': []}) as backend, \
+                patch.object(app_alchemy, 'attach_song_features'):
+            resp = alchemy_client.post('/api/alchemy',
+                                       json={'items': [{'op': 'ADD', 'id': 's1'}], 'n': 999999})
+        assert resp.status_code == 200
+        used = backend.call_args.kwargs['n_results']
+        assert used == config.ALCHEMY_MAX_N_RESULTS
+        assert used < 999999
+
+    def test_non_numeric_n_falls_back_to_default(self, alchemy_client):
+        with patch.object(app_alchemy, 'song_alchemy', return_value={'results': []}) as backend, \
+                patch.object(app_alchemy, 'attach_song_features'):
+            resp = alchemy_client.post('/api/alchemy',
+                                       json={'items': [{'op': 'ADD', 'id': 's1'}], 'n': 'notanint'})
+        assert resp.status_code == 200
+        assert backend.call_args.kwargs['n_results'] == config.ALCHEMY_DEFAULT_N_RESULTS
+
+    def test_negative_n_is_clamped_to_min_one(self, alchemy_client):
+        with patch.object(app_alchemy, 'song_alchemy', return_value={'results': []}) as backend, \
+                patch.object(app_alchemy, 'attach_song_features'):
+            resp = alchemy_client.post('/api/alchemy',
+                                       json={'items': [{'op': 'ADD', 'id': 's1'}], 'n': -7})
+        assert resp.status_code == 200
+        used = backend.call_args.kwargs['n_results']
+        assert used == 1
+        assert used >= 1
+
+
+class TestIvfCreatePlaylistName:
+    def test_empty_name_rejected_400(self, client):
+        with patch.object(app_ivf, 'create_playlist_from_ids') as backend:
+            resp = client.post('/api/create_playlist',
+                               json={'playlist_name': '', 'track_ids': ['a']})
+        assert resp.status_code == 400
+        backend.assert_not_called()
+
+    def test_missing_name_rejected_400(self, client):
+        with patch.object(app_ivf, 'create_playlist_from_ids') as backend:
+            resp = client.post('/api/create_playlist', json={'track_ids': ['a']})
+        assert resp.status_code == 400
+        backend.assert_not_called()
+
+    @pytest.mark.xfail(strict=True, reason="app_ivf create_media_server_playlist only does "
+                       "'if not playlist_name' (empty check); a non-string truthy name (int/list) "
+                       "passes and is forwarded to create_playlist_from_ids, returning 201 instead "
+                       "of a 4xx (app_ivf.py:564). PR.md theme #5 claims a name type check.")
+    def test_non_string_name_rejected_4xx(self, client):
+        with patch.object(app_ivf, 'create_playlist_from_ids', return_value='pid') as backend:
+            resp = client.post('/api/create_playlist',
+                               json={'playlist_name': 123, 'track_ids': ['a']})
+        assert 400 <= resp.status_code < 500
+        backend.assert_not_called()
+
+
+class TestAlchemyAnchorName:
+    def test_empty_name_rejected_400(self, alchemy_client):
+        with patch('database.save_alchemy_anchor') as backend:
+            resp = alchemy_client.post('/api/anchors',
+                                       json={'name': '', 'centroid': [1.0, 2.0]})
+        assert resp.status_code == 400
+        backend.assert_not_called()
+
+    def test_whitespace_name_rejected_400(self, alchemy_client):
+        with patch('database.save_alchemy_anchor') as backend:
+            resp = alchemy_client.post('/api/anchors',
+                                       json={'name': '   ', 'centroid': [1.0, 2.0]})
+        assert resp.status_code == 400
+        backend.assert_not_called()
+
+    @pytest.mark.xfail(strict=True, reason="app_alchemy create_anchor does "
+                       "(payload.get('name') or '').strip() which raises AttributeError on a "
+                       "non-string name, producing a 500 instead of a 4xx validation error "
+                       "(app_alchemy.py:294). rename_anchor (app_alchemy.py:365) shares the bug.")
+    def test_non_string_name_rejected_4xx(self, alchemy_client):
+        with patch('database.save_alchemy_anchor', return_value={'id': 1, 'name': 'n'}) as backend:
+            resp = alchemy_client.post('/api/anchors',
+                                       json={'name': 123, 'centroid': [1.0, 2.0]})
+        assert 400 <= resp.status_code < 500
+        backend.assert_not_called()

--- a/test/unit/test_ivf_fetch_batches.py
+++ b/test/unit/test_ivf_fetch_batches.py
@@ -1,0 +1,199 @@
+"""
+Unit tests for tasks/ivf_manager.py batched fetch helpers.
+
+Covers:
+- _fetch_in_batches: empty input, single batch, multi-batch merge, and the
+  sequential-execution regression guard (batches must run on the calling thread,
+  not fanned out across a thread pool that would share one psycopg2 connection).
+- _fetch_details_map: builds an id->details map from a mock cursor.
+- SCORE_DETAIL_COLUMNS constant value.
+"""
+
+import os
+import sys
+import threading
+
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from conftest import make_dict_row, make_mock_connection
+
+
+# =============================================================================
+# SCORE_DETAIL_COLUMNS CONSTANT
+# =============================================================================
+
+class TestScoreDetailColumns:
+
+    def test_constant_value(self):
+        from tasks.ivf_manager import SCORE_DETAIL_COLUMNS
+
+        assert SCORE_DETAIL_COLUMNS == 'title, author'
+
+
+# =============================================================================
+# _fetch_in_batches
+# =============================================================================
+
+class TestFetchInBatches:
+
+    def test_empty_item_ids_returns_empty_dict_no_call(self):
+        """Empty item_ids should return an empty dict and never call fetch fn."""
+        from tasks.ivf_manager import _fetch_in_batches
+
+        fetch_fn = MagicMock(return_value={'unexpected': 1})
+
+        result = _fetch_in_batches([], fetch_fn)
+
+        assert result == {}
+        fetch_fn.assert_not_called()
+
+    def test_single_batch_calls_fetch_once(self):
+        """<= BATCH_SIZE_DB_OPS ids -> one call, result passed through."""
+        from tasks.ivf_manager import _fetch_in_batches, BATCH_SIZE_DB_OPS
+
+        ids = [f'id-{i}' for i in range(BATCH_SIZE_DB_OPS)]
+        expected = {i: {'v': i} for i in ids}
+        fetch_fn = MagicMock(return_value=expected)
+
+        result = _fetch_in_batches(ids, fetch_fn)
+
+        assert result == expected
+        assert fetch_fn.call_count == 1
+        # The single call received the full list of ids.
+        called_batch = fetch_fn.call_args[0][0]
+        assert called_batch == ids
+
+    def test_multiple_batches_split_and_merge(self):
+        """250 ids with batch size 100 -> 3 chunks, merged into one dict."""
+        from tasks.ivf_manager import _fetch_in_batches, BATCH_SIZE_DB_OPS
+
+        assert BATCH_SIZE_DB_OPS == 100
+        n = 250
+        ids = [f'id-{i}' for i in range(n)]
+
+        batches_seen = []
+
+        def fetch_fn(batch):
+            batches_seen.append(list(batch))
+            return {item: {'idx': item} for item in batch}
+
+        result = _fetch_in_batches(ids, fetch_fn)
+
+        # ceil(250 / 100) == 3 chunks.
+        assert len(batches_seen) == 3
+        assert [len(b) for b in batches_seen] == [100, 100, 50]
+
+        # Every id present exactly once in the merged result.
+        assert len(result) == n
+        for item in ids:
+            assert result[item] == {'idx': item}
+
+        # Chunks are contiguous and cover the whole input in order.
+        rejoined = [item for batch in batches_seen for item in batch]
+        assert rejoined == ids
+
+    def test_batches_run_sequentially_on_calling_thread(self):
+        """REGRESSION GUARD: batches must run on the calling thread, not a pool.
+
+        The old code fanned batches out via a ThreadPoolExecutor; because the
+        batches share one psycopg2 connection (not concurrency-safe) the fix
+        made execution strictly sequential on the caller's thread.
+        """
+        from tasks.ivf_manager import _fetch_in_batches
+
+        n = 250
+        ids = [f'id-{i}' for i in range(n)]
+        test_ident = threading.get_ident()
+        idents_seen = []
+
+        def fetch_fn(batch):
+            idents_seen.append(threading.get_ident())
+            return {item: 1 for item in batch}
+
+        _fetch_in_batches(ids, fetch_fn)
+
+        # More than one batch ran (so a pool would have shown other idents).
+        assert len(idents_seen) == 3
+        assert all(ident == test_ident for ident in idents_seen)
+
+    def test_later_batch_keys_override_earlier(self):
+        """merged.update semantics: identical keys in a later batch win."""
+        from tasks.ivf_manager import _fetch_in_batches
+
+        ids = [f'id-{i}' for i in range(150)]
+
+        def fetch_fn(batch):
+            # Every batch claims the same shared key; later call must win.
+            out = {item: 'own' for item in batch}
+            out['shared'] = batch[0]
+            return out
+
+        result = _fetch_in_batches(ids, fetch_fn)
+
+        # Second (final) batch starts at id-100.
+        assert result['shared'] == 'id-100'
+
+
+# =============================================================================
+# _fetch_details_map
+# =============================================================================
+
+class TestFetchDetailsMap:
+
+    def _make_conn(self, rows):
+        cursor = MagicMock()
+        cursor.fetchall.return_value = rows
+        cursor.__enter__.return_value = cursor
+        cursor.__exit__.return_value = False
+        conn = make_mock_connection(cursor)
+        # cursor() is used as a context manager: with conn.cursor(...) as cur
+        conn.cursor.return_value.__enter__.return_value = cursor
+        conn.cursor.return_value.__exit__.return_value = False
+        return conn, cursor
+
+    def test_builds_id_to_details_map(self):
+        from tasks.ivf_manager import _fetch_details_map
+
+        rows = [
+            make_dict_row({'item_id': 'a', 'title': 'Song A', 'author': 'Artist A'}),
+            make_dict_row({'item_id': 'b', 'title': 'Song B', 'author': 'Artist B'}),
+        ]
+        conn, cursor = self._make_conn(rows)
+
+        result = _fetch_details_map(conn, ['a', 'b'], 'title, author')
+
+        assert result == {
+            'a': {'title': 'Song A', 'author': 'Artist A'},
+            'b': {'title': 'Song B', 'author': 'Artist B'},
+        }
+        cursor.execute.assert_called_once()
+        query, params = cursor.execute.call_args[0]
+        assert 'SELECT item_id, title, author FROM score' in query
+        assert 'item_id = ANY(%s)' in query
+        assert params == (['a', 'b'],)
+
+    def test_respects_passed_column_list(self):
+        """Only the columns named in the list should appear in each detail dict."""
+        from tasks.ivf_manager import _fetch_details_map
+
+        rows = [
+            make_dict_row({'item_id': 'x', 'title': 'T', 'author': 'X'}),
+        ]
+        conn, cursor = self._make_conn(rows)
+
+        result = _fetch_details_map(conn, ['x'], 'title')
+
+        assert result == {'x': {'title': 'T'}}
+        assert 'author' not in result['x']
+
+    def test_empty_item_ids_no_query(self):
+        """No ids -> no batch, so the cursor is never opened or executed."""
+        from tasks.ivf_manager import _fetch_details_map
+
+        conn, cursor = self._make_conn([])
+
+        result = _fetch_details_map(conn, [], 'title, author')
+
+        assert result == {}
+        cursor.execute.assert_not_called()

--- a/test/unit/test_ivf_fetch_batches.py
+++ b/test/unit/test_ivf_fetch_batches.py
@@ -109,7 +109,7 @@ class TestFetchInBatches:
 
         def fetch_fn(batch):
             idents_seen.append(threading.get_ident())
-            return {item: 1 for item in batch}
+            return dict.fromkeys(batch, 1)
 
         _fetch_in_batches(ids, fetch_fn)
 
@@ -125,7 +125,7 @@ class TestFetchInBatches:
 
         def fetch_fn(batch):
             # Every batch claims the same shared key; later call must win.
-            out = {item: 'own' for item in batch}
+            out = dict.fromkeys(batch, 'own')
             out['shared'] = batch[0]
             return out
 
@@ -180,7 +180,7 @@ class TestFetchDetailsMap:
         rows = [
             make_dict_row({'item_id': 'x', 'title': 'T', 'author': 'X'}),
         ]
-        conn, cursor = self._make_conn(rows)
+        conn, _ = self._make_conn(rows)
 
         result = _fetch_details_map(conn, ['x'], 'title')
 

--- a/test/unit/test_misc_correctness.py
+++ b/test/unit/test_misc_correctness.py
@@ -1,0 +1,184 @@
+"""Unit tests for two correctness fixes (PR theme #13).
+
+1. tasks/ai/providers/mistral.py: the Mistral request timeout must be derived
+   from config.AI_REQUEST_TIMEOUT_SECONDS * 1000 (milliseconds), not a
+   hardcoded constant. The timeout_ms kwarg passed to chat.complete must scale
+   with the configured value.
+
+2. query/brainstorm_real_gmm_080.py: fit_gmm_bic caps the GMM component count
+   at len(X), so a GaussianMixture is never fit with n_components > sample
+   count (which would crash) even when a larger K range is requested.
+
+Heavy / missing deps are stubbed; no real network or DB access occurs.
+"""
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, Mock, patch
+
+import numpy as np
+
+
+_REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+)
+
+
+def _ensure_namespace_pkg(name: str, sub_path: str) -> None:
+    if name in sys.modules:
+        return
+    pkg = types.ModuleType(name)
+    pkg.__path__ = [os.path.join(_REPO_ROOT, sub_path)]
+    sys.modules[name] = pkg
+
+
+def _ensure_mistralai_stub():
+    if 'mistralai' in sys.modules:
+        return
+    try:
+        import mistralai  # noqa: F401
+        return
+    except (ImportError, ModuleNotFoundError):
+        pass
+    mod = types.ModuleType('mistralai')
+    mod.Mistral = MagicMock
+    sys.modules['mistralai'] = mod
+
+
+def _load_submodule(name: str, relpath: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_REPO_ROOT, relpath)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_ensure_namespace_pkg('tasks', 'tasks')
+_ensure_namespace_pkg('tasks.ai', 'tasks/ai')
+_ensure_namespace_pkg('tasks.ai.providers', 'tasks/ai/providers')
+_ensure_mistralai_stub()
+
+mistral_mod = _load_submodule(
+    'tasks.ai.providers.mistral', 'tasks/ai/providers/mistral.py'
+)
+
+
+def _load_brainstorm_gmm():
+    name = 'brainstorm_real_gmm_080'
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_REPO_ROOT, 'query', 'brainstorm_real_gmm_080.py')
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _mock_mistral_client():
+    """Build a Mistral client mock whose chat.complete records its kwargs."""
+    mock_message = Mock()
+    mock_message.content = "Generated Name"
+    mock_choice = Mock()
+    mock_choice.message = mock_message
+    mock_response = Mock()
+    mock_response.choices = [mock_choice]
+
+    mock_chat = Mock()
+    mock_chat.complete.return_value = mock_response
+
+    mock_client = Mock()
+    mock_client.chat = mock_chat
+    return mock_client, mock_chat
+
+
+# ---------------------------------------------------------------------------
+# (1) Mistral timeout scales with config.AI_REQUEST_TIMEOUT_SECONDS
+# ---------------------------------------------------------------------------
+
+class TestMistralTimeoutScaling:
+    def _invoke_and_capture_timeout(self, timeout_seconds):
+        import config as cfg
+        cfg.AI_REQUEST_TIMEOUT_SECONDS = timeout_seconds
+
+        mock_client, mock_chat = _mock_mistral_client()
+        with patch('mistralai.Mistral', return_value=mock_client), \
+                patch.object(mistral_mod.time, 'sleep'):
+            result = mistral_mod.generate_text(
+                api_key="valid-key",
+                model_name="ministral-3b-latest",
+                full_prompt="Create a name",
+                skip_delay=True,
+            )
+        assert result == "Generated Name"
+        assert mock_chat.complete.called
+        _, kwargs = mock_chat.complete.call_args
+        return kwargs
+
+    def test_timeout_is_30000_for_30_seconds(self):
+        kwargs = self._invoke_and_capture_timeout(30)
+        assert 'timeout_ms' in kwargs
+        assert kwargs['timeout_ms'] == 30000
+        # Guard against the old hardcoded value.
+        assert kwargs['timeout_ms'] != 960
+
+    def test_timeout_is_300000_for_default_300_seconds(self):
+        kwargs = self._invoke_and_capture_timeout(300)
+        assert kwargs['timeout_ms'] == 300000
+
+    def test_timeout_scales_linearly(self):
+        k15 = self._invoke_and_capture_timeout(15)
+        k60 = self._invoke_and_capture_timeout(60)
+        assert k15['timeout_ms'] == 15000
+        assert k60['timeout_ms'] == 60000
+        assert k60['timeout_ms'] == 4 * k15['timeout_ms']
+
+    def test_timeout_not_hardcoded_960(self):
+        # The pre-fix bug hardcoded the timeout to 960; any config value other
+        # than 0.96s must therefore produce a different timeout_ms.
+        for seconds in (1, 10, 45, 120):
+            kwargs = self._invoke_and_capture_timeout(seconds)
+            assert kwargs['timeout_ms'] == seconds * 1000
+
+
+# ---------------------------------------------------------------------------
+# (2) GMM component count is capped at len(X)
+# ---------------------------------------------------------------------------
+
+class TestGmmComponentCap:
+    def test_k_capped_at_sample_count(self):
+        mod = _load_brainstorm_gmm()
+        X = np.array([[0.0, 0.0, 1.0], [1.0, 1.0, 0.0]], dtype=np.float64)
+        # Request many more components than samples.
+        best_gmm, best_k, bic_values = mod.fit_gmm_bic(X, k_range=range(2, 50))
+
+        assert best_gmm is not None
+        assert best_gmm.n_components <= len(X)
+        assert best_k <= len(X)
+        # No K above the sample count may have been evaluated.
+        assert all(k <= len(X) for k in bic_values)
+
+    def test_does_not_crash_with_tiny_X(self):
+        mod = _load_brainstorm_gmm()
+        X = np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float64)
+        best_gmm, best_k, bic_values = mod.fit_gmm_bic(X, k_range=range(2, 100))
+        assert best_gmm is not None
+        assert best_gmm.n_components <= len(X)
+        # With exactly 2 samples and a min K of 2, only K=2 is admissible.
+        assert best_k == len(X)
+        assert set(bic_values) == {2}
+
+    def test_larger_X_uses_full_range_within_cap(self):
+        mod = _load_brainstorm_gmm()
+        rng = np.random.RandomState(0)
+        X = rng.rand(6, 4).astype(np.float64)
+        _, best_k, bic_values = mod.fit_gmm_bic(X, k_range=range(2, 5))
+        # cap = min(stop-1, len(X)) = min(4, 6) = 4; range start is 2.
+        assert set(bic_values) == {2, 3, 4}
+        assert best_k <= len(X)

--- a/test/unit/test_misc_correctness.py
+++ b/test/unit/test_misc_correctness.py
@@ -39,7 +39,7 @@ def _ensure_mistralai_stub():
     try:
         import mistralai  # noqa: F401
         return
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         pass
     mod = types.ModuleType('mistralai')
     mod.Mistral = MagicMock

--- a/test/unit/test_native_supervisor.py
+++ b/test/unit/test_native_supervisor.py
@@ -1,0 +1,307 @@
+"""Unit tests for the native-build ProcessSupervisor concurrency guards.
+
+Covers PR theme #11 (native supervisor stop/boot race) for whichever
+per-platform supervisor module imports cleanly on the host running the suite:
+
+  (a) _join_workers skips the CURRENT thread (and, on Windows, the MAIN thread)
+      so teardown never blocks on a thread that parks forever.
+  (b) _start_health_loop CLEARS the stop event before spawning, so a restart
+      after stop_all yields a LIVE health thread instead of one that exits at
+      once on a stale set event.
+  (c) start_child / start_in_background refuse to spawn once a stop is in
+      progress, so a stop racing a boot cannot orphan a child process.
+
+CI runs on Linux; native-build/linux/supervisor.py is the reference and always
+imports. macOS/Windows supervisors may pull platform-only deps -- each is loaded
+in isolation and SKIPPED cleanly if it cannot import here.
+"""
+import importlib.util
+import os
+import sys
+import threading
+import time
+
+import pytest
+
+REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+)
+NATIVE_BUILD = os.path.join(REPO_ROOT, 'native-build')
+
+# Windows is the only supervisor whose _join_workers also skips the main thread
+# (its console `start` runs the boot on the main thread, which then parks).
+SKIPS_MAIN_THREAD = {'windows'}
+
+
+def _ensure_path(entry):
+    if entry not in sys.path:
+        sys.path.insert(0, entry)
+
+
+def _load_supervisor(platform_name):
+    """Load one platform supervisor in isolation; skip if it cannot import here."""
+    _ensure_path(REPO_ROOT)
+    _ensure_path(NATIVE_BUILD)
+    mod_name = 'native_supervisor_under_test_' + platform_name
+    path = os.path.join(NATIVE_BUILD, platform_name, 'supervisor.py')
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        sys.modules.pop(mod_name, None)
+        pytest.skip(f"{platform_name} supervisor does not import on this platform: {exc!r}")
+    return mod
+
+
+def _bare_supervisor(mod):
+    """Build a ProcessSupervisor without running __init__ (no socket / log file).
+
+    Only the attributes touched by the guards under test are populated.
+    """
+    sup = mod.ProcessSupervisor.__new__(mod.ProcessSupervisor)
+    sup._lock = threading.RLock()
+    sup._children = {}
+    sup._desired = set()
+    sup._state = 'stopped'
+    sup._stop_requested = threading.Event()
+    sup._health_stop = threading.Event()
+    sup._health_thread = None
+    sup._boot_thread = None
+    sup._database_url = 'postgresql://unused'
+    sup._redis_url = 'redis://unused'
+    sup._db_conn = 'postgresql://unused'
+
+    class _Log:
+        def __getattr__(self, _name):
+            return lambda *a, **k: None
+    sup._log = _Log()
+    return sup
+
+
+# Parametrize across every supervisor; non-importing ones skip inside the loader.
+PLATFORMS = ['linux', 'macos', 'windows']
+
+
+@pytest.fixture(params=PLATFORMS)
+def supervisor_case(request):
+    platform_name = request.param
+    mod = _load_supervisor(platform_name)
+    return platform_name, mod
+
+
+# ---------------------------------------------------------------------------
+# (a) _join_workers thread-skip guards
+# ---------------------------------------------------------------------------
+
+class TestJoinWorkersSkips:
+    def test_returns_promptly_when_boot_thread_is_current(self, supervisor_case):
+        """_join_workers must not block on the calling (current) thread."""
+        _platform, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+        sup._boot_thread = threading.current_thread()
+        sup._health_thread = None
+        start = time.time()
+        sup._join_workers()
+        assert time.time() - start < 1.0
+
+    def test_alive_non_current_thread_would_be_joined(self, supervisor_case):
+        """A sentinel proves a non-current, non-main alive thread IS joined,
+        so the current-thread skip is a real skip and not a no-op everywhere."""
+        _platform, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+        release = threading.Event()
+        joined = threading.Event()
+
+        def _sentinel_body():
+            release.wait(2)
+
+        sentinel = threading.Thread(target=_sentinel_body, name='sentinel', daemon=True)
+        sentinel.start()
+        sup._boot_thread = sentinel
+        sup._health_thread = None
+
+        def _runner():
+            sup._join_workers()
+            joined.set()
+
+        runner = threading.Thread(target=_runner, name='join-runner', daemon=True)
+        runner.start()
+        # Sentinel is still alive (release not set) -> the joiner must be blocked.
+        assert not joined.wait(0.5)
+        release.set()
+        assert joined.wait(2.0)
+        sentinel.join(2)
+
+    def test_skips_main_thread_only_on_windows(self, supervisor_case):
+        """Windows boots on the main thread (which then parks forever), so its
+        _join_workers must skip the main thread. The other supervisors do not."""
+        platform_name, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+        sup._boot_thread = threading.main_thread()
+        sup._health_thread = None
+
+        done = threading.Event()
+
+        def _runner():
+            sup._join_workers()
+            done.set()
+
+        runner = threading.Thread(target=_runner, name='main-skip-runner', daemon=True)
+        runner.start()
+
+        if platform_name in SKIPS_MAIN_THREAD:
+            # Main thread is alive but must be skipped -> returns promptly.
+            assert done.wait(1.0)
+        else:
+            # No main-thread skip: the alive main thread is joined, so the worker
+            # parks on the 30s join timeout and does not finish promptly.
+            assert not done.wait(0.5)
+        runner.join(1)
+
+
+# ---------------------------------------------------------------------------
+# (b) _start_health_loop clears the stop event
+# ---------------------------------------------------------------------------
+
+class TestStartHealthLoopClearsStop:
+    def test_clears_preset_stop_and_spawns_live_thread(self, supervisor_case, monkeypatch):
+        platform_name, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+        sup._state = 'running'
+
+        body_ran = threading.Event()
+
+        # Make the loop body harmless and observable, and make the wait
+        # non-blocking so the spawned thread iterates quickly regardless of the
+        # platform's wait interval.
+        def _record_and_stop(*_a, **_k):
+            body_ran.set()
+            sup._health_stop.set()
+
+        # Linux/macOS health loop calls these infra checks each iteration.
+        for name in ('_ensure_postgres_healthy', '_ensure_redis_healthy'):
+            if hasattr(sup, name):
+                monkeypatch.setattr(sup, name, _record_and_stop)
+        # Windows loop body issues an HTTP poll; neutralize and observe it.
+        if hasattr(mod, 'urllib'):
+            monkeypatch.setattr(mod.urllib.request, 'urlopen', _record_and_stop)
+
+        # Pre-set the stop event: a stale set event is exactly the restart bug.
+        sup._health_stop.set()
+        assert sup._health_stop.is_set()
+
+        real_event = sup._health_stop
+        non_blocking_wait = lambda timeout=None: real_event.is_set()
+        monkeypatch.setattr(real_event, 'wait', non_blocking_wait)
+
+        try:
+            sup._start_health_loop()
+            # The guard under test: the stop event was cleared before spawning.
+            # (The loop body re-sets it via _record_and_stop once it runs.)
+            assert sup._health_thread is not None
+            assert sup._health_thread.is_alive() or body_ran.is_set()
+            assert body_ran.wait(2.0), "spawned health loop body never executed"
+        finally:
+            real_event.set()
+            if sup._health_thread is not None:
+                sup._health_thread.join(2)
+
+
+# ---------------------------------------------------------------------------
+# (c) spawn refused once a stop is in progress
+# ---------------------------------------------------------------------------
+
+class TestSpawnRefusedWhileStopping:
+    def test_start_child_refuses_when_stopping(self, supervisor_case, monkeypatch):
+        """A stop racing a boot must not create a child: with state == stopping,
+        start_child returns False and never calls subprocess.Popen."""
+        _platform, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+
+        popen_calls = []
+
+        def _fake_popen(*a, **k):
+            popen_calls.append((a, k))
+            raise AssertionError("Popen must not be called once stopping")
+
+        monkeypatch.setattr(mod.subprocess, 'Popen', _fake_popen)
+
+        sup._state = 'stopping'
+        sup._stop_requested.set()
+
+        result = sup.start_child('flask')
+        assert result is False
+        assert popen_calls == []
+        assert 'flask' not in sup._children
+        assert 'flask' not in sup._desired
+
+    def test_start_child_allowed_while_starting(self, supervisor_case, monkeypatch):
+        """Sanity: the guard is state-specific -- in the 'starting' state the
+        child IS marked desired (proving the refusal is the stop, not a blanket
+        block). Popen is mocked so no real process spawns."""
+        platform_name, mod = supervisor_case
+        sup = _bare_supervisor(mod)
+
+        class _FakePopen:
+            def __init__(self, *a, **k):
+                self.pid = 4321
+                self.stdout = None
+
+            def poll(self):
+                return None
+
+        monkeypatch.setattr(mod.subprocess, 'Popen', _FakePopen)
+        # Neutralize platform side effects reached only after the guard passes.
+        for name in ('_terminate_named',):
+            if hasattr(sup, name):
+                monkeypatch.setattr(sup, name, lambda *a, **k: None)
+        if hasattr(mod, 'threading'):
+            monkeypatch.setattr(mod.threading, 'Thread', lambda *a, **k: type(
+                'T', (), {'start': lambda self: None, 'daemon': True})())
+        # Windows start_child touches db_backend / env / redis before spawning.
+        if hasattr(mod, 'db_backend'):
+            monkeypatch.setattr(mod.db_backend, 'ensure_embedded_running', lambda *a, **k: 'postgresql://x')
+        if hasattr(mod, 'env_builder'):
+            monkeypatch.setattr(mod.env_builder, 'build_child_env', lambda *a, **k: {})
+        if hasattr(sup, '_ensure_redis_running'):
+            monkeypatch.setattr(sup, '_ensure_redis_running', lambda *a, **k: 'redis://x')
+
+        sup._state = 'starting'
+        result = sup.start_child('flask')
+        assert result is True
+        assert 'flask' in sup._desired
+
+
+# ---------------------------------------------------------------------------
+# start_in_background owns the boot thread (Linux/macOS only)
+# ---------------------------------------------------------------------------
+
+class TestStartInBackground:
+    def test_owns_boot_thread_and_invokes_start_all(self, supervisor_case, monkeypatch):
+        platform_name, mod = supervisor_case
+        if not hasattr(mod.ProcessSupervisor, 'start_in_background'):
+            pytest.skip(f"{platform_name} supervisor has no start_in_background")
+
+        sup = _bare_supervisor(mod)
+        started = threading.Event()
+        boot_thread_seen = {}
+
+        def _fake_start_all():
+            boot_thread_seen['thread'] = threading.current_thread()
+            started.set()
+
+        monkeypatch.setattr(sup, 'start_all', _fake_start_all)
+        # is_running() gates the on_ready callback; keep it False to avoid it.
+        monkeypatch.setattr(sup, 'is_running', lambda: False)
+
+        thread = sup.start_in_background()
+        assert thread is sup._boot_thread
+        assert started.wait(2.0)
+        # start_all ran on the supervisor-owned background thread, not the caller.
+        assert boot_thread_seen['thread'] is sup._boot_thread
+        assert boot_thread_seen['thread'] is not threading.current_thread()
+        thread.join(2)

--- a/test/unit/test_native_supervisor.py
+++ b/test/unit/test_native_supervisor.py
@@ -169,7 +169,7 @@ class TestJoinWorkersSkips:
 
 class TestStartHealthLoopClearsStop:
     def test_clears_preset_stop_and_spawns_live_thread(self, supervisor_case, monkeypatch):
-        platform_name, mod = supervisor_case
+        _, mod = supervisor_case
         sup = _bare_supervisor(mod)
         sup._state = 'running'
 
@@ -243,7 +243,7 @@ class TestSpawnRefusedWhileStopping:
         """Sanity: the guard is state-specific -- in the 'starting' state the
         child IS marked desired (proving the refusal is the stop, not a blanket
         block). Popen is mocked so no real process spawns."""
-        platform_name, mod = supervisor_case
+        _, mod = supervisor_case
         sup = _bare_supervisor(mod)
 
         class _FakePopen:

--- a/test/unit/test_no_emoji_in_source.py
+++ b/test/unit/test_no_emoji_in_source.py
@@ -1,0 +1,115 @@
+"""Guard test: no emoji / pictographic icon codepoints in CODE files.
+
+Emoji embedded in source (especially in log strings) crash the Windows
+standalone build when written to the Windows console (cp1252). They are only
+allowed in rendered HTML pages, never in Python/shell/CI/config code.
+
+The candidate file list is built from ``git ls-files`` so it matches CI exactly.
+We flag only the unambiguous pictographic emoji codepoints to avoid false
+positives on legitimate accented Latin, CJK lyrics fixtures, typographic
+quotes/dashes, or mathematical symbols.
+"""
+import os
+import subprocess
+
+REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+)
+
+# Code file extensions to scan. HTML is intentionally absent (emoji allowed
+# in rendered pages). JSON is absent (test fixtures carry intentional unicode).
+CODE_EXTENSIONS = (
+    '.py', '.js', '.sh', '.bat', '.ps1',
+    '.yml', '.yaml', '.toml', '.cfg', '.ini',
+)
+
+# Files / trees excluded from the guard, with the reason:
+#   - plotly-2.29.1.min.js: vendored minified library (treat as binary blob).
+#   - lyrics_transcriber.py: contains a deliberate emoji-STRIPPING regex whose
+#     character class is literally built from emoji range boundaries.
+EXACT_EXCLUDES = {
+    'static/plotly-2.29.1.min.js',
+    'lyrics/lyrics_transcriber.py',
+}
+
+# Path fragments excluded outright (vendored / generated / non-console UI).
+PATH_FRAGMENT_EXCLUDES = (
+    '.venv',
+    'node_modules',
+    'screenshot/',
+)
+
+
+def _is_pictographic_emoji(codepoint):
+    """True for unambiguous pictographic emoji / icon codepoints.
+
+    Deliberately narrow: the astral Supplemental-Symbols/Emoji plane plus the
+    emoji presentation selector. This is the surface that crashes the Windows
+    console build and has no legitimate use in code. Accented Latin, CJK,
+    typographic punctuation and math symbols are all left untouched.
+    """
+    return (0x1F000 <= codepoint <= 0x1FAFF) or codepoint == 0xFE0F
+
+
+def _git_ls_files():
+    out = subprocess.check_output(
+        ['git', 'ls-files'], cwd=REPO_ROOT
+    ).decode('utf-8')
+    return [line for line in out.splitlines() if line]
+
+
+def _is_candidate(rel_path):
+    posix = rel_path.replace('\\', '/')
+    if not posix.endswith(CODE_EXTENSIONS):
+        return False
+    if posix.endswith('.html') or posix.startswith('templates/'):
+        return False
+    if posix.endswith('.json'):
+        return False
+    if posix in EXACT_EXCLUDES:
+        return False
+    # Browser-delivered UI scripts render to the DOM, not the Windows console,
+    # so emoji button labels there do not crash the build.
+    if posix.startswith('static/') and posix.endswith('.js'):
+        return False
+    for frag in PATH_FRAGMENT_EXCLUDES:
+        if frag in posix:
+            return False
+    return True
+
+
+def _candidate_files():
+    return [f for f in _git_ls_files() if _is_candidate(f)]
+
+
+def _scan_for_emoji(rel_path):
+    abs_path = os.path.join(REPO_ROOT, rel_path)
+    offenders = []
+    try:
+        with open(abs_path, encoding='utf-8') as handle:
+            lines = handle.read().splitlines()
+    except (OSError, UnicodeDecodeError):
+        return offenders
+    for line_no, line in enumerate(lines, start=1):
+        bad = sorted({ch for ch in line if _is_pictographic_emoji(ord(ch))})
+        if bad:
+            codes = ' '.join('U+%04X' % ord(c) for c in bad)
+            offenders.append((line_no, codes))
+    return offenders
+
+
+def test_candidate_file_list_is_non_empty():
+    # Sanity check: git ls-files resolved and produced code files to scan.
+    assert _candidate_files(), 'no candidate code files found via git ls-files'
+
+
+def test_no_emoji_in_code_files():
+    failures = []
+    for rel_path in _candidate_files():
+        for line_no, codes in _scan_for_emoji(rel_path):
+            failures.append('{0}:{1} ({2})'.format(rel_path, line_no, codes))
+    assert not failures, (
+        'Emoji / pictographic codepoints found in code files '
+        '(emoji are only allowed in HTML pages; they crash the Windows '
+        'console build):\n  ' + '\n  '.join(failures)
+    )

--- a/test/unit/test_paged_ivf.py
+++ b/test/unit/test_paged_ivf.py
@@ -364,6 +364,40 @@ def test_drop_resident_mmap_pages_reduces_rss(tmp_path):
     )
 
 
+def test_drop_pages_windows_routing(tmp_path, monkeypatch):
+    """On Windows the drop routes through VirtualUnlock; ERROR_NOT_LOCKED counts as success."""
+    import tasks.paged_ivf as pv
+
+    path = tmp_path / "wcells.bin"
+    with open(path, "wb") as f:
+        f.write(b"\xcd" * (2 * 1024 * 1024))
+
+    def make_stub():
+        mm = np.memmap(str(path), dtype=np.uint8, mode="r")
+        stub = type("S", (), {})()
+        stub._mmap = mm
+        return stub, mm
+
+    monkeypatch.setattr(pv.platform, "system", lambda: "Windows")
+
+    # FALSE + ERROR_NOT_LOCKED(158) is the documented success path for unlocked pages.
+    stub, mm = make_stub()
+    calls = []
+
+    def unlock_not_locked(addr, size):
+        calls.append((addr, size))
+        return 0
+
+    monkeypatch.setattr(pv, "_win_virtual_unlock", lambda: (unlock_not_locked, lambda: pv._WIN_ERROR_NOT_LOCKED))
+    assert pv._drop_resident_mmap_pages([stub]) == 1
+    assert calls == [(int(mm.ctypes.data), int(mm.nbytes))]
+
+    # A genuine failure (other error code, FALSE) must not be counted as dropped.
+    stub2, _mm2 = make_stub()
+    monkeypatch.setattr(pv, "_win_virtual_unlock", lambda: ((lambda addr, size: 0), lambda: 5))
+    assert pv._drop_resident_mmap_pages([stub2]) == 0
+
+
 def test_mmap_idle_worker_drops_pages_and_runs_callbacks(monkeypatch):
     """An idle disk-cache working set must fire the watcher: drop + idle callbacks."""
     import tasks.paged_ivf as pv

--- a/test/unit/test_proxy_prefix.py
+++ b/test/unit/test_proxy_prefix.py
@@ -1,0 +1,128 @@
+"""Regression tests for the reverse-proxy subpath prefix handling (issue #668).
+
+The bug: behind a reverse proxy that forwards the FULL path (e.g. nginx
+``proxy_pass`` without a trailing slash) while ALSO sending
+``X-Forwarded-Prefix``, ProxyFix puts the prefix in ``SCRIPT_NAME`` while
+``PATH_INFO`` still carries it. ``request.path`` then becomes
+``/audiomuseai/setup`` instead of ``/setup``; the setup barrier's literal
+comparison fails and it redirects to ``url_for('setup_page')`` ==
+``/audiomuseai/setup`` -- the same URL -- forever.
+
+``StripDuplicatedScriptName`` collapses the duplicated prefix so both the
+correctly-configured and the misconfigured proxy work, and the loop is
+impossible.
+"""
+from flask import Flask, request, redirect, url_for, jsonify
+from werkzeug.middleware.proxy_fix import ProxyFix
+
+from proxy_prefix import StripDuplicatedScriptName
+
+
+# --- the middleware in isolation -------------------------------------------
+
+def _run(environ):
+    captured = {}
+
+    def downstream(env, start_response):
+        captured['SCRIPT_NAME'] = env.get('SCRIPT_NAME', '')
+        captured['PATH_INFO'] = env.get('PATH_INFO', '')
+        return []
+
+    StripDuplicatedScriptName(downstream)(environ, lambda *a, **k: None)
+    return captured
+
+
+class TestStripDuplicatedScriptName:
+    def test_no_prefix_is_noop(self):
+        out = _run({'SCRIPT_NAME': '', 'PATH_INFO': '/setup'})
+        assert out['PATH_INFO'] == '/setup'
+
+    def test_correctly_stripped_path_is_noop(self):
+        # nginx already stripped the prefix: PATH_INFO does not start with it.
+        out = _run({'SCRIPT_NAME': '/audiomuseai', 'PATH_INFO': '/setup'})
+        assert out['PATH_INFO'] == '/setup'
+
+    def test_duplicated_prefix_is_collapsed(self):
+        out = _run({'SCRIPT_NAME': '/audiomuseai', 'PATH_INFO': '/audiomuseai/setup'})
+        assert out['PATH_INFO'] == '/setup'
+
+    def test_duplicated_prefix_bare_root(self):
+        out = _run({'SCRIPT_NAME': '/audiomuseai', 'PATH_INFO': '/audiomuseai/'})
+        assert out['PATH_INFO'] == '/'
+
+    def test_path_equal_to_prefix_becomes_root(self):
+        out = _run({'SCRIPT_NAME': '/audiomuseai', 'PATH_INFO': '/audiomuseai'})
+        assert out['PATH_INFO'] == '/'
+
+    def test_prefix_with_trailing_slash_normalized(self):
+        out = _run({'SCRIPT_NAME': '/audiomuseai/', 'PATH_INFO': '/audiomuseai/setup'})
+        assert out['PATH_INFO'] == '/setup'
+
+    def test_similar_but_unrelated_path_untouched(self):
+        # /amazing must NOT be treated as carrying the /am prefix.
+        out = _run({'SCRIPT_NAME': '/am', 'PATH_INFO': '/amazing'})
+        assert out['PATH_INFO'] == '/amazing'
+
+
+# --- end-to-end: the real setup barrier behind the real middleware ----------
+
+def _barrier_app(with_fix):
+    app = Flask(__name__)
+
+    @app.route('/')
+    def dashboard_page():
+        return 'DASH'
+
+    @app.route('/setup')
+    def setup_page():
+        return 'SETUP'
+
+    @app.before_request
+    def barrier():
+        # Mirror app_auth.auth_setup_barrier's setup-needed branch with setup
+        # unconditionally required.
+        if request.path in ('/setup', '/api/setup'):
+            return
+        if request.path.startswith('/api/'):
+            return jsonify(error='Setup required'), 403
+        return redirect(url_for('setup_page'))
+
+    inner = StripDuplicatedScriptName(app.wsgi_app) if with_fix else app.wsgi_app
+    app.wsgi_app = ProxyFix(inner, x_for=1, x_proto=1, x_host=1, x_prefix=1)
+    return app
+
+
+_PROXY_HEADERS = {
+    'X-Forwarded-Proto': 'https',
+    'X-Forwarded-Host': 'host',
+    'X-Forwarded-Prefix': '/audiomuseai',
+}
+
+
+class TestBarrierUnderMisconfiguredProxy:
+    def test_loop_without_fix(self):
+        # Reproduce the bug: full path forwarded + X-Forwarded-Prefix -> the
+        # barrier redirects /audiomuseai/setup back to /audiomuseai/setup.
+        app = _barrier_app(with_fix=False)
+        rv = app.test_client().get('/audiomuseai/setup', headers=_PROXY_HEADERS)
+        assert rv.status_code == 302
+        assert rv.headers['Location'] == '/audiomuseai/setup'  # points at itself
+
+    def test_no_loop_with_fix(self):
+        app = _barrier_app(with_fix=True)
+        rv = app.test_client().get('/audiomuseai/setup', headers=_PROXY_HEADERS)
+        assert rv.status_code == 200
+        assert rv.get_data(as_text=True) == 'SETUP'
+
+    def test_recommended_config_still_works_with_fix(self):
+        # nginx strips the prefix: app receives /setup; must keep working.
+        app = _barrier_app(with_fix=True)
+        rv = app.test_client().get('/setup', headers=_PROXY_HEADERS)
+        assert rv.status_code == 200
+        assert rv.get_data(as_text=True) == 'SETUP'
+
+    def test_root_redirect_target_is_prefixed_with_fix(self):
+        app = _barrier_app(with_fix=True)
+        rv = app.test_client().get('/audiomuseai/', headers=_PROXY_HEADERS)
+        assert rv.status_code == 302
+        assert rv.headers['Location'] == '/audiomuseai/setup'

--- a/test/unit/test_serialize_neighbor_results.py
+++ b/test/unit/test_serialize_neighbor_results.py
@@ -1,0 +1,224 @@
+"""Unit tests for the shared similar-tracks serializer and the IVF neighbor
+search error mapper.
+
+- app_helper.serialize_neighbor_results: shared response builder for the IVF
+  similarity endpoints and the sonic-fingerprint endpoint. The missing_album
+  sentinel contract (substitute vs. keep raw, incl. '') is the key refinement.
+- app_ivf._neighbor_search_error_response: maps a neighbor-search exception to a
+  generic (no-traceback) JSON error + HTTP status. Needs a Flask app context for
+  jsonify.
+
+Pure functions; the score-data lookup is mocked, no DB.
+"""
+from unittest.mock import patch
+
+import pytest
+from flask import Flask
+
+from app_helper import serialize_neighbor_results
+import app_ivf
+
+
+def score(item_id, title='T', author='A', album='Album', album_artist='AlbArt',
+          mood_vector='rock:0.9,happy:0.5', other_features='danceable:0.4'):
+    return {
+        'item_id': item_id,
+        'title': title,
+        'author': author,
+        'album': album,
+        'album_artist': album_artist,
+        'mood_vector': mood_vector,
+        'other_features': other_features,
+    }
+
+
+def neighbors(*pairs):
+    return [{'item_id': iid, 'distance': dist} for iid, dist in pairs]
+
+
+class TestSerializeShortCircuits:
+    def test_empty_list_returns_empty_without_lookup(self):
+        with patch('app_helper.get_score_data_by_ids') as mock_lookup:
+            assert serialize_neighbor_results([]) == []
+            mock_lookup.assert_not_called()
+
+    def test_none_returns_empty_without_lookup(self):
+        with patch('app_helper.get_score_data_by_ids') as mock_lookup:
+            assert serialize_neighbor_results(None) == []
+            mock_lookup.assert_not_called()
+
+
+class TestMissingAlbumDefault:
+    def test_none_album_substituted_with_default_unknown(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album=None)]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1)))
+        assert out[0]['album'] == 'unknown'
+
+    def test_empty_album_substituted_with_default_unknown(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album='')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1)))
+        assert out[0]['album'] == 'unknown'
+
+    def test_present_album_preserved_with_default(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album='Real Album')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1)))
+        assert out[0]['album'] == 'Real Album'
+
+    def test_custom_sentinel_substitutes(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album=None)]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), missing_album='N/A')
+        assert out[0]['album'] == 'N/A'
+
+
+class TestMissingAlbumNoneContract:
+    def test_none_album_kept_as_none(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album=None)]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), missing_album=None)
+        assert out[0]['album'] is None
+
+    def test_empty_album_kept_as_empty(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album='')]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), missing_album=None)
+        assert out[0]['album'] == ''
+
+    def test_present_album_kept_with_none_sentinel(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album='Real Album')]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), missing_album=None)
+        assert out[0]['album'] == 'Real Album'
+
+
+class TestMissingDetailsSkipped:
+    def test_id_absent_from_details_map_is_skipped(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1), ('2', 0.2)))
+        assert len(out) == 1
+        assert out[0]['item_id'] == '1'
+
+    def test_all_ids_absent_yields_empty(self):
+        with patch('app_helper.get_score_data_by_ids', return_value=[]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1), ('2', 0.2)))
+        assert out == []
+
+
+class TestDistancePassthrough:
+    def test_distance_comes_from_neighbor_map(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1'), score('2')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.25), ('2', 0.75)))
+        by_id = {r['item_id']: r['distance'] for r in out}
+        assert by_id == {'1': 0.25, '2': 0.75}
+
+    def test_distance_zero_preserved(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.0)))
+        assert out[0]['distance'] == 0.0
+
+
+class TestFeatureFlagsPassthrough:
+    def test_mood_and_other_features_present(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', mood_vector='metal:0.8',
+                                       other_features='danceable:0.9')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1)))
+        assert out[0]['mood_vector'] == 'metal:0.8'
+        assert out[0]['other_features'] == 'danceable:0.9'
+        assert out[0]['top_genre'] == 'metal'
+
+    def test_missing_features_become_none(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', mood_vector=None,
+                                       other_features=None)]):
+            out = serialize_neighbor_results(neighbors(('1', 0.1)))
+        assert out[0]['mood_vector'] is None
+        assert out[0]['other_features'] is None
+        assert out[0]['top_genre'] is None
+
+
+class TestAlbumArtistFlag:
+    def test_album_artist_included_when_flag_true(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album_artist='Band')]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), include_album_artist=True)
+        assert out[0]['album_artist'] == 'Band'
+
+    def test_album_artist_falls_back_to_unknown(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album_artist=None)]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), include_album_artist=True)
+        assert out[0]['album_artist'] == 'unknown'
+
+    def test_album_artist_omitted_when_flag_false(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', album_artist='Band')]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1)), include_album_artist=False)
+        assert 'album_artist' not in out[0]
+
+
+class TestOutputOrder:
+    def test_output_follows_input_neighbor_order(self):
+        # details returned in a different order than the neighbor input
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('3'), score('1'), score('2')]):
+            out = serialize_neighbor_results(
+                neighbors(('1', 0.1), ('2', 0.2), ('3', 0.3)))
+        assert [r['item_id'] for r in out] == ['1', '2', '3']
+
+    def test_core_fields_present(self):
+        with patch('app_helper.get_score_data_by_ids',
+                   return_value=[score('1', title='Song', author='Artist')]):
+            out = serialize_neighbor_results(neighbors(('1', 0.5)))
+        row = out[0]
+        assert row['item_id'] == '1'
+        assert row['title'] == 'Song'
+        assert row['author'] == 'Artist'
+
+
+@pytest.fixture
+def flask_ctx():
+    app = Flask(__name__)
+    with app.app_context():
+        yield
+
+
+class TestNeighborSearchErrorResponse:
+    def test_runtime_error_maps_to_503(self, flask_ctx):
+        resp, status = app_ivf._neighbor_search_error_response(
+            'item-1', RuntimeError('boom'), is_runtime=True)
+        assert status == 503
+        body = resp.get_json()
+        assert body['error'] == 'The similarity search service is currently unavailable.'
+
+    def test_unexpected_error_maps_to_500(self, flask_ctx):
+        resp, status = app_ivf._neighbor_search_error_response(
+            'item-1', ValueError('boom'), is_runtime=False)
+        assert status == 500
+        body = resp.get_json()
+        assert body['error'] == 'An unexpected error occurred.'
+
+    def test_message_does_not_leak_exception_text(self, flask_ctx):
+        secret = 'TRACEBACK_SECRET_42'
+        for is_runtime in (True, False):
+            resp, _status = app_ivf._neighbor_search_error_response(
+                'ctx', RuntimeError(secret), is_runtime=is_runtime)
+            assert secret not in resp.get_json()['error']
+
+    def test_context_value_not_leaked_to_client(self, flask_ctx):
+        resp, _status = app_ivf._neighbor_search_error_response(
+            'sensitive-item-id', RuntimeError('x'), is_runtime=True)
+        assert 'sensitive-item-id' not in resp.get_json()['error']

--- a/test/unit/test_serialize_neighbor_results.py
+++ b/test/unit/test_serialize_neighbor_results.py
@@ -124,7 +124,7 @@ class TestDistancePassthrough:
         with patch('app_helper.get_score_data_by_ids',
                    return_value=[score('1')]):
             out = serialize_neighbor_results(neighbors(('1', 0.0)))
-        assert out[0]['distance'] == 0.0
+        assert out[0]['distance'] == pytest.approx(0.0)
 
 
 class TestFeatureFlagsPassthrough:

--- a/test/unit/test_sql_injection_params.py
+++ b/test/unit/test_sql_injection_params.py
@@ -45,6 +45,8 @@ def _recording_db():
     cur = MagicMock()
     cur.fetchone.return_value = None
     cur.fetchall.return_value = []
+    cur.__enter__ = lambda self: self
+    cur.__exit__ = lambda self, *a: None
     db = MagicMock()
     db.cursor.return_value = cur
     return db, cur


### PR DESCRIPTION
This is a broad **hardening + cleanup** branch rather than a single feature. The only new user-facing capability is the reverse-proxy subpath fix (#668); everything else tightens security, fixes resource leaks, centralizes config, and removes duplicated code without changing behavior.

Touches **56 files** grouped into the 15 themes below.

## Changes

| # | Improvement | Description | Pro / Con | Files | Regression risk (1=safe, 10=high) |
|---|---|---|---|---|---|
| 1 | **Reverse-proxy subpath fix (#668)** | New `StripDuplicatedScriptName` WSGI middleware (after ProxyFix) collapses a doubled `/prefix` when a proxy forwards the full path *and* sends `X-Forwarded-Prefix`, killing the infinite redirect loop to `/<prefix>/setup`. JS adds `window.appUrl()` + a centralized `window.appRedirect()` so every root-relative redirect survives a subpath proxy. | Pro: fixes hard lockout, no-op for correct proxies, unit-tested, no per-call-site drift. Con: extra WSGI layer. | `proxy_prefix.py`, `app.py`, `config.py`, `templates/includes/reverse_proxy_prefix.html`, `login.html`, `backup.html`, `provider_migration.html`, `static/setup.js`, `test/unit/test_proxy_prefix.py` | **3** |
| 2 | **No raw errors/tracebacks to UI** | `str(e)` / `str(job.exc_info)` replaced with generic "check container logs" messages; full traceback still logged server-side via `exc_info=True`. | Pro: no info leak, trace kept in container log. Con: less detail in UI. | `app_provider_migration.py`, `app_waveform.py` | **1** |
| 3 | **XSS escaping** | `escapeHtml()` applied to library metadata (track/artist names) before `innerHTML`. | Pro: blocks stored XSS. Con: none. | `static/script.js`, `templates/artist_similarity.html` | **2** |
| 4 | **Auth hardening** | `secrets.compare_digest` on encoded bytes (no crash on non-ASCII token); the `Secure`-cookie decision (HTTPS incl. `X-Forwarded-Proto`) is centralized in one `_original_request_is_https()` helper. | Pro: safer tokens/cookies; single source of truth, no per-site drift; HTTP-only deploys unaffected. Con: a proxy that misreports proto could mark the cookie Secure on real HTTP. | `app_auth.py`, `test/unit/test_app_auth.py` | **2** |
| 5 | **Input validation & bound caps** | `userInput` / playlist-name type+empty checks; `n` coerced & clamped; search `limit` capped (500 tracks / 100 artists). | Pro: abuse/DoS guard. Con: hard caps change very-large page sizes. | `app_chat.py`, `app_alchemy.py`, `app_ivf.py`, `app_artist_similarity.py` | **2** |
| 6 | **Emoji/icon removal from code** | Emoji in logs/messages replaced with ASCII (`OK`/`WARN`/`X`) — emoji in source crashes the Windows build. | Pro: avoids Windows build crash. Con: none. | `app.py`, `app_waveform.py`, `tasks/ai/providers/openai.py`, `tasks/ai/tool_impl.py`, `tasks/mediaserver/{emby,jellyfin,lyrion,navidrome}.py`, `app_setup.py` | **1** |
| 7 | **Config centralization** | New `RQ_MAX_JOBS`, `RQ_MAX_JOBS_HIGH`, `RQ_LOGGING_LEVEL`, `RADIUS_INSTRUMENTATION` defined once in `config.py`; modules import them; `getattr(config, …, default)` fallbacks removed. | Pro: single source of truth for defaults. Con: a missing attribute now errors instead of silently defaulting. | `config.py`, `rq_worker.py`, `rq_worker_high_priority.py`, `tasks/radius_walk_helper.py`, `tasks/ivf_manager.py`, `app_setup.py`, `tasks/sem_grove_manager.py`, `app_provider_migration.py` | **2** |
| 8 | **Similarity-response de-duplication** | One shared `serialize_neighbor_results()` (in `app_helper.py`) now builds the similar-tracks JSON for both the IVF similarity endpoints and the sonic-fingerprint endpoint; IVF error mapping unified in `_neighbor_search_error_response()`. Also de-dups the IVF manager (`_fetch_details_map`, `_is_too_close`, `_mood_distance`). | Pro: one response contract, ~250 fewer duplicated lines. Con: shared helper now used by more call sites. | `app_helper.py`, `app_ivf.py`, `app_sonic_fingerprint.py`, `tasks/ivf_manager.py` | **2** |
| 9 | **Windows IVF idle page-drop** | `VirtualUnlock` analog of `MADV_DONTNEED` reclaims idle mmap RSS on Windows (previously a no-op there). | Pro: lower idle RAM on Windows. Con: new ctypes/native path. | `tasks/paged_ivf.py`, `test/unit/test_paged_ivf.py` | **4** |
| 10 | **Resource-leak cleanup** | Cursors moved to `with`; subprocess `timeout=30`; pubsub/redis closed in `finally`; temp dir cleaned with `shutil.rmtree`; Navidrome stream response closed; connection init guard; new empty `restart` sentinel file. | Pro: fewer leaked handles / temp files. Con: minimal. | `database.py`, `app_external.py`, `restart_listener.py`, `restart_manager.py`, `app_waveform.py`, `tasks/mediaserver/navidrome.py`, `tasks/clap_text_search.py`, `restart` | **2** |
| 11 | **Native supervisor stop/boot race (all 3 platforms)** | `start_in_background` / `_stop_requested` / `_join_workers` so a stop racing a boot cannot orphan child processes. macOS mirrors the already-shipping `native-build/linux` pattern; Windows is now brought to the same parity (boot-thread join, spawn-refused-while-stopping, locked child table). | Pro: no orphaned workers on any native build. Con: concurrency code; native-only (cannot affect container/Linux server — separate files). | `native-build/macos/{supervisor,launcher}.py`, `native-build/windows/{supervisor,env}.py` | **2** |
| 12 | **Cron matcher upgrade** | Adds step syntax (`*/N`, `a-b/N`), treats day-of-week `7` as Sunday, fixes a `ts=0` falsy bug, and anchors `*/N` at each field's minimum (`field_min=1` for month / day-of-month) so steps match standard cron instead of multiples of N. | Pro: standard cron semantics; the `field_min` fix corrects a real step-matching bug. Con: new parse paths. **Covered by cron unit tests.** | `app_cron.py` | **2** |
| 13 | **Misc correctness + perf** | Mistral timeout `960ms` → `AI_REQUEST_TIMEOUT_SECONDS*1000`; GMM `k` capped at `len(X)`; robust JSON parse of task details; `.tmp` suffix slice; dead `missing_ids` removed; clustering score format; clustering-kwargs reorder; drop unused path thread-pool; thread-safe one-time cache for the ~1 MB mood-centroids JSON in song alchemy. | Pro: real bug fixes (notably Mistral's near-instant timeout) + removes a per-request file read. Con: minor. | `tasks/ai/providers/mistral.py`, `query/brainstorm_real_gmm_080.py`, `app.py`, `tasks/mediaserver/__init__.py`, `tasks/song_alchemy.py`, `tasks/clustering.py`, `app_clustering.py`, `tasks/path_manager.py` | **2** |
| 14 | **Setup admin-password hint** | Advisory-only "recommend ≥15 chars" hint on the setup wizard; never blocks saving. | Pro: nudges stronger passwords. Con: none. | `static/setup.js`, `templates/setup.html` | **1** |
| 15 | **Test mock update** | Cursor mock gains `__enter__` / `__exit__` so it matches the new `with db.cursor()` usage. | Pro: keeps the SQL-injection test valid. Con: test-only. | `test/unit/test_sql_injection_params.py` | **1** |

## Testing

- `test_app_cron_parsing`, `test_app_cron`, `test_app_auth`, `test_sonic_fingerprint_manager`, `test_ivf_manager`, `test_paged_ivf`, `test_proxy_prefix` — **171 passed**.
- `pyflakes` clean on all edited modules (the only warnings are pre-existing unused re-exports in `app_helper.py`'s import block, unrelated to this branch).

## Notes / highest-attention items

- **#9** (new Windows `VirtualUnlock` ctypes path) carries the most behavioral risk — review first.
- **#8**, **#11**, **#12** were de-risked by follow-up refinements: the IVF/sonic serializer is now a single shared helper, the supervisor race-guard reaches parity across macOS/Linux/Windows, and the cron `*/N` step now anchors at the field minimum (correctness fix), all covered by passing tests.
- **#4** is safe for plain-HTTP deployments (no `X-Forwarded-Proto` header → `Secure=False` as before); it only changes behavior behind a TLS-terminating proxy.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578902/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578888/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-670`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-670-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-670-noavx2`
<!-- pr-test-build:end -->