### PR TITLE
Multiple fix

### DIFF
--- a/app_backup.py
+++ b/app_backup.py
@@ -85,16 +85,19 @@ def _pg_cmd(tool, *extra_args):
 _TXN_TIMEOUT_RE = re.compile(rb'(?m)^SET transaction_timeout\b[^\n]*\n')
 
 
-def _feed_dump(stdin, dump_file):
-    """Stream the dump into psql, dropping prologue GUCs older servers reject."""
+def _feed_dump(stdin, dump_file, result):
+    """Stream the dump into psql; record delivery in result so a short feed isn't reported as success."""
     try:
         with open(dump_file, 'rb') as src:
-            head = _TXN_TIMEOUT_RE.sub(b'', src.read(1024 * 1024))
+            head = _TXN_TIMEOUT_RE.sub(b'', src.read(1024 * 1024), count=1)
             stdin.write(b'DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;\n')
             stdin.write(head)
             shutil.copyfileobj(src, stdin, 1024 * 1024)
-    except (BrokenPipeError, OSError):
-        pass
+        result['ok'] = True
+    except BrokenPipeError:
+        result['error'] = 'psql closed the input stream before the dump finished'
+    except OSError as exc:
+        result['error'] = str(exc)
     finally:
         try:
             stdin.close()
@@ -146,12 +149,13 @@ def _run_restore_runner(dump_file, log_file):
             '-v', 'ON_ERROR_STOP=1',
             '--single-transaction',
         )
-        log.write(f"Running restore command: {' '.join(restore_cmd)}\n")
+        log.write(f"Running restore command: {' '.join(restore_cmd)} < {dump_file} (via stdin)\n")
         log.write("Streaming dump via stdin (stripping pg_dump 17+ transaction_timeout for old-server compatibility).\n")
         log.flush()
 
         proc = None
         feeder = None
+        feed_result = {}
         ret = -1
         try:
             proc = subprocess.Popen(
@@ -163,11 +167,15 @@ def _run_restore_runner(dump_file, log_file):
                 start_new_session=True,
                 close_fds=True,
             )
-            feeder = threading.Thread(target=_feed_dump, args=(proc.stdin, dump_file), daemon=True)
+            feeder = threading.Thread(target=_feed_dump, args=(proc.stdin, dump_file, feed_result), daemon=True)
             feeder.start()
             ret = proc.wait(timeout=3600)
         except subprocess.TimeoutExpired:
             if proc is not None:
+                try:
+                    proc.stdin.close()
+                except OSError:
+                    pass
                 proc.kill()
                 proc.wait()
             ret = -1
@@ -179,36 +187,47 @@ def _run_restore_runner(dump_file, log_file):
         finally:
             if feeder is not None:
                 feeder.join(timeout=10)
+        if ret == 0 and not feed_result.get('ok'):
+            ret = 1
+            log.write(
+                "Restore FAILED: dump was not fully streamed to psql (%s); database may be incomplete.\n"
+                % feed_result.get('error', 'feeder did not finish')
+            )
+            log.flush()
         log.write(f"Restore command finished with return code {ret}\n")
         log.flush()
 
         try:
-            restart_manager.publish_start_request()
-            log.write("Published worker start request.\n")
-            log.flush()
-        except Exception as exc:
-            log.write(f"Failed to publish worker start request: {exc}\n")
-            log.flush()
+            try:
+                restart_manager.publish_start_request()
+                log.write("Published worker start request.\n")
+                log.flush()
+            except Exception as exc:
+                log.write(f"Failed to publish worker start request: {exc}\n")
+                log.flush()
 
-        try:
-            restart_manager.start_local_flask_service()
-            log.write("Started local Flask service.\n")
-            log.flush()
-        except Exception as exc:
-            log.write(f"Failed to start local Flask service: {exc}\n")
-            log.flush()
+            try:
+                restart_manager.start_local_flask_service()
+                log.write("Started local Flask service.\n")
+                log.flush()
+            except Exception as exc:
+                log.write(f"Failed to start local Flask service: {exc}\n")
+                log.flush()
 
-        try:
-            os.unlink(dump_file)
-            log.write(f"Deleted temporary dump file {dump_file}\n")
-            log.flush()
-        except Exception as exc:
-            log.write(f"Could not delete temporary dump file {dump_file}: {exc}\n")
-            log.flush()
-
-        _release_restore_lock()
-        log.write("Released restore lock.\n")
-        log.flush()
+            try:
+                os.unlink(dump_file)
+                log.write(f"Deleted temporary dump file {dump_file}\n")
+                log.flush()
+            except Exception as exc:
+                log.write(f"Could not delete temporary dump file {dump_file}: {exc}\n")
+                log.flush()
+        finally:
+            _release_restore_lock()
+            try:
+                log.write("Released restore lock.\n")
+                log.flush()
+            except OSError:
+                pass
 
         log.write(f"Restore runner finished at {datetime.now().isoformat()}\n")
         log.flush()
@@ -451,8 +470,8 @@ def restore_backup():
                     if f.startswith('backup_') and f.endswith('.sql'):
                         try:
                             os.unlink(os.path.join(chunks_dir, f))
-                        except Exception as exc:
-                            logger.warning(f"Could not delete leftover chunk {f}: {exc}")
+                        except Exception:
+                            logger.warning("Could not delete leftover chunk %s", f, exc_info=True)
 
             # Save the current chunk
             try:
@@ -529,8 +548,8 @@ def restore_backup():
                         try:
                             if os.path.exists(chunk_path):
                                 os.unlink(chunk_path)
-                        except OSError as exc:
-                            logger.warning("Could not delete chunk %s after reassembly failure: %s", i, exc)
+                        except OSError:
+                            logger.warning("Could not delete chunk %s after reassembly failure", i, exc_info=True)
                     _release_restore_lock()
                     return jsonify({'error': 'Failed to reassemble chunks due to an internal error.'}), 500
             else:

--- a/tasks/ai/providers/openai.py
+++ b/tasks/ai/providers/openai.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 THINK_END_TAG = "</think>"
 
+# Models that 400-rejected reasoning_effort once; skip the param for them next time.
+_MODELS_REJECTING_REASONING = set()
+
 
 def _is_ollama_format_url(server_url: str) -> bool:
     """Detect Ollama endpoints from the URL path (issue #467 fix preserved)."""
@@ -79,8 +82,9 @@ def generate_text(
             "stream": True,
             "temperature": temp,
             "max_tokens": out_tokens,
-            "reasoning_effort": "low" if is_deepseek else "none",
         }
+        if model_name not in _MODELS_REJECTING_REASONING:
+            payload["reasoning_effort"] = "low" if is_deepseek else "none"
     else:
         payload = {
             "model": model_name,
@@ -92,7 +96,6 @@ def generate_text(
 
     max_retries = 3
     base_delay = 5
-    tried_drop_reasoning = False
     tried_aggressive_fallback = False
     tried_ultra_minimal_fallback = False
 
@@ -209,16 +212,19 @@ def generate_text(
                 try:
                     error_body = e.response.json()
                     error_obj = error_body.get("error", {})
+                    if not isinstance(error_obj, dict):
+                        error_obj = {}
                     error_code = error_obj.get("code", "") or ""
+                    error_param = error_obj.get("param", "") or ""
                     error_message = (error_obj.get("message", "") or "").lower()
-                    # Non-reasoning models (gpt-4o, gpt-4o-mini, gpt-4.1*) reject
-                    # reasoning_effort with a 400 whose error.code is null, so
-                    # match the message text and just drop the param (#696).
-                    if (not tried_drop_reasoning and "reasoning_effort" in payload
-                            and "reasoning_effort" in error_message):
+                    # gpt-4o*/gpt-4.1* reject reasoning_effort with error.code null;
+                    # drop it, remember the model, and retry (#696).
+                    if ("reasoning_effort" in payload
+                            and (error_param == "reasoning_effort"
+                                 or "reasoning_effort" in error_message)):
                         logger.info("reasoning_effort rejected (400); retrying without it")
                         payload.pop("reasoning_effort", None)
-                        tried_drop_reasoning = True
+                        _MODELS_REJECTING_REASONING.add(model_name)
                         continue
                     if error_code in ("unsupported_parameter", "unsupported_value"):
                         if not tried_aggressive_fallback:
@@ -318,7 +324,7 @@ def call_with_tools(
         ]
         if is_deepseek:
             payload.update(deepseek_thinking_off_forms[0])
-        else:
+        elif model_name not in _MODELS_REJECTING_REASONING:
             payload["reasoning_effort"] = "none"
 
         timeout = config.AI_REQUEST_TIMEOUT_SECONDS
@@ -356,6 +362,7 @@ def call_with_tools(
             elif "reasoning_effort" in payload:
                 log_messages.append("reasoning_effort unsupported by this model; retrying without it")
                 payload.pop("reasoning_effort", None)
+                _MODELS_REJECTING_REASONING.add(model_name)
                 result = _post(payload)
             else:
                 raise

--- a/test/unit/test_ai.py
+++ b/test/unit/test_ai.py
@@ -123,13 +123,22 @@ for _name, _relpath in (
 
 
 from unittest.mock import Mock, patch
+import pytest
 import requests
 import json
+import tasks.ai.providers.openai as ai_openai
 from tasks.ai.api import clean_playlist_name, get_ai_playlist_name
 from tasks.ai.providers.openai import generate_text as get_openai_compatible_playlist_name
 from tasks.ai.providers.gemini import generate_text as get_gemini_playlist_name
 from tasks.ai.providers.mistral import generate_text as get_mistral_playlist_name
 from tasks.ai.prompts import creative_prompt_template
+
+
+@pytest.fixture(autouse=True)
+def _reset_reasoning_cache():
+    ai_openai._MODELS_REJECTING_REASONING.clear()
+    yield
+    ai_openai._MODELS_REJECTING_REASONING.clear()
 
 
 class TestCleanPlaylistName:
@@ -833,7 +842,7 @@ class TestGetOpenAICompatiblePlaylistName:
     @patch('tasks.ai.providers.openai.time.sleep')
     def test_reasoning_effort_dropped_on_null_code_400(self, mock_sleep, mock_post, mock_env):
         """#696: non-reasoning models reject reasoning_effort with code=null; drop it and retry."""
-        mock_env.return_value = "0"
+        mock_env.side_effect = lambda key, default=None: "0" if key == "OPENAI_API_CALL_DELAY_SECONDS" else default
 
         # First call: 400 with code=null and message naming reasoning_effort
         mock_response_400 = Mock()
@@ -868,6 +877,9 @@ class TestGetOpenAICompatiblePlaylistName:
 
         assert result == "OK Playlist"
         assert mock_post.call_count == 2
+        # First call must actually carry reasoning_effort, else the drop is a no-op.
+        first_call_data = json.loads(mock_post.call_args_list[0][1]['data'])
+        assert first_call_data.get('reasoning_effort') == 'none'
         # Only reasoning_effort dropped; temperature and max_tokens preserved.
         second_call_data = json.loads(mock_post.call_args_list[1][1]['data'])
         assert 'reasoning_effort' not in second_call_data

--- a/test/unit/test_app_backup_restore.py
+++ b/test/unit/test_app_backup_restore.py
@@ -132,13 +132,23 @@ class TestFeedDumpStrip:
             b"COPY t (a) FROM stdin;\n1\n\\.\n"
         )
         fake = _FakeStdin()
-        app_backup._feed_dump(fake, str(dump))
+        result = {}
+        app_backup._feed_dump(fake, str(dump), result)
         out = bytes(fake.buf)
         assert out.startswith(b"DROP SCHEMA IF EXISTS public CASCADE; CREATE SCHEMA public;\n")
         assert b"transaction_timeout" not in out
         assert b"SET statement_timeout = 0;\n" in out
         assert b"SET client_encoding = 'UTF8';\n" in out
         assert b"COPY t (a) FROM stdin;" in out
+        assert fake.closed is True
+        assert result.get('ok') is True
+
+    def test_missing_dump_file_is_not_reported_ok(self, tmp_path):
+        fake = _FakeStdin()
+        result = {}
+        app_backup._feed_dump(fake, str(tmp_path / 'does_not_exist.sql'), result)
+        assert result.get('ok') is not True
+        assert 'error' in result
         assert fake.closed is True
 
 


### PR DESCRIPTION
This PR contains:
## app_backup.py (restore)

###  Reliability & correctness
- **HIGH — Prevent silent false-success:** `_feed_dump` now records delivery in a result dict. The runner forces failure (`ret=1` + an explicit **"Restore FAILED… database may be incomplete"** log entry) whenever `psql` exits with `0` but the dump was not fully streamed. The previous `except: pass` no longer hides a short/incomplete feed.
- **Regex over-match fixed:** `sub(..., count=1)` now removes only the single prologue `transaction_timeout` line, ensuring `COPY` data rows can never be accidentally deleted.
- **Timeout kill-path:** `proc.stdin.close()` is now called before `proc.kill()` on timeout so the feeder thread unblocks correctly.
- **Redis lock leak fixed:** Post-`psql` cleanup is wrapped in `try/finally`, ensuring the Redis lock is always released even if logging raises an exception.

### Logging
- **S8572:** `app_backup.py:477` and `:555` now use `exc_info=True` instead of `f"...{exc}"`.
- **Reproducible logging:** The **"Running restore command"** log now includes `< <dump_file>` to accurately reflect stdin redirection.

### Tests
- Updated tests for the new `_feed_dump` signature.
- Added a missing-file test verifying the restore is **not** incorrectly reported as successful.

---

## tasks/ai/providers/openai.py (`reasoning_effort`)

### Performance
- **Eliminated repeated failed probes:** Added a self-learning `_MODELS_REJECTING_REASONING` cache. Once a model returns a `400` rejecting `reasoning_effort`, subsequent calls (both `generate_text` and `call_with_tools`) skip the unsupported parameter. Models such as `gpt-4o-mini` now pay the failed probe at most once per process instead of once per request.

###  Robustness
- **Improved fallback detection:** Detects unsupported `reasoning_effort` using either:
  - `error.param == "reasoning_effort"` (structured errors), or
  - the error message substring.
- Added an `isinstance(error_obj, dict)` guard so string-form error bodies no longer raise `AttributeError` and silently bypass the fallback.

### Consistency
- `call_with_tools` now shares the same cache/gating behavior.
- Removed the redundant `tried_drop_reasoning` flag.

### Tests
- Added an `autouse` fixture to reset the cache between tests.
- Updated tests to assert the first call includes `reasoning_effort`.
- Scoped the environment mock to the delay variable only.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28360635726/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28356646046/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28356646046/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28356646046/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28356646046/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28360635704/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-705`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-705-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-705-noavx2`
<!-- pr-test-build:end -->