### PR TITLE
[DOCS]: Fix docs.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ docs_dir: web
 site_url: https://neptunehub.github.io/AudioMuse-AI/
 repo_url: https://github.com/NeptuneHub/AudioMuse-AI
 repo_name: GitHub
+edit_uri: edit/main/docs/
 
 nav:
   - Home: index.md
@@ -14,4 +15,4 @@ nav:
   - Parameters: PARAMETERS.md
   - Authentication: AUTH.md
 
-theme: readthedocs
+theme: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,4 +15,4 @@ nav:
   - Parameters: PARAMETERS.md
   - Authentication: AUTH.md
 
-theme: material
+theme: readthedocs


### PR DESCRIPTION
The `edit on github` button on docs website redirects to wrong branch of the repo. (for eg. [this](https://github.com/NeptuneHub/AudioMuse-AI/edit/master/docs/index.md)).
This was due to master branch default selected for editing docs in mkdocs.
Added `edit_uri` parameter to redirect to `/docs` folder of main branch.

**Testing**
Tested the working on local and github pages both, works as expected.

**Type of change:**
- [ ] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Breaking change

**Updated:**
- [x] Documentation
- [ ] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** Closes #736 