### PR TITLE
Fix #684: Replace `X-Emby-Token` with `Authorization` headers

### DIFF
--- a/config.py
+++ b/config.py
@@ -53,7 +53,7 @@ TEMP_DIR = os.environ.get("TEMP_DIR", "/app/temp_audio")
 
 def _compute_headers():
     if MEDIASERVER_TYPE == "jellyfin":
-        return {"X-Emby-Token": JELLYFIN_TOKEN}
+        return {"Authorization": f'MediaBrowser Token="{JELLYFIN_TOKEN}"'}
     if MEDIASERVER_TYPE == "emby":
         return {"X-Emby-Token": EMBY_TOKEN}
     return {}

--- a/tasks/mediaserver/jellyfin.py
+++ b/tasks/mediaserver/jellyfin.py
@@ -1,4 +1,5 @@
 # tasks/mediaserver/jellyfin.py
+from typing import Any
 
 from . import http as requests
 import logging
@@ -104,18 +105,18 @@ def _jellyfin_base_url(user_creds=None):
     return (user_creds.get('url') if user_creds and user_creds.get('url') else config.JELLYFIN_URL).rstrip('/')
 
 
-def _jellyfin_headers_from_creds(user_creds=None):
+def _jellyfin_headers_from_creds(user_creds: dict[str, str]|None=None) -> dict[str, str]:
     headers = dict(getattr(config, 'HEADERS', {}) or {})
     token = user_creds.get('token') if user_creds else getattr(config, 'JELLYFIN_TOKEN', None)
     if token:
-        headers['X-Emby-Token'] = token
+        headers['Authorization'] = f'MediaBrowser Token="{token}"'
     return headers
 
 
-def _jellyfin_get_users(token):
+def _jellyfin_get_users(token: str|None) -> list[dict[str, Any]]|None:
     """Fetches a list of all users from Jellyfin using a provided token."""
     url = f"{config.JELLYFIN_URL}/Users"
-    headers = {"X-Emby-Token": token}
+    headers = _jellyfin_headers_from_creds(user_creds={'token': token} if token else None)
     try:
         r = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -453,14 +454,14 @@ def delete_playlist(playlist_id):
         return False
 
 # --- USER-SPECIFIC JELLYFIN FUNCTIONS ---
-def get_top_played_songs(limit, user_creds=None):
+def get_top_played_songs(limit, user_creds: dict[str, str] | None=None) -> list[dict[str, Any]]:
     """Fetches the top N most played songs from Jellyfin for a specific user."""
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
     token = user_creds.get('token') if user_creds else config.JELLYFIN_TOKEN
     if not user_id or not token: raise ValueError("Jellyfin User ID and Token are required.")
 
     url = f"{config.JELLYFIN_URL}/Users/{user_id}/Items"
-    headers = {"X-Emby-Token": token}
+    headers = _jellyfin_headers_from_creds(user_creds)
     params = {"IncludeItemTypes": "Audio", "SortBy": "PlayCount", "SortOrder": "Descending", "Recursive": True, "Limit": limit, "Fields": "UserData,Path,ProductionYear"}
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
@@ -482,14 +483,14 @@ def get_top_played_songs(limit, user_creds=None):
         logger.error(f"Jellyfin get_all_songs failed: {e}", exc_info=True)
         return []
 
-def get_last_played_time(item_id, user_creds=None):
+def get_last_played_time(item_id, user_creds: dict[str, str]|None=None) -> str|None:
     """Fetches the last played time for a specific track from Jellyfin for a specific user."""
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
     token = user_creds.get('token') if user_creds else config.JELLYFIN_TOKEN
     if not user_id or not token: raise ValueError("Jellyfin User ID and Token are required.")
 
     url = f"{config.JELLYFIN_URL}/Users/{user_id}/Items/{item_id}"
-    headers = {"X-Emby-Token": token}
+    headers = _jellyfin_headers_from_creds(user_creds)
     params = {"Fields": "UserData"}
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
@@ -520,7 +521,7 @@ def get_lyrics(track_id: str, timeout: float = 2.5):
         logger.debug('Jellyfin get_lyrics failed for %s: %s', track_id, exc)
         return None
 
-def create_instant_playlist(playlist_name, item_ids, user_creds=None):
+def create_instant_playlist(playlist_name: str, item_ids, user_creds: dict[str, str]|None=None) -> dict[str, Any]|None:
     """Creates a new instant playlist on Jellyfin for a specific user."""
     # Treat empty token ("") as not provided and fall back to admin token from config
     token = config.JELLYFIN_TOKEN
@@ -541,7 +542,7 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
     
     final_playlist_name = f"{playlist_name.strip()}_instant"
     url = f"{config.JELLYFIN_URL}/Playlists"
-    headers = {"X-Emby-Token": token}
+    headers = _jellyfin_headers_from_creds(user_creds)
     body = {"Name": final_playlist_name, "Ids": item_ids, "UserId": user_id}
     try:
         r = requests.post(url, headers=headers, json=body, timeout=REQUESTS_TIMEOUT)
@@ -552,13 +553,13 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
         return None
 
 
-def _fetch_playlist_items(playlist_id, user_creds=None):
+def _fetch_playlist_items(playlist_id: str, user_creds: dict[str,str]|None=None) -> list[dict[str, Any]]|None:
     """GETs the raw entries of a Jellyfin playlist. Each entry carries both the audio
     item's ``Id`` and a separate ``PlaylistItemId`` (the removal handle). Returns the
     list of entry dicts, or None on HTTP failure. Uses admin creds unless user_creds given.
     """
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    headers = {"X-Emby-Token": user_creds.get('token')} if user_creds else config.HEADERS
+    headers = _jellyfin_headers_from_creds(user_creds) if user_creds else config.HEADERS
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     params = {"UserId": user_id}
     try:

--- a/test/unit/test_mediaserver.py
+++ b/test/unit/test_mediaserver.py
@@ -12,6 +12,14 @@ import requests
 # JELLYFIN TESTS
 # =============================================================================
 
+try:
+    JELLYFIN_AUTHORIZATION_HEADERS = frozendict({'Authorization': 'MediaBrowser Token="token"'})
+    EMBY_AUTHORIZATION_HEADERS = frozendict({'X-Emby-Token': 'token'})
+except NameError: # Python 3.14 or earlier
+    from types import MappingProxyType
+    JELLYFIN_AUTHORIZATION_HEADERS = MappingProxyType({'Authorization': 'MediaUser Token="token"'})
+    EMBY_AUTHORIZATION_HEADERS = MappingProxyType({'X-Emby-Token': 'token'})
+
 class TestJellyfinSelectBestArtist:
     """Test artist field prioritization logic - no mocking needed"""
 
@@ -153,7 +161,7 @@ class TestJellyfinGetTracksFromAlbum:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         
         mock_response = Mock()
         mock_response.json.return_value = {'Items': []}
@@ -180,7 +188,7 @@ class TestJellyfinGetTracksFromAlbum:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -261,7 +269,7 @@ class TestJellyfinGetAllPlaylists:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         
         mock_response = Mock()
         mock_response.json.return_value = {'Items': []}
@@ -335,7 +343,7 @@ class TestJellyfinGetPlaylistTrackIds:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
 
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -377,7 +385,7 @@ class TestJellyfinDeletePlaylist:
         from tasks.mediaserver.jellyfin import delete_playlist
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
-        mock_config.HEADERS = {'X-Emby-Token': 'test-token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
@@ -393,7 +401,7 @@ class TestJellyfinDeletePlaylist:
             f"URL changed! Expected '/Items/playlist-123', got '{call_url}'"
         # Verify headers are passed
         call_kwargs = mock_delete.call_args[1]
-        assert call_kwargs.get('headers') == {'X-Emby-Token': 'test-token'}
+        assert call_kwargs.get('headers') == JELLYFIN_AUTHORIZATION_HEADERS
 
     @patch('tasks.mediaserver.jellyfin.requests.delete')
     @patch('tasks.mediaserver.jellyfin.config')
@@ -2071,7 +2079,7 @@ class TestEmbyGetAllPlaylists:
         
         mock_config.EMBY_URL = 'http://emby:8096'
         mock_config.EMBY_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = EMBY_AUTHORIZATION_HEADERS
         
         mock_response = Mock()
         mock_response.json.return_value = {'Items': []}
@@ -2143,8 +2151,8 @@ class TestEmbyDeletePlaylist:
         from tasks.mediaserver.emby import delete_playlist
         
         mock_config.EMBY_URL = 'http://emby:8096'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
-        
+        mock_config.HEADERS = EMBY_AUTHORIZATION_HEADERS
+
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_post.return_value = mock_response
@@ -2385,7 +2393,7 @@ class TestJellyfinListLibraries:
         called_url = mock_get.call_args[0][0]
         assert called_url == 'http://target-jelly:8096/Library/VirtualFolders'
         headers = mock_get.call_args[1]['headers']
-        assert headers.get('X-Emby-Token') == 'target-token'
+        assert headers.get('Authorization') == 'MediaBrowser Token="target-token"'
 
 
 class TestEmbyListLibraries:
@@ -2701,7 +2709,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         mock_get.return_value = None
 
         post_resp = MagicMock()
@@ -2725,7 +2733,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         mock_get.return_value = {'Id': 'pl-existing', 'Name': 'SF'}
 
         # GET items returns two entries with PlaylistItemId
@@ -2778,7 +2786,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         mock_get.return_value = {'Id': 'pl-1', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1']
         mock_remove.return_value = True
@@ -2803,7 +2811,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1', 'e2']
         mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
@@ -2830,7 +2838,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1']
         mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
@@ -3057,7 +3065,7 @@ class TestJellyfinGetAllSongsPagination:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         # Page 1 full (500) -> continue; page 2 short (3) -> stop.
         mock_get.side_effect = [_audio_page(500), _audio_page(3, start=500)]
 
@@ -3078,7 +3086,7 @@ class TestJellyfinGetAllSongsPagination:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = JELLYFIN_AUTHORIZATION_HEADERS
         # Page 1 succeeds (full -> would continue); page 2 times out.
         mock_get.side_effect = [
             _audio_page(500),
@@ -3113,7 +3121,7 @@ class TestEmbyGetAllSongsRaisesOnFailure:
 
         mock_config.EMBY_URL = 'http://emby:8096'
         mock_config.EMBY_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = EMBY_AUTHORIZATION_HEADERS
         # Page 1 full (1000 -> would continue); page 2 times out.
         mock_get.side_effect = [
             _audio_page(1000),


### PR DESCRIPTION
## AS-IS
The Jellyfin authentication currently uses a deprecated `X-Emby-Token` header.

## TO-BE
The Jellyfin authentication will use the `Authorization` header

## Test
<!-- What you tested and how to reproduce it. -->

## Other useful information
<!-- Anything else worth knowing (optional). -->

## Checklist
<!-- Not all items are mandatory — just check the ones that apply to your case. -->

**Type of change:**
- [X] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Jellyfin
- [ ] Navidrome
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [X] Unit test
- [ ] Integration test

**Other:**
- [ ] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #684
