### PR TITLE
Workflow permission fix

### DIFF
--- a/.github/workflows/build-arm-intel.yml
+++ b/.github/workflows/build-arm-intel.yml
@@ -29,6 +29,9 @@ concurrency:
   group: build-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   REGISTRY: ghcr.io
 

--- a/.github/workflows/build-noavx2.yml
+++ b/.github/workflows/build-noavx2.yml
@@ -28,6 +28,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push-noavx2:
     # Run on non-PR events; for PR events skip drafts and fork PRs (the

--- a/.github/workflows/build-nvidia.yml
+++ b/.github/workflows/build-nvidia.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   build-and-push:
     # Run on non-PR events; for PR events skip drafts and fork PRs (the

--- a/.github/workflows/lint-line-endings.yml
+++ b/.github/workflows/lint-line-endings.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 jobs:
   check-crlf:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-no-avx2.yml
+++ b/.github/workflows/test-no-avx2.yml
@@ -3,6 +3,9 @@ name: Test absence of AVX2
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   avx2-scan-and-import-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Workflow permission fix

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27938520419/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27906578893/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/27938520379/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-673`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-673-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-673-noavx2`
<!-- pr-test-build:end -->