### PR TITLE
Multi-Plugin fix

### DIFF
--- a/docs/PLUGIN.md
+++ b/docs/PLUGIN.md
@@ -134,6 +134,8 @@ def register(ctx):
 
 The full SongCounter draws its counts as a bar chart with matplotlib, which is why its `plugin.json` lists `matplotlib` under `requirements`.
 
+One naming rule: **the Blueprint name must be your plugin id**, like SongCounter does with `Blueprint("song_counter", __name__)`. The plugin id is unique by definition, so your routes (`song_counter.home`, `song_counter.settings`) can never collide with another plugin. Blueprint names are unique across the whole app: if two plugins use the same name, the second one fails to load with a clear error, and a plugin using any other name gets a warning in the log.
+
 If you want a settings page, add a route called `settings`. AudioMuse-AI opens it from the Settings button on the Manage Plugins page, so it does not add a menu entry for it. If your settings route has a different name, point to it with `ctx.set_settings_page("song_counter.my_settings")`. The settings page is always admin only.
 
 To publish, one more file lists the plugin: the catalog `manifest.json`. It has one small entry per plugin, holding `id`, `name`, `author`, `description`, and a `pluginUrl` that points at that plugin's `plugin.json`. AudioMuse-AI reads the catalog, follows `pluginUrl` to your `plugin.json`, picks the newest version the running core supports, downloads its `sourceUrl` zip (code only, with no `plugin.json` inside), and verifies the `checksum`. You never write the catalog or the `sourceUrl`/`checksum`; the build workflow generates them from your `plugin.json`.
@@ -502,7 +504,7 @@ Each plugin on the Installed tab has a status badge:
 * **ok** - the plugin loaded and is running.
 * **error** - the plugin failed to load. A short message shows under the plugin and tells you which container failed (for example "failed on worker: ..."); the full error is in that container's logs. The rest of AudioMuse-AI keeps working.
 * **incompatible** - this version needs a newer AudioMuse-AI core, or it needs extra pip packages on a build that cannot install them (a standalone build, or `PLUGIN_ALLOW_PIP=false`).
-* **deps_failed** - the plugin code is installed but its pip dependencies could not be installed. The message under the plugin shows the pip error.
+* **deps_failed** - the plugin code is installed but its pip dependencies could not be satisfied. The message under the plugin shows the reason. This can also happen when two plugins pin conflicting versions of the same package: they share one library folder, so only one pin can win. The plugin still runs, but check that it behaves correctly.
 * **pending** - the plugin has not been loaded yet. Apply the restart.
 
 ### Where the logs are

--- a/plugin/manager.py
+++ b/plugin/manager.py
@@ -187,6 +187,8 @@ def _valid_requirement(spec):
 
 _PLUGIN_ROLES = ('flask', 'worker')
 
+_LOADED_STATUSES = ('ok', 'deps_failed')
+
 
 def _plugin_targets(manifest):
     raw = (manifest or {}).get('targets')
@@ -521,6 +523,17 @@ class PluginManager:
                         'Dependency install failed for plugin %s: %s',
                         plugin_id, record['requirements'],
                     )
+        for plugin_id in plugins_with_reqs:
+            record = self.records[plugin_id]
+            unmet = self._missing_specs(
+                sorted({str(s) for s in record['requirements'] if _valid_requirement(s)})
+            )
+            if unmet:
+                record['deps_error'] = (
+                    'unsatisfied requirement(s) after install: ' + ', '.join(unmet) +
+                    ' (another plugin may pin a conflicting version of the same package)'
+                )
+                logger.error('Plugin %s has %s', plugin_id, record['deps_error'])
 
     def _persist_status(self, plugin_id, status, role=None, error=None):
         if role is None and self._loaded_role is not None:
@@ -584,6 +597,17 @@ class PluginManager:
                     record['onnx_providers'] = ctx.onnx_providers
                     record['song_analyzed_hooks'] = ctx.song_analyzed_hooks
                     if role == 'web' and flask_app is not None and ctx.blueprint is not None:
+                        if ctx.blueprint.name != plugin_id:
+                            logger.warning(
+                                'Plugin %s names its Blueprint %r; the convention is to name it '
+                                'after the plugin id, otherwise it can collide with another plugin',
+                                plugin_id, ctx.blueprint.name,
+                            )
+                        if ctx.blueprint.name in flask_app.blueprints:
+                            raise ValueError(
+                                f'blueprint name "{ctx.blueprint.name}" is already registered by '
+                                'another plugin or by the app; rename the Blueprint (use your plugin id)'
+                            )
                         flask_app.register_blueprint(ctx.blueprint, url_prefix=f'/plugins/{plugin_id}')
                         if not record['settings_endpoint']:
                             candidate = f'{ctx.blueprint.name}.settings'
@@ -595,9 +619,15 @@ class PluginManager:
                         self._run_hooks(ctx.flask_start, plugin_id, 'flask_start')
                     elif role == 'worker':
                         self._run_hooks(ctx.worker_start, plugin_id, 'worker_start')
-                record['load_status'] = 'ok'
-                record['error'] = None
-                self._persist_status(plugin_id, 'ok')
+                deps_error = record.get('deps_error')
+                if deps_error:
+                    record['load_status'] = 'deps_failed'
+                    record['error'] = deps_error
+                    self._persist_status(plugin_id, 'deps_failed', error=deps_error)
+                else:
+                    record['load_status'] = 'ok'
+                    record['error'] = None
+                    self._persist_status(plugin_id, 'ok')
             except Exception as exc:
                 logger.exception('Failed to load plugin %s', plugin_id)
                 record['load_status'] = 'error'
@@ -815,14 +845,14 @@ class PluginManager:
     def get_onnx_providers(self):
         providers = []
         for record in self.records.values():
-            if record.get('load_status') == 'ok':
+            if record.get('load_status') in _LOADED_STATUSES:
                 providers.extend(record.get('onnx_providers', []))
         return providers
 
     def song_analyzed_hooks(self):
         hooks = []
         for record in self.records.values():
-            if record.get('load_status') == 'ok':
+            if record.get('load_status') in _LOADED_STATUSES:
                 hooks.extend(record.get('song_analyzed_hooks', []))
         return hooks
 
@@ -837,7 +867,7 @@ class PluginManager:
     def menu_items(self):
         items = []
         for record in self.records.values():
-            if record.get('load_status') != 'ok':
+            if record.get('load_status') not in _LOADED_STATUSES:
                 continue
             settings_ep = record.get('settings_endpoint')
             for entry in record.get('menu_items', []):

--- a/plugin/manager.py
+++ b/plugin/manager.py
@@ -438,14 +438,17 @@ class PluginManager:
             logger.exception('Could not read installed plugin dependencies from _lib')
         return versions
 
-    def _missing_specs(self, specs):
+    def _missing_specs(self, specs, have=None):
         """Return the specs whose distribution is absent OR whose version pin is unmet in _lib.
 
         Unlike a name-only presence check, this parses each spec with packaging so a
         changed pin (matplotlib==3.7 -> matplotlib==3.9) is correctly seen as missing
         and reinstalled, instead of being silently satisfied by any matplotlib on disk.
+        ``have`` lets a caller share one _lib scan across several checks; when omitted
+        the directory is re-read, which the in-lock re-check relies on.
         """
-        have = self._installed_dist_versions()
+        if have is None:
+            have = self._installed_dist_versions()
         missing = []
         for spec in specs:
             try:
@@ -523,10 +526,12 @@ class PluginManager:
                         'Dependency install failed for plugin %s: %s',
                         plugin_id, record['requirements'],
                     )
+        have = self._installed_dist_versions() if plugins_with_reqs else {}
         for plugin_id in plugins_with_reqs:
             record = self.records[plugin_id]
             unmet = self._missing_specs(
-                sorted({str(s) for s in record['requirements'] if _valid_requirement(s)})
+                sorted({str(s) for s in record['requirements'] if _valid_requirement(s)}),
+                have=have,
             )
             if unmet:
                 record['deps_error'] = (

--- a/test/unit/test_plugin_manager.py
+++ b/test/unit/test_plugin_manager.py
@@ -858,6 +858,143 @@ class TestSongAnalyzedHooks:
         mgr.records = {}
         mgr.run_song_analyzed({'item_id': 'x'})
 
+    def test_multiple_plugins_run_in_sequence_and_isolated(self):
+        seen = []
+
+        def a1(payload):
+            seen.append('a1')
+
+        def a2(payload):
+            seen.append('a2')
+
+        def b_bad(payload):
+            raise RuntimeError('boom')
+
+        def c1(payload):
+            seen.append('c1')
+
+        mgr = self._mgr({'a': [a1, a2], 'b': [b_bad], 'c': [c1]})
+        mgr.run_song_analyzed({'item_id': 'x'})
+        assert seen == ['a1', 'a2', 'c1']
+
+    def test_deps_failed_plugin_hooks_stay_active(self):
+        def a(payload):
+            """Stub listener."""
+
+        mgr = self._mgr({'a': [a]})
+        mgr.records['a']['load_status'] = 'deps_failed'
+        assert mgr.song_analyzed_hooks() == [a]
+
+
+class TestMultiPluginConflicts:
+    def test_conflicting_pin_surfaces_deps_error_on_the_unmet_plugin(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config, 'PLUGINS_DIR', str(tmp_path))
+        monkeypatch.setattr(config, 'PLUGINS_ENABLED', True)
+        monkeypatch.setattr(config, 'PLUGIN_ALLOW_PIP', True)
+        dist = tmp_path / '_lib' / 'matplotlib-3.9.0.dist-info'
+        dist.mkdir(parents=True)
+        (dist / 'METADATA').write_text(
+            'Metadata-Version: 2.1\nName: matplotlib\nVersion: 3.9.0\n', encoding='utf-8'
+        )
+        mgr = manager.PluginManager()
+        monkeypatch.setattr(mgr, '_pip_install', lambda specs: True)
+        mgr.records = {
+            'wants39': _record('wants39', requirements=['matplotlib==3.9.0']),
+            'wants37': _record('wants37', requirements=['matplotlib==3.7.0']),
+        }
+
+        mgr.ensure_requirements()
+
+        assert 'deps_error' not in mgr.records['wants39']
+        assert 'matplotlib==3.7.0' in mgr.records['wants37']['deps_error']
+        assert 'conflicting version' in mgr.records['wants37']['deps_error']
+
+    def test_load_persists_deps_failed_but_plugin_still_loads(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(config, 'PLUGINS_DIR', str(tmp_path))
+        monkeypatch.setattr(config, 'PLUGINS_ENABLED', True)
+        monkeypatch.setattr(config, 'APP_VERSION', 'v2.5.0')
+        _write_plugin(tmp_path, 'conflicted', 'def register(ctx):\n    pass\n')
+        persisted = {}
+
+        mgr = manager.PluginManager()
+        monkeypatch.setattr(
+            mgr, '_persist_status',
+            lambda pid, status, role=None, error=None: persisted.__setitem__(pid, (status, error)),
+        )
+        record = _record('conflicted')
+        record['deps_error'] = 'unsatisfied requirement(s) after install: matplotlib==3.7.0'
+        mgr.records = {'conflicted': record}
+        mgr.load('worker')
+
+        assert record['load_status'] == 'deps_failed'
+        assert 'matplotlib==3.7.0' in record['error']
+        assert persisted['conflicted'][0] == 'deps_failed'
+
+    def test_blueprint_named_after_plugin_id_loads_without_warning(self, monkeypatch, tmp_path, caplog):
+        import flask
+
+        monkeypatch.setattr(config, 'PLUGINS_DIR', str(tmp_path))
+        monkeypatch.setattr(config, 'PLUGINS_ENABLED', True)
+        monkeypatch.setattr(config, 'APP_VERSION', 'v2.5.0')
+        _write_plugin(tmp_path, 'goodname', (
+            "from flask import Blueprint\n"
+            "bp = Blueprint('goodname', __name__)\n"
+            "def register(ctx):\n"
+            "    ctx.add_blueprint(bp)\n"
+        ))
+        mgr = manager.PluginManager()
+        monkeypatch.setattr(mgr, '_persist_status', lambda *a, **k: None)
+        mgr.records = {'goodname': _record('goodname')}
+        with caplog.at_level('WARNING'):
+            mgr.load('web', flask_app=flask.Flask(__name__))
+        assert mgr.records['goodname']['load_status'] == 'ok'
+        assert not any('names its Blueprint' in r.message for r in caplog.records)
+
+    def test_blueprint_not_named_after_plugin_id_warns_but_loads(self, monkeypatch, tmp_path, caplog):
+        import flask
+
+        monkeypatch.setattr(config, 'PLUGINS_DIR', str(tmp_path))
+        monkeypatch.setattr(config, 'PLUGINS_ENABLED', True)
+        monkeypatch.setattr(config, 'APP_VERSION', 'v2.5.0')
+        _write_plugin(tmp_path, 'oddname', (
+            "from flask import Blueprint\n"
+            "bp = Blueprint('something_else', __name__)\n"
+            "def register(ctx):\n"
+            "    ctx.add_blueprint(bp)\n"
+        ))
+        mgr = manager.PluginManager()
+        monkeypatch.setattr(mgr, '_persist_status', lambda *a, **k: None)
+        mgr.records = {'oddname': _record('oddname')}
+        with caplog.at_level('WARNING'):
+            mgr.load('web', flask_app=flask.Flask(__name__))
+        assert mgr.records['oddname']['load_status'] == 'ok'
+        assert any('names its Blueprint' in r.message for r in caplog.records)
+
+    def test_duplicate_blueprint_name_fails_with_clear_error_and_isolates(self, monkeypatch, tmp_path):
+        import flask
+
+        monkeypatch.setattr(config, 'PLUGINS_DIR', str(tmp_path))
+        monkeypatch.setattr(config, 'PLUGINS_ENABLED', True)
+        monkeypatch.setattr(config, 'APP_VERSION', 'v2.5.0')
+        body = (
+            "from flask import Blueprint\n"
+            "bp = Blueprint('dup', __name__)\n"
+            "def register(ctx):\n"
+            "    ctx.add_blueprint(bp)\n"
+        )
+        _write_plugin(tmp_path, 'firstp', body)
+        _write_plugin(tmp_path, 'secondp', body)
+
+        app = flask.Flask(__name__)
+        mgr = manager.PluginManager()
+        monkeypatch.setattr(mgr, '_persist_status', lambda *a, **k: None)
+        mgr.records = {'firstp': _record('firstp'), 'secondp': _record('secondp')}
+        mgr.load('web', flask_app=app)
+
+        assert mgr.records['firstp']['load_status'] == 'ok'
+        assert mgr.records['secondp']['load_status'] == 'error'
+        assert 'rename the Blueprint' in mgr.records['secondp']['error']
+
 
 class TestRunSongAnalyzedHookHelper:
     class _PM:


### PR DESCRIPTION
This PR test and enforce the case where an user install multiple plugin.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29012814608/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28944287487/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28944287487/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28944287487/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/28944287487/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29012814705/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-733`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-733-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-733-noavx2`
<!-- pr-test-build:end -->