### PR TITLE
mediaserver API align for Jellyfin 12.0

### DIFF
--- a/config.py
+++ b/config.py
@@ -51,9 +51,15 @@ MIGRATION_MAX_COLLISION_DETAILS = int(os.environ.get("MIGRATION_MAX_COLLISION_DE
 TEMP_DIR = os.environ.get("TEMP_DIR", "/app/temp_audio")
 
 
+def jellyfin_auth_header(token):
+    # Jellyfin 12.0 disables the legacy X-Emby-Token header by default; the
+    # Authorization: MediaBrowser scheme works on every supported version.
+    return {"Authorization": f'MediaBrowser Token="{token}"'} if token else {}
+
+
 def _compute_headers():
     if MEDIASERVER_TYPE == "jellyfin":
-        return {"X-Emby-Token": JELLYFIN_TOKEN}
+        return jellyfin_auth_header(JELLYFIN_TOKEN)
     if MEDIASERVER_TYPE == "emby":
         return {"X-Emby-Token": EMBY_TOKEN}
     return {}

--- a/tasks/mediaserver/jellyfin.py
+++ b/tasks/mediaserver/jellyfin.py
@@ -106,7 +106,7 @@ def _jellyfin_base_url(user_creds=None):
 
 
 def _jellyfin_headers_from_creds(user_creds=None):
-    token = user_creds.get('token') if user_creds else getattr(config, 'JELLYFIN_TOKEN', None)
+    token = (user_creds.get('token') if user_creds else None) or getattr(config, 'JELLYFIN_TOKEN', None)
     return jellyfin_auth_header(token)
 
 
@@ -562,7 +562,7 @@ def _fetch_playlist_items(playlist_id, user_creds=None):
     list of entry dicts, or None on HTTP failure. Uses admin creds unless user_creds given.
     """
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    headers = jellyfin_auth_header(user_creds.get('token')) if user_creds else config.HEADERS
+    headers = jellyfin_auth_header(user_creds.get('token')) if user_creds and user_creds.get('token') else config.HEADERS
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     params = {"UserId": user_id}
     try:

--- a/tasks/mediaserver/jellyfin.py
+++ b/tasks/mediaserver/jellyfin.py
@@ -4,6 +4,7 @@ from . import http as requests
 import logging
 import os
 import config
+from config import jellyfin_auth_header
 
 from .helper import detect_path_format, detect_download_extension, is_auth_error
 from .helper import select_best_artist as _select_best_artist
@@ -105,17 +106,14 @@ def _jellyfin_base_url(user_creds=None):
 
 
 def _jellyfin_headers_from_creds(user_creds=None):
-    headers = dict(getattr(config, 'HEADERS', {}) or {})
     token = user_creds.get('token') if user_creds else getattr(config, 'JELLYFIN_TOKEN', None)
-    if token:
-        headers['X-Emby-Token'] = token
-    return headers
+    return jellyfin_auth_header(token)
 
 
 def _jellyfin_get_users(token):
     """Fetches a list of all users from Jellyfin using a provided token."""
     url = f"{config.JELLYFIN_URL}/Users"
-    headers = {"X-Emby-Token": token}
+    headers = jellyfin_auth_header(token)
     try:
         r = requests.get(url, headers=headers, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -163,8 +161,9 @@ def get_recent_albums(limit):
         page_size = 500
         while True:
             # We fetch full pages and apply the limit only after collecting and sorting.
-            url = f"{config.JELLYFIN_URL}/Users/{config.JELLYFIN_USER_ID}/Items"
+            url = f"{config.JELLYFIN_URL}/Items"
             params = {
+                "userId": config.JELLYFIN_USER_ID,
                 "IncludeItemTypes": "MusicAlbum", "SortBy": "DateCreated", "SortOrder": "Descending",
                 "Recursive": True, "Limit": page_size, "StartIndex": start_index
             }
@@ -193,8 +192,9 @@ def get_recent_albums(limit):
             start_index = 0
             page_size = 500
             while True: # Paginate through the current library
-                url = f"{config.JELLYFIN_URL}/Users/{config.JELLYFIN_USER_ID}/Items"
+                url = f"{config.JELLYFIN_URL}/Items"
                 params = {
+                    "userId": config.JELLYFIN_USER_ID,
                     "IncludeItemTypes": "MusicAlbum", "SortBy": "DateCreated", "SortOrder": "Descending",
                     "Recursive": True, "Limit": page_size, "StartIndex": start_index,
                     "ParentId": library_id
@@ -230,8 +230,9 @@ def get_recent_albums(limit):
 def get_tracks_from_album(album_id, user_creds=None):
     """Fetches all audio tracks for a given album ID from Jellyfin using admin or override credentials."""
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    url = f"{_jellyfin_base_url(user_creds)}/Users/{user_id}/Items"
+    url = f"{_jellyfin_base_url(user_creds)}/Items"
     params = {
+        "userId": user_id,
         "ParentId": album_id,
         "IncludeItemTypes": "Audio",
         "Fields": "Path,ProductionYear,IndexNumber,ParentIndexNumber,AlbumArtist,Album,ArtistItems,Artists",
@@ -288,13 +289,14 @@ def get_all_songs(user_creds=None):
     already wrap this call and surface the error to the user.
     """
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    url = f"{_jellyfin_base_url(user_creds)}/Users/{user_id}/Items"
+    url = f"{_jellyfin_base_url(user_creds)}/Items"
     all_items = []
     start_index = 0
     limit = 500  # smaller than Emby's 1000 due to Jellyfin 10.11.x per-request DB cost
 
     while True:
         params = {
+            "userId": user_id,
             "IncludeItemTypes": "Audio",
             "Recursive": True,
             "StartIndex": start_index,
@@ -333,8 +335,9 @@ def get_all_songs(user_creds=None):
 def search_albums(query, user_creds=None):
     """Search Jellyfin albums using admin or override credentials."""
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    url = f"{_jellyfin_base_url(user_creds)}/Users/{user_id}/Items"
+    url = f"{_jellyfin_base_url(user_creds)}/Items"
     params = {
+        "userId": user_id,
         "IncludeItemTypes": "MusicAlbum",
         "Recursive": True,
         "SearchTerm": query,
@@ -364,8 +367,9 @@ def test_connection(user_creds=None):
     """Test Jellyfin connectivity using admin or override credentials."""
     try:
         user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-        url = f"{_jellyfin_base_url(user_creds)}/Users/{user_id}/Items"
+        url = f"{_jellyfin_base_url(user_creds)}/Items"
         params = {
+            "userId": user_id,
             "IncludeItemTypes": "Audio",
             "Recursive": True,
             "Fields": "Path,ProductionYear,IndexNumber,ParentIndexNumber,AlbumArtist,Album,ArtistItems,Artists",
@@ -401,12 +405,12 @@ def test_connection(user_creds=None):
 def get_playlist_by_name(playlist_name):
     """Finds a Jellyfin playlist by its exact name using admin credentials.
 
-    Jellyfin's /Users/{userId}/Items endpoint silently ignores the Name query
-    parameter and returns every playlist regardless of value, so we have to
-    filter client-side by exact match (mirrors the Emby version).
+    Jellyfin's /Items endpoint silently ignores the Name query parameter and
+    returns every playlist regardless of value, so we have to filter client-side
+    by exact match (mirrors the Emby version).
     """
-    url = f"{config.JELLYFIN_URL}/Users/{config.JELLYFIN_USER_ID}/Items"
-    params = {"IncludeItemTypes": "Playlist", "Recursive": True}
+    url = f"{config.JELLYFIN_URL}/Items"
+    params = {"userId": config.JELLYFIN_USER_ID, "IncludeItemTypes": "Playlist", "Recursive": True}
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -431,8 +435,8 @@ def create_playlist(base_name, item_ids):
 
 def get_all_playlists():
     """Fetches all playlists from Jellyfin using admin credentials."""
-    url = f"{config.JELLYFIN_URL}/Users/{config.JELLYFIN_USER_ID}/Items"
-    params = {"IncludeItemTypes": "Playlist", "Recursive": True}
+    url = f"{config.JELLYFIN_URL}/Items"
+    params = {"userId": config.JELLYFIN_USER_ID, "IncludeItemTypes": "Playlist", "Recursive": True}
     try:
         r = requests.get(url, headers=config.HEADERS, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -459,9 +463,9 @@ def get_top_played_songs(limit, user_creds=None):
     token = user_creds.get('token') if user_creds else config.JELLYFIN_TOKEN
     if not user_id or not token: raise ValueError("Jellyfin User ID and Token are required.")
 
-    url = f"{config.JELLYFIN_URL}/Users/{user_id}/Items"
-    headers = {"X-Emby-Token": token}
-    params = {"IncludeItemTypes": "Audio", "SortBy": "PlayCount", "SortOrder": "Descending", "Recursive": True, "Limit": limit, "Fields": "UserData,Path,ProductionYear"}
+    url = f"{config.JELLYFIN_URL}/Items"
+    headers = jellyfin_auth_header(token)
+    params = {"userId": user_id, "IncludeItemTypes": "Audio", "SortBy": "PlayCount", "SortOrder": "Descending", "Recursive": True, "Limit": limit, "Fields": "UserData,Path,ProductionYear"}
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -488,9 +492,9 @@ def get_last_played_time(item_id, user_creds=None):
     token = user_creds.get('token') if user_creds else config.JELLYFIN_TOKEN
     if not user_id or not token: raise ValueError("Jellyfin User ID and Token are required.")
 
-    url = f"{config.JELLYFIN_URL}/Users/{user_id}/Items/{item_id}"
-    headers = {"X-Emby-Token": token}
-    params = {"Fields": "UserData"}
+    url = f"{config.JELLYFIN_URL}/Items/{item_id}"
+    headers = jellyfin_auth_header(token)
+    params = {"userId": user_id, "Fields": "UserData"}
     try:
         r = requests.get(url, headers=headers, params=params, timeout=REQUESTS_TIMEOUT)
         r.raise_for_status()
@@ -541,7 +545,7 @@ def create_instant_playlist(playlist_name, item_ids, user_creds=None):
     
     final_playlist_name = f"{playlist_name.strip()}_instant"
     url = f"{config.JELLYFIN_URL}/Playlists"
-    headers = {"X-Emby-Token": token}
+    headers = jellyfin_auth_header(token)
     body = {"Name": final_playlist_name, "Ids": item_ids, "UserId": user_id}
     try:
         r = requests.post(url, headers=headers, json=body, timeout=REQUESTS_TIMEOUT)
@@ -558,7 +562,7 @@ def _fetch_playlist_items(playlist_id, user_creds=None):
     list of entry dicts, or None on HTTP failure. Uses admin creds unless user_creds given.
     """
     user_id = user_creds.get('user_id') if user_creds else config.JELLYFIN_USER_ID
-    headers = {"X-Emby-Token": user_creds.get('token')} if user_creds else config.HEADERS
+    headers = jellyfin_auth_header(user_creds.get('token')) if user_creds else config.HEADERS
     url = f"{config.JELLYFIN_URL}/Playlists/{playlist_id}/Items"
     params = {"UserId": user_id}
     try:

--- a/tasks/provider_probe.py
+++ b/tasks/provider_probe.py
@@ -5,7 +5,7 @@ takes a ``creds`` dict so the migration tool can test and migrate to a new
 provider without mutating the running app's active configuration.
 
 Supported providers:
-  * ``jellyfin`` / ``emby`` — X-Emby-Token header API, identical shape
+  * ``jellyfin`` / ``emby`` — token header API (Jellyfin: Authorization MediaBrowser; Emby: X-Emby-Token), identical shape
   * ``navidrome``           — Subsonic JSON API
   * ``lyrion``              — Logitech Media Server JSON-RPC (``/jsonrpc.js``)
  

--- a/test/unit/test_mediaserver.py
+++ b/test/unit/test_mediaserver.py
@@ -148,7 +148,7 @@ class TestJellyfinGetTracksFromAlbum:
     @patch('tasks.mediaserver.jellyfin.requests.get')
     @patch('tasks.mediaserver.jellyfin.config')
     def test_uses_correct_url_and_params(self, mock_config, mock_get):
-        """CRITICAL: Must use /Users/{id}/Items with ParentId - catches if URL changes"""
+        """CRITICAL: Must use /Items with userId+ParentId (Jellyfin 12.0) - catches if URL changes"""
         from tasks.mediaserver.jellyfin import get_tracks_from_album
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
@@ -165,10 +165,11 @@ class TestJellyfinGetTracksFromAlbum:
         call_url = mock_get.call_args[0][0]
         call_params = mock_get.call_args[1].get('params', {})
         
-        # Verify exact URL
-        assert call_url == 'http://jellyfin:8096/Users/user123/Items', \
-            f"URL changed! Expected '/Users/user123/Items', got '{call_url}'"
+        # Verify exact URL (modern non-deprecated /Items endpoint; Jellyfin 12.0)
+        assert call_url == 'http://jellyfin:8096/Items', \
+            f"URL changed! Expected '/Items', got '{call_url}'"
         # Verify required params
+        assert call_params.get('userId') == 'user123', "userId param missing or wrong"
         assert call_params.get('ParentId') == 'album-xyz', "ParentId param missing or wrong"
         assert call_params.get('IncludeItemTypes') == 'Audio', "IncludeItemTypes param wrong"
 
@@ -256,7 +257,7 @@ class TestJellyfinGetAllPlaylists:
     @patch('tasks.mediaserver.jellyfin.requests.get')
     @patch('tasks.mediaserver.jellyfin.config')
     def test_uses_correct_url_and_params(self, mock_config, mock_get):
-        """CRITICAL: Must use /Users/{id}/Items with IncludeItemTypes=Playlist"""
+        """CRITICAL: Must use /Items with userId+IncludeItemTypes=Playlist (Jellyfin 12.0)"""
         from tasks.mediaserver.jellyfin import get_all_playlists
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
@@ -273,10 +274,11 @@ class TestJellyfinGetAllPlaylists:
         call_url = mock_get.call_args[0][0]
         call_params = mock_get.call_args[1].get('params', {})
         
-        # Verify exact URL
-        assert call_url == 'http://jellyfin:8096/Users/user123/Items', \
+        # Verify exact URL (modern non-deprecated /Items endpoint; Jellyfin 12.0)
+        assert call_url == 'http://jellyfin:8096/Items', \
             f"URL changed! Got '{call_url}'"
         # Verify required params
+        assert call_params.get('userId') == 'user123', "userId param missing or wrong"
         assert call_params.get('IncludeItemTypes') == 'Playlist', \
             "IncludeItemTypes must be 'Playlist'"
         assert call_params.get('Recursive') == True, \
@@ -2385,7 +2387,7 @@ class TestJellyfinListLibraries:
         called_url = mock_get.call_args[0][0]
         assert called_url == 'http://target-jelly:8096/Library/VirtualFolders'
         headers = mock_get.call_args[1]['headers']
-        assert headers.get('X-Emby-Token') == 'target-token'
+        assert headers.get('Authorization') == 'MediaBrowser Token="target-token"'
 
 
 class TestEmbyListLibraries:

--- a/test/unit/test_mediaserver.py
+++ b/test/unit/test_mediaserver.py
@@ -12,6 +12,32 @@ import requests
 # JELLYFIN TESTS
 # =============================================================================
 
+class TestJellyfinAuthHeader:
+    """Jellyfin 12.0 auth: Authorization: MediaBrowser scheme (legacy X-Emby-Token
+    is disabled by default on 12.0). Emby still uses X-Emby-Token."""
+
+    def test_builds_authorization_header_from_token(self):
+        import config
+        assert config.jellyfin_auth_header('abc123') == {'Authorization': 'MediaBrowser Token="abc123"'}
+
+    def test_empty_token_yields_no_header(self):
+        import config
+        assert config.jellyfin_auth_header('') == {}
+        assert config.jellyfin_auth_header(None) == {}
+
+    def test_compute_headers_jellyfin_uses_authorization(self, monkeypatch):
+        import config
+        monkeypatch.setattr(config, 'MEDIASERVER_TYPE', 'jellyfin')
+        monkeypatch.setattr(config, 'JELLYFIN_TOKEN', 'jf-tok')
+        assert config._compute_headers() == {'Authorization': 'MediaBrowser Token="jf-tok"'}
+
+    def test_compute_headers_emby_keeps_x_emby_token(self, monkeypatch):
+        import config
+        monkeypatch.setattr(config, 'MEDIASERVER_TYPE', 'emby')
+        monkeypatch.setattr(config, 'EMBY_TOKEN', 'emby-tok')
+        assert config._compute_headers() == {'X-Emby-Token': 'emby-tok'}
+
+
 class TestJellyfinSelectBestArtist:
     """Test artist field prioritization logic - no mocking needed"""
 
@@ -153,13 +179,13 @@ class TestJellyfinGetTracksFromAlbum:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
-        
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
+
         mock_response = Mock()
         mock_response.json.return_value = {'Items': []}
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
-        
+
         get_tracks_from_album('album-xyz')
         
         call_url = mock_get.call_args[0][0]
@@ -181,8 +207,8 @@ class TestJellyfinGetTracksFromAlbum:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
-        
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
+
         mock_response = Mock()
         mock_response.json.return_value = {
             'Items': [
@@ -262,13 +288,13 @@ class TestJellyfinGetAllPlaylists:
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
-        
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
+
         mock_response = Mock()
         mock_response.json.return_value = {'Items': []}
         mock_response.raise_for_status = Mock()
         mock_get.return_value = mock_response
-        
+
         get_all_playlists()
         
         call_url = mock_get.call_args[0][0]
@@ -337,7 +363,7 @@ class TestJellyfinGetPlaylistTrackIds:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
 
         mock_response = Mock()
         mock_response.json.return_value = {
@@ -379,12 +405,12 @@ class TestJellyfinDeletePlaylist:
         from tasks.mediaserver.jellyfin import delete_playlist
         
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
-        mock_config.HEADERS = {'X-Emby-Token': 'test-token'}
-        
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="test-token"'}
+
         mock_response = Mock()
         mock_response.raise_for_status = Mock()
         mock_delete.return_value = mock_response
-        
+
         result = delete_playlist('playlist-123')
         
         assert result is True
@@ -395,7 +421,7 @@ class TestJellyfinDeletePlaylist:
             f"URL changed! Expected '/Items/playlist-123', got '{call_url}'"
         # Verify headers are passed
         call_kwargs = mock_delete.call_args[1]
-        assert call_kwargs.get('headers') == {'X-Emby-Token': 'test-token'}
+        assert call_kwargs.get('headers') == {'Authorization': 'MediaBrowser Token="test-token"'}
 
     @patch('tasks.mediaserver.jellyfin.requests.delete')
     @patch('tasks.mediaserver.jellyfin.config')
@@ -2703,7 +2729,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="t"'}
         mock_get.return_value = None
 
         post_resp = MagicMock()
@@ -2727,7 +2753,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="t"'}
         mock_get.return_value = {'Id': 'pl-existing', 'Name': 'SF'}
 
         # GET items returns two entries with PlaylistItemId
@@ -2780,7 +2806,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="t"'}
         mock_get.return_value = {'Id': 'pl-1', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1']
         mock_remove.return_value = True
@@ -2805,7 +2831,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="t"'}
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1', 'e2']
         mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
@@ -2832,7 +2858,7 @@ class TestJellyfinCreateOrReplacePlaylist:
 
         mock_config.JELLYFIN_URL = 'http://jf'
         mock_config.JELLYFIN_USER_ID = 'admin-user'
-        mock_config.HEADERS = {'X-Emby-Token': 't'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="t"'}
         mock_get.return_value = {'Id': 'old-pl', 'Name': 'SF'}
         mock_get_entries.return_value = ['e1']
         mock_remove.side_effect = requests.exceptions.HTTPError('400 Bad Request')
@@ -3059,7 +3085,7 @@ class TestJellyfinGetAllSongsPagination:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
         # Page 1 full (500) -> continue; page 2 short (3) -> stop.
         mock_get.side_effect = [_audio_page(500), _audio_page(3, start=500)]
 
@@ -3080,7 +3106,7 @@ class TestJellyfinGetAllSongsPagination:
 
         mock_config.JELLYFIN_URL = 'http://jellyfin:8096'
         mock_config.JELLYFIN_USER_ID = 'user123'
-        mock_config.HEADERS = {'X-Emby-Token': 'token'}
+        mock_config.HEADERS = {'Authorization': 'MediaBrowser Token="token"'}
         # Page 1 succeeds (full -> would continue); page 2 times out.
         mock_get.side_effect = [
             _audio_page(500),


### PR DESCRIPTION
This PR is to adapt Jellyfin mediaserver api call to Jellyfin 12.0. It takes as source of truth the draft of the jellyfin releae note:
- https://notes.jellyfin.org/v12.0_release_notes

| Change | Details | Status |
|---------|---------|--------|
| Authentication | Replaced `X-Emby-Token` with `Authorization: MediaBrowser Token="..."` via a single `config.jellyfin_auth_header()` builder. Emby authentication is unchanged. | ✅ Verified |
| Item listing | Updated `/Users/{userId}/Items` to `/Items?userId=` (9 call sites). | ✅ Equivalent behavior (10.9+) |
| Item lookup | Updated `/Users/{userId}/Items/{itemId}` to `/Items/{itemId}?userId=`. `UserData` remains returned inline. | ✅ Equivalent behavior (10.9+) |
| Other endpoints | `VirtualFolders`, `/Users`, `Download`, `Lyrics`, all `/Playlists/{id}/Items`, and `DELETE /Items/{id}` remain unchanged because they are still supported. | ✅ No changes required |
| Playlist creation | `POST /Playlists` route is unchanged. Query parameters are deprecated but still functional. |  ✅No change needed |

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461590/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461589/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461589/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461589/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461589/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28319461586/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-701`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-701-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-701-noavx2`
<!-- pr-test-build:end -->