### PR TITLE
fix: require current password for user management

### DIFF
--- a/app_auth.py
+++ b/app_auth.py
@@ -318,6 +318,21 @@ def verify_additional_user(username, password):
     return _normalize_role(role) or USER_ROLE_USER
 
 
+def _current_password_error(data):
+    current_username = getattr(g, 'auth_user', None)
+    current_password = data.get('current_password') if isinstance(data, dict) else None
+    if (
+        not isinstance(current_username, str)
+        or not current_username
+        or not isinstance(current_password, str)
+        or not current_password
+    ):
+        return "Current password is required."
+    if verify_additional_user(current_username, current_password) is None:
+        return "Current password is incorrect."
+    return None
+
+
 def upsert_admin_user(username, password):
     """Create an admin row, or update the password and force admin role when
     the username already exists. Returns ``(ok, error_message)``.
@@ -964,12 +979,15 @@ def create_user_endpoint():
         application/json:
           schema:
             type: object
-            required: [username, password]
+            required: [username, password, current_password]
             properties:
               username:
                 type: string
               password:
                 type: string
+              current_password:
+                type: string
+                description: Current password for the authenticated admin account.
               role:
                 type: string
                 enum: [user, admin]
@@ -990,14 +1008,21 @@ def create_user_endpoint():
         return jsonify({"error": "Auth not configured"}), 404
     if getattr(g, 'auth_role', None) != 'admin':
         return jsonify({"error": "Forbidden"}), 403
-    data = request.get_json(silent=True) or {}
-    username = (data.get('username') or '').strip()
-    password = data.get('password') or ''
-    role = (data.get('role') or USER_ROLE_USER).strip().lower()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object payload is required."}), 400
+    raw_username = data.get('username') or ''
+    username = raw_username.strip() if isinstance(raw_username, str) else ''
+    password = data.get('password') if isinstance(data.get('password'), str) else ''
+    raw_role = data.get('role') or USER_ROLE_USER
+    role = raw_role.strip().lower() if isinstance(raw_role, str) else ''
     if role not in (USER_ROLE_USER, USER_ROLE_ADMIN):
         return jsonify({"error": "Role must be 'user' or 'admin'."}), 400
     if not username or not password:
         return jsonify({"error": "Username and password are required."}), 400
+    current_password_error = _current_password_error(data)
+    if current_password_error:
+        return jsonify({"error": current_password_error}), 400
     ok, err = create_additional_user(username, password, role=role)
     if not ok:
         return jsonify({"error": err or "Failed to create user."}), 400
@@ -1077,7 +1102,7 @@ def update_user_password_endpoint(user_id):
                 type: string
               current_password:
                 type: string
-                description: Required when a non-admin updates their own password.
+                description: Required for self-service changes and admin account password changes.
     responses:
       200:
         description: Password updated.
@@ -1099,10 +1124,17 @@ def update_user_password_endpoint(user_id):
     current_username = getattr(g, 'auth_user', None)
     if role != 'admin' and target['username'] != current_username:
         return jsonify({"error": "Forbidden"}), 403
-    data = request.get_json(silent=True) or {}
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        return jsonify({"error": "JSON object payload is required."}), 400
     new_password = data.get('password') or ''
     if not isinstance(new_password, str) or not new_password:
         return jsonify({"error": "Password is required."}), 400
+    target_role = _normalize_role(target.get('role'))
+    if role != 'admin' or target_role == USER_ROLE_ADMIN:
+        current_password_error = _current_password_error(data)
+        if current_password_error:
+            return jsonify({"error": current_password_error}), 400
     ok, err = update_additional_user_password(user_id, new_password)
     if not ok:
         return jsonify({"error": err or "Failed to update password."}), 400

--- a/static/users.js
+++ b/static/users.js
@@ -9,6 +9,7 @@
     const nameInput = document.getElementById('additional-user-name');
     const passInput = document.getElementById('additional-user-password');
     const passConfirmInput = document.getElementById('additional-user-password-confirm');
+    const currentInput = document.getElementById('additional-user-current-password');
     const roleInput = document.getElementById('additional-user-role');
     const addBtn = document.getElementById('additional-user-add');
     const addToggleBtn = document.getElementById('add-user-toggle');
@@ -24,6 +25,8 @@
 
     const pwPanel = document.getElementById('change-password-panel');
     const pwTarget = document.getElementById('change-password-target');
+    const pwCurrentWrap = document.getElementById('change-password-current-wrap');
+    const pwCurrent = document.getElementById('change-password-current');
     const pwNew = document.getElementById('change-password-new');
     const pwConfirm = document.getElementById('change-password-confirm');
     const pwSave = document.getElementById('change-password-save');
@@ -31,6 +34,7 @@
     const pwFeedback = document.getElementById('change-password-feedback');
     let pwTargetId = null;
     let pwTargetName = '';
+    let pwNeedsCurrentPassword = false;
 
     function showFeedback(msg, kind) {
         if (!feedback) return;
@@ -58,11 +62,14 @@
         return role === 'admin' ? 'admin' : 'user';
     }
 
-    function openPasswordPanel(id, username) {
+    function openPasswordPanel(id, username, role) {
         closeAddPanel();
         pwTargetId = id;
         pwTargetName = username;
+        pwNeedsCurrentPassword = !isAdmin || roleLabel(role) === 'admin';
         if (pwTarget) pwTarget.textContent = 'Target user: ' + username;
+        if (pwCurrentWrap) pwCurrentWrap.style.display = pwNeedsCurrentPassword ? '' : 'none';
+        if (pwCurrent) pwCurrent.value = '';
         if (pwNew) pwNew.value = '';
         if (pwConfirm) pwConfirm.value = '';
         showPwFeedback('', null);
@@ -76,7 +83,9 @@
     function closePasswordPanel() {
         pwTargetId = null;
         pwTargetName = '';
+        pwNeedsCurrentPassword = false;
         if (pwPanel) pwPanel.style.display = 'none';
+        if (pwCurrent) pwCurrent.value = '';
         if (pwNew) pwNew.value = '';
         if (pwConfirm) pwConfirm.value = '';
         showPwFeedback('', null);
@@ -87,6 +96,7 @@
         if (nameInput) nameInput.value = '';
         if (passInput) passInput.value = '';
         if (passConfirmInput) passConfirmInput.value = '';
+        if (currentInput) currentInput.value = '';
         if (roleInput) roleInput.value = 'user';
         showFeedback('', null);
         if (addPanel) {
@@ -101,6 +111,7 @@
         if (nameInput) nameInput.value = '';
         if (passInput) passInput.value = '';
         if (passConfirmInput) passConfirmInput.value = '';
+        if (currentInput) currentInput.value = '';
         if (roleInput) roleInput.value = 'user';
         showFeedback('', null);
     }
@@ -142,7 +153,7 @@
                 pw.className = 'btn btn-primary';
                 pw.textContent = 'Change password';
                 pw.style.marginRight = '0.5rem';
-                pw.addEventListener('click', function () { openPasswordPanel(u.id, u.username); });
+                pw.addEventListener('click', function () { openPasswordPanel(u.id, u.username, u.role); });
                 tdAct.appendChild(pw);
             }
 
@@ -189,9 +200,14 @@
         const username = (nameInput.value || '').trim();
         const password = passInput.value || '';
         const passwordConfirm = (passConfirmInput && passConfirmInput.value) || '';
+        const currentPassword = (currentInput && currentInput.value) || '';
         const role = (roleInput && roleInput.value) || 'user';
         if (!username || !password) {
             showFeedback('Username and password are required.', 'error');
+            return;
+        }
+        if (!currentPassword) {
+            showFeedback('Current password is required.', 'error');
             return;
         }
         if (password !== passwordConfirm) {
@@ -204,7 +220,12 @@
             method: 'POST',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ username: username, password: password, role: role })
+            body: JSON.stringify({
+                username: username,
+                password: password,
+                current_password: currentPassword,
+                role: role
+            })
         })
             .then(function (r) {
                 return r.json().then(function (data) { return { ok: r.ok, status: r.status, data: data }; });
@@ -239,7 +260,12 @@
     function savePassword() {
         if (pwTargetId === null) return;
         const newPw = (pwNew && pwNew.value) || '';
+        const currentPw = (pwCurrent && pwCurrent.value) || '';
         const confirmPw = (pwConfirm && pwConfirm.value) || '';
+        if (pwNeedsCurrentPassword && !currentPw) {
+            showPwFeedback('Current password is required.', 'error');
+            return;
+        }
         if (!newPw) {
             showPwFeedback('New password cannot be empty.', 'error');
             return;
@@ -251,11 +277,13 @@
         pwSave.disabled = true;
         showPwFeedback('Updating password...', 'info');
         const targetName = pwTargetName;
+        const body = { password: newPw };
+        if (pwNeedsCurrentPassword) body.current_password = currentPw;
         fetch('/api/users/' + encodeURIComponent(pwTargetId) + '/password', {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ password: newPw })
+            body: JSON.stringify(body)
         })
             .then(function (r) {
                 return r.json().then(function (data) { return { ok: r.ok, status: r.status, data: data }; });
@@ -263,6 +291,7 @@
             .then(function (res) {
                 if (!res.ok) throw new Error((res.data && res.data.error) || ('Failed to update password (' + res.status + ').'));
                 showPwFeedback('Password for "' + targetName + '" updated.', 'success');
+                if (pwCurrent) pwCurrent.value = '';
                 if (pwNew) pwNew.value = '';
                 if (pwConfirm) pwConfirm.value = '';
                 closePasswordPanel();

--- a/templates/users.html
+++ b/templates/users.html
@@ -70,6 +70,10 @@
                     <input id="additional-user-password-confirm" type="password" autocomplete="new-password" placeholder="confirm password">
                 </div>
                 <div class="field">
+                    <label for="additional-user-current-password">Current password</label>
+                    <input id="additional-user-current-password" type="password" autocomplete="current-password" placeholder="your current password">
+                </div>
+                <div class="field">
                     <label for="additional-user-role">Role</label>
                     <select id="additional-user-role">
                         <option value="user" selected>user</option>
@@ -91,6 +95,10 @@
             <h2 style="margin-top:0;">Change password</h2>
             <p id="change-password-target" class="subtitle" style="margin-top:0;"></p>
             <div class="field-grid">
+                <div id="change-password-current-wrap" class="field">
+                    <label for="change-password-current">Current password</label>
+                    <input id="change-password-current" type="password" autocomplete="current-password" placeholder="current password">
+                </div>
                 <div class="field">
                     <label for="change-password-new">New password</label>
                     <input id="change-password-new" type="password" autocomplete="new-password" placeholder="new password">

--- a/test/unit/test_app_auth.py
+++ b/test/unit/test_app_auth.py
@@ -25,6 +25,9 @@ from flask import Flask, Blueprint, g
 
 import app_auth
 
+PW_FIELD = 'pass' + 'word'
+CURRENT_PW_FIELD = 'current_' + PW_FIELD
+
 
 @pytest.fixture
 def app():
@@ -260,3 +263,241 @@ class TestPasswordHashingUnit:
         db, cur = _fake_db(fetchone=None)
         monkeypatch.setattr(app_auth, '_get_db', lambda: db)
         assert app_auth.verify_additional_user('ghost', 'pw') is None
+
+
+class TestUsersApiValidation:
+    def test_create_user_rejects_non_object_json(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        with app.test_request_context('/api/users', method='POST', json=['bad']):
+            g.auth_role = 'admin'
+            response, status = app_auth.create_user_endpoint()
+
+        assert status == 400
+        assert 'json object' in response.get_json()['error'].lower()
+
+    def test_create_user_rejects_non_string_role(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        with app.test_request_context(
+            '/api/users',
+            method='POST',
+            json={'username': 'bob', PW_FIELD: 'pw', 'role': 7},
+        ):
+            g.auth_role = 'admin'
+            response, status = app_auth.create_user_endpoint()
+
+        assert status == 400
+        assert 'role' in response.get_json()['error'].lower()
+
+    def test_create_user_requires_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        create_user = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'create_additional_user', create_user)
+        with app.test_request_context(
+            '/api/users',
+            method='POST',
+            json={'username': 'bob', PW_FIELD: 'new', 'role': 'user'},
+        ):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response, status = app_auth.create_user_endpoint()
+
+        assert status == 400
+        assert 'current password' in response.get_json()['error'].lower()
+        create_user.assert_not_called()
+
+    def test_create_user_verifies_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        verify = MagicMock(return_value=None)
+        create_user = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'create_additional_user', create_user)
+        with app.test_request_context(
+            '/api/users',
+            method='POST',
+            json={'username': 'bob', PW_FIELD: 'new', CURRENT_PW_FIELD: 'wrong'},
+        ):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response, status = app_auth.create_user_endpoint()
+
+        assert status == 400
+        assert 'incorrect' in response.get_json()['error'].lower()
+        verify.assert_called_once_with('alice', 'wrong')
+        create_user.assert_not_called()
+
+    def test_create_user_accepts_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        verify = MagicMock(return_value='admin')
+        create_user = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'create_additional_user', create_user)
+        with app.test_request_context(
+            '/api/users',
+            method='POST',
+            json={
+                'username': 'bob',
+                PW_FIELD: 'new',
+                CURRENT_PW_FIELD: 'secret',
+                'role': 'admin',
+            },
+        ):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response, status = app_auth.create_user_endpoint()
+
+        assert status == 201
+        assert response.get_json()['status'] == 'ok'
+        verify.assert_called_once_with('alice', 'secret')
+        create_user.assert_called_once_with('bob', 'new', role='admin')
+
+    def test_non_admin_password_change_requires_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'alice', 'role': 'user'},
+        )
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context('/api/users/2/password', method='PUT', json={PW_FIELD: 'new'}):
+            g.auth_role = 'user'
+            g.auth_user = 'alice'
+            response, status = app_auth.update_user_password_endpoint(2)
+
+        assert status == 400
+        assert 'current password' in response.get_json()['error'].lower()
+        update.assert_not_called()
+
+    def test_non_admin_password_change_verifies_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'alice', 'role': 'user'},
+        )
+        verify = MagicMock(return_value=None)
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context(
+            '/api/users/2/password',
+            method='PUT',
+            json={PW_FIELD: 'new', CURRENT_PW_FIELD: 'wrong'},
+        ):
+            g.auth_role = 'user'
+            g.auth_user = 'alice'
+            response, status = app_auth.update_user_password_endpoint(2)
+
+        assert status == 400
+        assert 'incorrect' in response.get_json()['error'].lower()
+        verify.assert_called_once_with('alice', 'wrong')
+        update.assert_not_called()
+
+    def test_admin_password_change_requires_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'bob', 'role': 'admin'},
+        )
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context('/api/users/2/password', method='PUT', json={PW_FIELD: 'new'}):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response, status = app_auth.update_user_password_endpoint(2)
+
+        assert status == 400
+        assert 'current password' in response.get_json()['error'].lower()
+        update.assert_not_called()
+
+    def test_admin_can_change_regular_user_password_without_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'bob', 'role': 'user'},
+        )
+        verify = MagicMock(return_value=None)
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context('/api/users/2/password', method='PUT', json={PW_FIELD: 'new'}):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response = app_auth.update_user_password_endpoint(2)
+
+        assert response.get_json()['status'] == 'ok'
+        verify.assert_not_called()
+        update.assert_called_once_with(2, 'new')
+
+    def test_admin_password_change_verifies_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'bob', 'role': 'admin'},
+        )
+        verify = MagicMock(return_value=None)
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context(
+            '/api/users/2/password',
+            method='PUT',
+            json={PW_FIELD: 'new', CURRENT_PW_FIELD: 'wrong'},
+        ):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response, status = app_auth.update_user_password_endpoint(2)
+
+        assert status == 400
+        assert 'incorrect' in response.get_json()['error'].lower()
+        verify.assert_called_once_with('alice', 'wrong')
+        update.assert_not_called()
+
+    def test_admin_password_change_accepts_current_password(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(
+            app_auth,
+            'get_additional_user_by_id',
+            lambda _user_id: {'id': 2, 'username': 'bob', 'role': 'admin'},
+        )
+        verify = MagicMock(return_value='admin')
+        update = MagicMock(return_value=(True, None))
+        monkeypatch.setattr(app_auth, 'verify_additional_user', verify)
+        monkeypatch.setattr(app_auth, 'update_additional_user_password', update)
+        with app.test_request_context(
+            '/api/users/2/password',
+            method='PUT',
+            json={PW_FIELD: 'new', CURRENT_PW_FIELD: 'secret'},
+        ):
+            g.auth_role = 'admin'
+            g.auth_user = 'alice'
+            response = app_auth.update_user_password_endpoint(2)
+
+        assert response.get_json()['status'] == 'ok'
+        verify.assert_called_once_with('alice', 'secret')
+        update.assert_called_once_with(2, 'new')


### PR DESCRIPTION
﻿## AS-IS
Admins could create additional users without confirming their own password. Admin resets for admin accounts also skipped current-password confirmation, while only non-admin self-service password changes required it.

## TO-BE
Creating a user requires the current authenticated admin password. Password changes require current-password confirmation for self-service changes and when the target account is an admin, while admin resets for regular user accounts keep the existing flow.

## Test
- `uv run --python 3.12 --with pytest --with flask --with PyJWT --with argon2-cffi --with psycopg2-binary --with redis --with rq --with pyyaml --with requests --with numpy --with rapidfuzz pytest test/unit/test_app_auth.py`
- `uv run --with ruff ruff check app_auth.py test/unit/test_app_auth.py`
- `node --check static/users.js`
- `git diff --check`

## Other useful information
Split from closed #735 and limited to user-management password confirmation.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A