### PR TITLE
upgrade to postgresql-client-18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -360,7 +360,12 @@ RUN set -ux; \
             ffmpeg wget curl \
             supervisor procps \
             git vim redis-tools strace iputils-ping \
-            "$(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda:([0-9]+)\.([0-9]+).+$ ]]; then echo "cuda-compiler-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"; fi)"; then \
+            postgresql-common ca-certificates \
+            "$(if [[ "$BASE_IMAGE" =~ ^nvidia/cuda:([0-9]+)\.([0-9]+).+$ ]]; then echo "cuda-compiler-${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"; fi)" \
+            # PostgreSQL 18 client from PGDG (pg_dump 18 backs up PG 15-18; psql restore stays compatible with old pg_dump 16 / PG 15 dumps)
+            && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+            && DEBIAN_FRONTEND=noninteractive apt-get update \
+            && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client-18; then \
             break; \
         fi; \
         n=$((n+1)); \
@@ -371,17 +376,6 @@ RUN set -ux; \
     apt-get remove -y python3-numpy || true && \
     apt-get autoremove -y || true && \
     rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
-
-# PostgreSQL 18 client via PGDG (pg_dump 18 dumps PG 15-18; psql restore stays back-compatible with old pg_dump 16 / PG 15 backups)
-RUN set -ux; \
-    DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        postgresql-common ca-certificates && \
-    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
-    DEBIAN_FRONTEND=noninteractive apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-        postgresql-client-18 && \
-    rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
 # Stage 2b: base — runtime-base + compilers / -dev headers (BUILD-ONLY)

--- a/Dockerfile
+++ b/Dockerfile
@@ -356,7 +356,7 @@ RUN set -ux; \
             libopenblas0 \
             liblapack3=3.12.0-3build1.1 \
             libgomp1 \
-            libpq5 postgresql-client \
+            libpq5 \
             ffmpeg wget curl \
             supervisor procps \
             git vim redis-tools strace iputils-ping \
@@ -371,6 +371,17 @@ RUN set -ux; \
     apt-get remove -y python3-numpy || true && \
     apt-get autoremove -y || true && \
     rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
+
+# PostgreSQL 18 client via PGDG (pg_dump 18 dumps PG 15-18; psql restore stays back-compatible with old pg_dump 16 / PG 15 backups)
+RUN set -ux; \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        postgresql-common ca-certificates && \
+    /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        postgresql-client-18 && \
+    rm -rf /var/lib/apt/lists/*
 
 # ============================================================================
 # Stage 2b: base — runtime-base + compilers / -dev headers (BUILD-ONLY)


### PR DESCRIPTION
This PR upgrade normal cpu image and nvidia image to postgresql-client-18.

We still suggest to use Postgresql 15 as server container but this fix will solve possible issue (people whom deployed higher version and now is not able to use the backup&restore functionality).

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28094469210/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28013845487/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28013845487/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28013845487/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28013845487/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28094469118/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-690`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-690-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-690-noavx2`
<!-- pr-test-build:end -->