### PR TITLE
Navidrome first in documentation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,7 +34,7 @@ If applicable, add screenshots to help explain your problem.
  - OS: [e.g. Debian, Windows]
  - Deployment: [e.g. Docker Compose, K3s, Helm]
  - AudioMuse-AI Version: [e.g. v0.4.0-beta, latest]
- - Jellyfin/Navidrome Version: [e.g. Navidrome 0.57.0]
+ - Navidrome/Jellyfin Version: [e.g. Navidrome 0.57.0]
  - Browser: [e.g. chrome, safari]
  - CPU: [e.g. Intel I5-6500, Arm xyz]
  - RAM: [e.g. 8GB DDR4]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,8 +27,8 @@
 - [ ] NVIDIA image
 
 **Tested on media server:**
-- [ ] Jellyfin
 - [ ] Navidrome
+- [ ] Jellyfin
 - [ ] Emby
 - [ ] Lyrion
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ The following table details the most important paths in the repository, their pu
 | :---- | :---- |
 | app.py, app_*.py | The main entry point for the Flask web application. It handles the initialization of the Flask app, database connections, and the registration of API routes and blueprints. |
 | tasks/ | **The Core Logic Hub.** This is where the most intensive computations occur. Each API or async task then point to an specific implementation in this directory|
-| tasks/mediaserver/ | In this package the generic methods to interact with the mediaservers (`__init__.py`) dispatch to the specific backend (`jellyfin.py`, `navidrome.py`, `emby.py`, `lyrion.py`) |
+| tasks/mediaserver/ | In this package the generic methods to interact with the mediaservers (`__init__.py`) dispatch to the specific backend (`navidrome.py`, `jellyfin.py`, `emby.py`, `lyrion.py`) |
 | tasks/ai/ | All AI / MCP code. `tasks/ai/api.py` is the provider dispatcher (called via `tasks.ai.api.call_with_tools()`), with backends in `tasks/ai/providers/{openai,gemini,mistral}.py` (openai.py also drives Ollama). Prompts and the derived tool-call grammar are in `tasks/ai/prompts.py`. MCP tool schemas + dispatcher in `tasks/ai/tools.py`; tool bodies in `tasks/ai/tool_impl.py`. Single-call planner (plan validation + execution) in `tasks/ai/planner.py`. Vocabulary normalization helpers in `tasks/ai/vocab.py`. |
 | config.py | Contains the application's default, non-sensitive configuration parameters. These values serve as fallbacks and can be easily overridden by environment variables, providing a flexible and secure configuration system. |
 | Authentication | Configured in `config.py` by `AUTH_ENABLED`, `AUDIOMUSE_USER`, `AUDIOMUSE_PASSWORD`, `API_TOKEN`, and `JWT_SECRET`. Enforcement happens in `app.py` and `app_helepr.py` functionality |
@@ -136,8 +136,8 @@ This workflow helps avoid spending time on PRs that may not align with project g
 Below the full list of related repository. When you submit a PR avoid to introduce change that could brake one or more of this repository:
   > * [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI): the core application, it run Flask and Worker containers to actually run all the feature;
   > * [AudioMuse-AI Helm Chart](https://github.com/NeptuneHub/AudioMuse-AI-helm): helm chart for easy installation on Kubernetes;
-  > * [AudioMuse-AI Plugin for Jellyfin](https://github.com/NeptuneHub/audiomuse-ai-plugin): Jellyfin Plugin;
   > * [AudioMuse-AI Plugin for Navidrome](https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin): Navidrome Plugin;
+  > * [AudioMuse-AI Plugin for Jellyfin](https://github.com/NeptuneHub/audiomuse-ai-plugin): Jellyfin Plugin;
   > * [AudioMuse-AI MusicServer](https://github.com/NeptuneHub/AudioMuse-AI-MusicServer): Open Subosnic like Music Sever with integrated sonic functionality.
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![GitHub license](https://img.shields.io/github/license/neptunehub/AudioMuse-AI.svg)
 ![Latest Tag](https://img.shields.io/github/v/tag/neptunehub/AudioMuse-AI?label=latest-tag)
-![Media Server Support: Jellyfin 12.0, Navidrome 0.62.0, LMS v3.69.0, Lyrion 9.0.2, Emby 4.9.1.80, Plex 1.43.2](https://img.shields.io/badge/Media%20Server-Jellyfin%2012.0%2C%20Navidrome%200.62.0%2C%20LMS%20v3.69.0%2C%20Lyrion%209.0.2%2C%20Emby%204.9.1.80%2C%20Plex%201.43.2-blue?style=flat-square&logo=server&logoColor=white)
+![Media Server Support: Navidrome 0.62.0, Jellyfin 12.0, LMS v3.69.0, Lyrion 9.0.2, Emby 4.9.1.80, Plex 1.43.2](https://img.shields.io/badge/Media%20Server-Navidrome%200.62.0%2C%20Jellyfin%2012.0%2C%20LMS%20v3.69.0%2C%20Lyrion%209.0.2%2C%20Emby%204.9.1.80%2C%20Plex%201.43.2-blue?style=flat-square&logo=server&logoColor=white)
 <a href="https://www.bestpractices.dev/projects/13329"><img src="https://www.bestpractices.dev/projects/13329/badge"></a>
 
 <p align="center">
@@ -19,7 +19,7 @@
 
 AudioMuse-AI is an opensource and self-hosted tool that uses sonic analysis to rediscover forgotten songs in your music library and generate groove-aware playlists that also capture the meaning behind each track, without relying on metadata or external APIs.
 
-You can run it locally with Docker Compose or Podman, deploy it at scale in a Kubernetes cluster (**AMD64** and **ARM64** supported), or use native applications available for **macOS, Windows, and Linux**. It integrates with major self-hosted music servers including [Jellyfin](https://jellyfin.org), [Navidrome](https://www.navidrome.org/), [LMS](https://github.com/epoupon/lms/tree/master), [Lyrion](https://lyrion.org/), [Emby](https://emby.media), and [Plex](https://www.plex.tv/), with more integrations planned.
+You can run it locally with Docker Compose or Podman, deploy it at scale in a Kubernetes cluster (**AMD64** and **ARM64** supported), or use native applications available for **macOS, Windows, and Linux**. It integrates with major self-hosted music servers including [Navidrome](https://www.navidrome.org/), [Jellyfin](https://jellyfin.org), [LMS](https://github.com/epoupon/lms/tree/master), [Lyrion](https://lyrion.org/), [Emby](https://emby.media), and [Plex](https://www.plex.tv/), with more integrations planned.
 
 > **Prefer not to self-host?** We're proud that [Elestio](https://elest.io/open-source/audiomuse-ai) picked AudioMuse-AI as a managed cloud service, happy to see the project reach more people.
 
@@ -56,8 +56,8 @@ More information like [ARCHITECTURE](docs/ARCHITECTURE.md), [ALGORITHM DESCRIPTI
 **The full list or AudioMuse-AI related repository are:** 
   > * [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI): the core application, it run Flask and Worker containers to actually run all the feature;
   > * [AudioMuse-AI Helm Chart](https://github.com/NeptuneHub/AudioMuse-AI-helm): helm chart for easy installation on Kubernetes;
-  > * [AudioMuse-AI Plugin for Jellyfin](https://github.com/NeptuneHub/audiomuse-ai-plugin): Jellyfin Plugin;
   > * [AudioMuse-AI Plugin for Navidrome](https://github.com/NeptuneHub/AudioMuse-AI-NV-plugin): Navidrome Plugin;
+  > * [AudioMuse-AI Plugin for Jellyfin](https://github.com/NeptuneHub/audiomuse-ai-plugin): Jellyfin Plugin;
   > * [lyrion-audiomuseai-plugin](https://github.com/JameZUK/lyrion-audiomuseai-plugin): Unofficial Lyrion Plugin by [JameZUK](https://github.com/JameZUK);
   > * [AudioMuse-AI MusicServer](https://github.com/NeptuneHub/AudioMuse-AI-MusicServer): Open Subosnic like Music Sever with integrated sonic functionality.
 
@@ -95,7 +95,7 @@ From `v1.0.0`, only PostgreSQL, Redis, and `TZ` configuration must still be conf
 
 **Prerequisites:**
 * Docker and Docker Compose installed
-* A running media server (Jellyfin, Navidrome, Lyrion, Emby, or Plex)
+* A running media server (Navidrome, Jellyfin, Lyrion, Emby, or Plex)
 * See [Hardware Requirements](#hardware-requirements)
 
 **Steps:**

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -86,7 +86,7 @@ Core components and responsibilities:
 
 - ONNX Models & Audio Stack: Analysis uses ONNX Runtime to run embedding and prediction models. Audio loading uses `librosa` with a `pydub`/ffmpeg fallback for resilient decoding. The Docker image pre-fetches ONNX model files and pins runtime libs to ensure consistent behavior across environments.
 
-- Media Server Adapters: the `tasks/mediaserver/` package provides adapters for Jellyfin, Navidrome, Emby, etc., enabling playlist creation and reading play-history for the Sonic Fingerprint feature.
+- Media Server Adapters: the `tasks/mediaserver/` package provides adapters for Navidrome, Jellyfin, Emby, etc., enabling playlist creation and reading play-history for the Sonic Fingerprint feature.
 
 Deployment considerations (informed by `Dockerfile`):
 
@@ -219,7 +219,7 @@ The technical process is a distributed, multi-stage pipeline orchestrated by a m
 
 This function, running in an RQ worker, acts as the "orchestrator."
 
-1. **Get Albums:** It calls get\_recent\_albums(num\_recent\_albums). This function's behavior is determined by MEDIASERVER\_TYPE (e.g., "jellyfin", "navidrome") and uses the corresponding credentials (e.g., JELLYFIN\_URL, JELLYFIN\_TOKEN, etc.) and MUSIC\_LIBRARIES to filter the scan.  
+1. **Get Albums:** It calls get\_recent\_albums(num\_recent\_albums). This function's behavior is determined by MEDIASERVER\_TYPE (e.g., "navidrome", "jellyfin") and uses the corresponding credentials (e.g., JELLYFIN\_URL, JELLYFIN\_TOKEN, etc.) and MUSIC\_LIBRARIES to filter the scan.  
 2. **Iterate & Check:** It loops through every album, checking against the PostgreSQL database (configured via DATABASE\_URL) to see if all tracks already exist in the score and embedding tables.  
 3. **Spawn Child Tasks:** For new or incomplete albums, it enqueues a tasks.analysis.analyze\_album\_task child task.  
 4. **Manage Parallelism:** The main task monitors the number of active\_jobs and limits concurrent enqueued album tasks to MAX\_QUEUED\_ANALYSIS\_JOBS.  
@@ -266,11 +266,11 @@ The Song Analysis functionality is configured by the following environment varia
 
 #### **Media Server**
 
-* MEDIASERVER\_TYPE: **(Required)** Specifies the media server to connect to. (e.g., jellyfin, navidrome, emby, lyrion).  
+* MEDIASERVER\_TYPE: **(Required)** Specifies the media server to connect to. (e.g., navidrome, jellyfin, emby, lyrion).  
 * MUSIC\_LIBRARIES: (Optional) A comma-separated list of library names to scan. If empty, all music libraries are scanned.  
+* NAVIDROME\_URL, NAVIDROME\_USER, NAVIDROME\_PASSWORD: Credentials for Navidrome (if MEDIASERVER\_TYPE="navidrome").  
 * JELLYFIN\_URL, JELLYFIN\_USER\_ID, JELLYFIN\_TOKEN: Credentials for Jellyfin (if MEDIASERVER\_TYPE="jellyfin").  
 * EMBY\_URL, EMBY\_USER\_ID, EMBY\_TOKEN: Credentials for Emby (if MEDIASERVER\_TYPE="emby").  
-* NAVIDROME\_URL, NAVIDROME\_USER, NAVIDROME\_PASSWORD: Credentials for Navidrome (if MEDIASERVER\_TYPE="navidrome").  
 * LYRION\_URL: Credentials for Lyrion (if MEDIASERVER\_TYPE="lyrion").
 
 #### **Task & Performance Tuning**
@@ -1045,8 +1045,8 @@ The Sonic Fingerprint feature uses the following configurations:
 #### **Media Server**
 
 * MEDIASERVER\_TYPE: **(Required)** Determines how to interact with the media server API to get play history and create playlists.  
-* JELLYFIN\_URL, JELLYFIN\_USER\_ID, JELLYFIN\_TOKEN: Default Jellyfin credentials (used if user doesn't provide specific ones, and for resolving usernames).  
 * NAVIDROME\_URL, NAVIDROME\_USER, NAVIDROME\_PASSWORD: Default Navidrome credentials (used if user doesn't provide specific ones).  
+* JELLYFIN\_URL, JELLYFIN\_USER\_ID, JELLYFIN\_TOKEN: Default Jellyfin credentials (used if user doesn't provide specific ones, and for resolving usernames).  
 * *(Other media server credentials)*: Used similarly based on MEDIASERVER\_TYPE.
 
 #### **Sonic Fingerprint Parameters**
@@ -1119,7 +1119,7 @@ Stage 5: Execute Query & Post-process Results
 
 Stage 6: Optional Playlist Creation on Media Server
 
-1. The frontend posts the playlist name and `item_ids` to an endpoint that maps internal `item_id`s to media-server-specific IDs and creates the playlist using the configured media server adapter (Jellyfin/Emby/Navidrome). These adapter functions live in `tasks/mediaserver/`.
+1. The frontend posts the playlist name and `item_ids` to an endpoint that maps internal `item_id`s to media-server-specific IDs and creates the playlist using the configured media server adapter (Navidrome/Jellyfin/Emby). These adapter functions live in `tasks/mediaserver/`.
 2. Return the media server response (success, playlist id, or error) to the frontend and display it in the UI.
 
 Safety & Fallbacks
@@ -1180,7 +1180,7 @@ Key User Interactions & Workflow
 1. The user opens the Database Cleaning page (`/cleaning`) served by the `analysis_bp` blueprint. The page shows a summary area, Start/Clear buttons, and a status panel (see `templates/cleaning.html`).
 2. The user clicks "Start Cleaning". The frontend requests `/api/cleaning/start` which enqueues a high-priority RQ job (`tasks.cleaning.identify_and_clean_orphaned_albums_task`).
 3. The cleaning job performs these high-level steps:
-   - Fetch all albums/tracks from the configured media server via the mediaserver adapter (Jellyfin/Navidrome/Emby).
+   - Fetch all albums/tracks from the configured media server via the mediaserver adapter (Navidrome/Jellyfin/Emby).
    - Read all tracks currently present in the application's PostgreSQL database (score + embedding tables).
    - Compute the set difference to discover orphaned tracks (in DB but not on the media server).
    - Group orphaned tracks by artist/album and present a summary.
@@ -1236,7 +1236,7 @@ Core Infra
 
 * `REDIS_URL` - Required by RQ for job queueing and for the background listener used elsewhere.
 * `DATABASE_URL` - Required to query and delete database rows, and to rebuild the Voyager index.
-* `MEDIASERVER_TYPE`, `JELLYFIN_URL`, `JELLYFIN_TOKEN`, `NAVIDROME_URL`, etc. - Credentials used by the mediaserver adapter to enumerate media server albums and to resolve track IDs.
+* `MEDIASERVER_TYPE`, `NAVIDROME_URL`, `JELLYFIN_URL`, `JELLYFIN_TOKEN`, etc. - Credentials used by the mediaserver adapter to enumerate media server albums and to resolve track IDs.
 
 Cleaning-Specific
 

--- a/docs/ALGORITHM.md
+++ b/docs/ALGORITHM.md
@@ -484,7 +484,7 @@ The Song Clustering functionality is configured by the following environment var
 
 * REDIS\_URL: **(Required)** The connection string for the Redis server, used for task queueing and status management.  
 * DATABASE\_URL (or POSTGRES\_\* variables): **(Required)** The connection string for the PostgreSQL database where all analysis results are read from.  
-* MEDIASERVER\_TYPE, JELLYFIN\_URL, etc.: **(Required)** Media server credentials are used at the *end* of the process to delete old playlists and create the new ones.
+* MEDIASERVER\_TYPE, NAVIDROME\_URL, etc.: **(Required)** Media server credentials are used at the *end* of the process to delete old playlists and create the new ones.
 
 #### **Main Clustering Configuration**
 
@@ -633,7 +633,7 @@ The "Playlist from Similar Song" feature relies on the Voyager index built durin
 
 * REDIS\_URL: **(Required)** Used by the background listener thread that reloads the Voyager index.  
 * DATABASE\_URL (or POSTGRES\_\* variables): **(Required)** Used to load the index data, fetch track details (Title/Artist), and perform autocomplete searches.  
-* MEDIASERVER\_TYPE, JELLYFIN\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
+* MEDIASERVER\_TYPE, NAVIDROME\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
 
 #### **Voyager Index Querying (Used during Similarity Search)**
 
@@ -752,7 +752,7 @@ The Song Path feature uses the Voyager index and relies on several specific conf
 
 #### **Media Server (for Playlist Creation)**
 
-* MEDIASERVER\_TYPE, JELLYFIN\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
+* MEDIASERVER\_TYPE, NAVIDROME\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
 
 ## **5\. Song Alchemy**
 
@@ -858,7 +858,7 @@ Song Alchemy uses the Voyager index and several specific parameters:
 
 #### **Media Server (for Playlist Creation)**
 
-* MEDIASERVER\_TYPE, JELLYFIN\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
+* MEDIASERVER\_TYPE, NAVIDROME\_URL, etc.: **(Required)** Used at the final stage to create the playlist on the media server.
 
 ## **6\. Music Map**
 
@@ -958,7 +958,7 @@ The Music Map relies heavily on data generated during Analysis but has fewer dir
 #### **Core Infrastructure**
 
 * DATABASE\_URL (or POSTGRES\_\* variables): **(Required)** Used by build\_map\_cache to fetch all song data and embeddings at startup, and potentially to load precomputed projections.  
-* MEDIASERVER\_TYPE, JELLYFIN\_URL, etc.: **(Required)** Used by the "Create playlist" button functionality.
+* MEDIASERVER\_TYPE, NAVIDROME\_URL, etc.: **(Required)** Used by the "Create playlist" button functionality.
 
 #### **Data & Visualization (Implicit)**
 
@@ -1000,7 +1000,7 @@ This feature combines media server interaction for user history with vector anal
 #### **Stage 1: API Call & Credential Handling**
 
 1. **Route:** Clicking "Generate My Sonic Fingerprint" sends a POST (or GET for backward compatibility) request to /api/sonic\_fingerprint/generate (app\_sonic\_fingerprint.py).  
-2. **Payload/Params:** Contains the desired number of results (n) and user-specific credentials (jellyfin\_user\_identifier, jellyfin\_token or navidrome\_user, navidrome\_password).  
+2. **Payload/Params:** Contains the desired number of results (n) and user-specific credentials (navidrome\_user, navidrome\_password or jellyfin\_user\_identifier, jellyfin\_token).  
 3. **Credential Resolution:**  
    * The backend retrieves the credentials from the request.  
    * For Jellyfin/Emby, it uses resolve\_emby\_jellyfin\_user to convert a username/identifier into the required User ID using the provided token.  
@@ -1451,7 +1451,7 @@ The Text Search functionality is configured by the following environment variabl
 
 * `REDIS_URL`: **(Required)** Used by RQ workers and pub/sub.
 * `DATABASE_URL` (or `POSTGRES_*` variables): **(Required)** Used to fetch CLAP embeddings and song metadata.
-* `MEDIASERVER_TYPE`, `JELLYFIN_URL`, etc.: **(Required)** Used to create playlists from search results.
+* `MEDIASERVER_TYPE`, `NAVIDROME_URL`, etc.: **(Required)** Used to create playlists from search results.
 
 #### **CLAP Feature Toggle**
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,7 +16,7 @@ graph TB
     Redis ---|Dequeue Tasks| Worker[Worker Container<br/>Analysis + Clustering]
     PostgreSQL ---|Read/Write| Worker
     
-    MediaServer[Media Server<br/>Jellyfin/Navidrome<br/>Lyrion/Emby] -.-|Fetch Music| Flask
+    MediaServer[Media Server<br/>Navidrome/Jellyfin<br/>Lyrion/Emby] -.-|Fetch Music| Flask
     MediaServer -.-|Fetch Audio Files| Worker
     
     style User fill:#607D8B
@@ -56,7 +56,7 @@ graph TB
 
 ### Media Server
 - **Music Source**: Provides access to audio library
-- **API Integration**: Jellyfin, Navidrome, Lyrion, or Emby APIs
+- **API Integration**: Navidrome, Jellyfin, Lyrion, or Emby APIs
 - **Audio Streaming**: Streams audio files for analysis
 - **Playlist Sync**: Target for generated playlists
 
@@ -88,8 +88,8 @@ graph TB
 | Flask (Web UI + API) | 8000 | HTTP |
 | Redis | 6379 | TCP |
 | PostgreSQL | 5432 | TCP |
-| Jellyfin | 8096 | HTTP |
 | Navidrome | 4533 | HTTP |
+| Jellyfin | 8096 | HTTP |
 | Lyrion | 9000 | HTTP |
 | Emby | 8096 | HTTP |
 

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -74,6 +74,6 @@ spec:
 
 ## Plugin 
 
-> Actually Jellyfin plugin `v0.1.51` (for Jellyfin 10.10.7) and `v0.1.52` (for jellyfin 10.11) already added this support
+> Navidrome plugin support it from release v7
 > 
-> Navidrome plugin support it from release v7 
+> Jellyfin plugin `v0.1.51` (for Jellyfin 10.10.7) and `v0.1.52` (for jellyfin 10.11) already added this support

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -20,7 +20,7 @@ The easiest way to install AudioMuse-AI on K3S is with the [AudioMuse-AI Helm Ch
   * A running K3S cluster
   * `kubectl` configured for your cluster
   * `helm` installed
-  * A media server already installed: Jellyfin, Emby, Navidrome, or Lyrion
+  * A media server already installed: Navidrome, Jellyfin, Emby, or Lyrion
   * See the hardware requirements in the documentation
 
 Use the Helm chart for the simplest, most production-ready K3S deploy.
@@ -32,7 +32,7 @@ This section covers direct deployment with the `deployment/*.yaml` manifests.
 * **Prerequisites:**
   * A running K3S cluster
   * `kubectl` configured for your cluster
-  * A media server already installed: Jellyfin, Emby, Navidrome, or Lyrion
+  * A media server already installed: Navidrome, Jellyfin, Emby, or Lyrion
   * See the hardware requirements in the documentation
 
 * **Get manifest example:**
@@ -65,7 +65,7 @@ AudioMuse-AI provides Docker Compose files example:
 
 **Prerequisites:**
 * Docker and Docker Compose installed
-* A media server already installed: Jellyfin, Navidrome, Lyrion, or Emby
+* A media server already installed: Navidrome, Jellyfin, Lyrion, or Emby
 * See the [hardware requirements](../README.md#hardware-requirements)
 
 **Steps:**

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -26,9 +26,9 @@ Find answers to common questions about setting up, configuring, and deploying Au
 <details>
 <summary>Can AudioMuse-AI support multiple music libraries?</summary>
 
-> Yes, it can support multiple music libraries within a single media server instance (e.g., two separate music folders in one Jellyfin server). However, a single AudioMuse-AI instance cannot connect to multiple different media servers (e.g., one Jellyfin and one Navidrome server) at the same time.
+> Yes, it can support multiple music libraries within a single media server instance (e.g., two separate music folders in one Jellyfin server). However, a single AudioMuse-AI instance cannot connect to multiple different media servers (e.g., one Navidrome and one Jellyfin server) at the same time.
 >
-> The parameters `MUSIC_LIBRARIES` can be used for matching multiple music libraries on the same music server. It is a comma-separated list of music libraries/folders for analysis. If empty, all libraries/folders are scanned. For Lyrion: Use folder paths like "/music/myfolder". For Jellyfin/Navidrome: Use library/folder names.
+> The parameters `MUSIC_LIBRARIES` can be used for matching multiple music libraries on the same music server. It is a comma-separated list of music libraries/folders for analysis. If empty, all libraries/folders are scanned. For Lyrion: Use folder paths like "/music/myfolder". For Navidrome/Jellyfin: Use library/folder names.
 
 </details>
 

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -26,15 +26,15 @@ The **mandatory** parameter that you need to change from the example are this:
 | Parameter            | Description                                                             | Default Value                     |
 |----------------------|-------------------------------------------------------------------------|-----------------------------------|
 | **Mediaserver General**                        |                                                                 |                 |
+| `NAVIDROME_URL`      | (Required) Your Navidrome server's full URL                             | `http://YOUR_JELLYFIN_IP:4553`    |
+| `NAVIDROME_USER`     | (Required) Navidrome User ID.                                           | *(N/A - from Secret)* |
+| `NAVIDROME_PASSWORD` | (Required) Navidrome user Password.                                     | *(N/A - from Secret)* |
 | `JELLYFIN_URL`       | (Required) Your Jellyfin server's full URL                              | `http://YOUR_JELLYFIN_IP:8096`    |
 | `JELLYFIN_USER_ID`   | (Required) Jellyfin User ID.                                            | *(N/A - from Secret)* |
 | `JELLYFIN_TOKEN`     | (Required) Jellyfin API Token.                                          | *(N/A - from Secret)* |
 | `EMBY_URL`           | (Required) Your Emby server's full URL                                  | `http://YOUR_EMBY_IP:8096`    |
 | `EMBY_USER_ID`       | (Required) Emby User ID.                                                | *(N/A - from Secret)* |
 | `EMBY_TOKEN`         | (Required) Emby API Token.                                              | *(N/A - from Secret)* |
-| `NAVIDROME_URL`      | (Required) Your Navidrome server's full URL                             | `http://YOUR_JELLYFIN_IP:4553`    |
-| `NAVIDROME_USER`     | (Required) Navidrome User ID.                                           | *(N/A - from Secret)* |
-| `NAVIDROME_PASSWORD` | (Required) Navidrome user Password.                                     | *(N/A - from Secret)* |
 | `LYRION_URL`         | (Required) Your Lyrion server's full URL                                | `http://YOUR_LYRION_IP:9000`      |
 | `PLEX_URL`           | (Required) Your Plex Media Server's full URL                            | `http://YOUR_PLEX_IP:32400`       |
 | `PLEX_TOKEN`         | (Required) Plex API token (X-Plex-Token).                               | *(N/A - from Secret)* |

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -60,7 +60,7 @@ These parameters can be left as-is:
 | Parameter               | Description                                  | Default Value     |
 |-------------------------|----------------------------------------------|-------------------|
 | `CLEANING_SAFETY_LIMIT` | Max number of albums deleted during cleaning | `100`             |
-| `MUSIC_LIBRARIES`       | Comma-separated list of music libraries/folders for analysis. If empty, all libraries/folders are scanned. For Lyrion: Use folder paths like "/music/myfolder". For Jellyfin/Navidrome: Use library/folder names. | `""` (empty - scan all) |
+| `MUSIC_LIBRARIES`       | Comma-separated list of music libraries/folders for analysis. If empty, all libraries/folders are scanned. For Lyrion: Use folder paths like "/music/myfolder". For Navidrome/Jellyfin: Use library/folder names. | `""` (empty - scan all) |
 | `ENABLE_PROXY_FIX` | Enable Proxy Fix for Flask when behind a reverse proxy. Example Nginx configuration: [config.py](https://github.com/NeptuneHub/AudioMuse-AI/blob/main/config.py#L346) | `false` |
 | `WORKER_URL` | This is the Url your worker instance runs on. The server instance uses this parameter to call the worker. Make sure to include /worker at the end of the url (e.g. http://worker.example.com:8029/worker) | `false` |
 | `WORKER_POSTGRES_HOST` | This is the Url of your the postgres service on your server. The worker uses this to connect the postgres service the flask app uses too. Make sure to not include a protocol (like "http") (e.g. 100.000.00.00) | `false` |
@@ -175,7 +175,7 @@ These are the default parameters used when launching analysis or clustering task
 | `SCORE_WEIGHT_DAVIES_BOULDIN`               | Weight for Davies-Bouldin Index (cluster separation).                                     | `0.0`                                  |
 | `SCORE_WEIGHT_CALINSKI_HARABASZ`            | Weight for Calinski-Harabasz Index (cluster separation).                                  | `0.0`                                  |
 | **Lyrics & SemGrove (Semantic + Groove) Search** |                                                                                      |                                        |
-| `MUSICSERVER_LYRICS_TIMEOUT`                | Timeout (seconds) for fetching embedded lyrics from the media server (Jellyfin / Emby / Navidrome / Lyrion). Increase if your server fetches lyrics on-the-fly via plugins that may take several seconds to respond. | `2.5` |
+| `MUSICSERVER_LYRICS_TIMEOUT`                | Timeout (seconds) for fetching embedded lyrics from the media server (Navidrome / Jellyfin / Emby / Lyrion). Increase if your server fetches lyrics on-the-fly via plugins that may take several seconds to respond. | `2.5` |
 | `LYRICS_ENABLED`                            | When `false`, the lyrics transcription/embedding step is skipped entirely during analysis. | `true`                                |
 | `LYRICS_API_ENABLE`                         | When `true`, fetches lyrics from external APIs (slots 1 & 2) before falling back to Whisper-small ASR transcription. | `true`               |
 | `LYRICS_ASR_ENABLE`                         | When `false`, skips the Whisper-small ASR transcription stage entirely. Tracks with no media-server lyrics and no external-API lyrics are marked as instrumental (sentinel embedding) instead of being transcribed. | `true` |

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -26,7 +26,7 @@ The **mandatory** parameter that you need to change from the example are this:
 | Parameter            | Description                                                             | Default Value                     |
 |----------------------|-------------------------------------------------------------------------|-----------------------------------|
 | **Mediaserver General**                        |                                                                 |                 |
-| `NAVIDROME_URL`      | (Required) Your Navidrome server's full URL                             | `http://YOUR_JELLYFIN_IP:4553`    |
+| `NAVIDROME_URL`      | (Required) Your Navidrome server's full URL                             | `http://YOUR_NAVIDROME_IP:4533`   |
 | `NAVIDROME_USER`     | (Required) Navidrome User ID.                                           | *(N/A - from Secret)* |
 | `NAVIDROME_PASSWORD` | (Required) Navidrome user Password.                                     | *(N/A - from Secret)* |
 | `JELLYFIN_URL`       | (Required) Your Jellyfin server's full URL                              | `http://YOUR_JELLYFIN_IP:8096`    |


### PR DESCRIPTION
Navidrome first in documentation

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28745718388/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28741694032/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28741694032/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28741694032/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28741694032/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28746125709/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-717`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-717-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-717-noavx2`
<!-- pr-test-build:end -->