### PR TITLE
fix: validate backup restore uploads before locking

### DIFF
--- a/app_backup.py
+++ b/app_backup.py
@@ -85,6 +85,21 @@ def _restore_lock_held():
         return True
 
 
+def _uploaded_file_is_empty(uploaded):
+    stream = getattr(uploaded, 'stream', None)
+    if stream is None:
+        return False
+    try:
+        pos = stream.tell()
+        stream.seek(0, os.SEEK_END)
+        size = stream.tell()
+        stream.seek(pos)
+        return size == 0
+    except (AttributeError, OSError):
+        content_length = getattr(uploaded, 'content_length', None)
+        return content_length == 0
+
+
 def _pg_env():
     """Return a copy of os.environ with PGPASSWORD set."""
     env = os.environ.copy()
@@ -453,10 +468,14 @@ def restore_backup():
     uploaded = request.files.get('file')
     if not uploaded or not uploaded.filename:
         return jsonify({'error': 'No file uploaded.'}), 400
+    if _uploaded_file_is_empty(uploaded):
+        return jsonify({'error': 'Uploaded backup file is empty.'}), 400
 
     # Check if this is a chunked upload
     chunk_num = request.form.get('chunk_num')
     total_chunks = request.form.get('total_chunks')
+    if bool(chunk_num) != bool(total_chunks):
+        return jsonify({'error': 'chunk_num and total_chunks must be provided together.'}), 400
 
     restore_file = None
     restore_log = None

--- a/templates/backup.html
+++ b/templates/backup.html
@@ -178,6 +178,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
         const file = fileInput.files[0];
         const fileSize = file.size;
+        if (fileSize === 0) {
+            restoreStatus.textContent = 'Selected backup file is empty.';
+            restoreStatus.style.color = 'var(--color-danger, red)';
+            restoreBtn.disabled = false;
+            return;
+        }
         const fileSizeMB = (fileSize / (1024 * 1024)).toFixed(2);
         const chunkSize = 1024 * 1024 * 1024; // 1GB chunks
         const totalChunks = Math.ceil(fileSize / chunkSize);

--- a/test/unit/test_app_backup_restore.py
+++ b/test/unit/test_app_backup_restore.py
@@ -36,14 +36,20 @@ def client():
     return app.test_client()
 
 
-def _form(confirmation=CONFIRMATION, chunk_num=None, total_chunks=None, with_file=True):
+def _form(
+    confirmation=CONFIRMATION,
+    chunk_num=None,
+    total_chunks=None,
+    with_file=True,
+    file_bytes=b'SELECT 1;\n',
+):
     data = {'confirmation': confirmation}
     if chunk_num is not None:
         data['chunk_num'] = str(chunk_num)
     if total_chunks is not None:
         data['total_chunks'] = str(total_chunks)
     if with_file:
-        data['file'] = (io.BytesIO(b'SELECT 1;\n'), 'backup.sql')
+        data['file'] = (io.BytesIO(file_bytes), 'backup.sql')
     return data
 
 
@@ -69,6 +75,29 @@ class TestRestoreValidation:
         resp = _post(client, with_file=False)
         assert resp.status_code == 400
         assert resp.get_json()['error'] == 'No file uploaded.'
+
+    @pytest.mark.parametrize(
+        'fields',
+        [
+            {'chunk_num': 1},
+            {'total_chunks': 2},
+        ],
+    )
+    def test_partial_chunk_metadata_is_400_before_lock(self, client, monkeypatch, fields):
+        acquire = MagicMock(return_value=True)
+        monkeypatch.setattr(app_backup, '_acquire_restore_lock', acquire)
+        resp = _post(client, **fields)
+        assert resp.status_code == 400
+        assert 'provided together' in resp.get_json()['error']
+        acquire.assert_not_called()
+
+    def test_empty_upload_is_400_before_lock(self, client, monkeypatch):
+        acquire = MagicMock(return_value=True)
+        monkeypatch.setattr(app_backup, '_acquire_restore_lock', acquire)
+        resp = _post(client, file_bytes=b'')
+        assert resp.status_code == 400
+        assert 'empty' in resp.get_json()['error']
+        acquire.assert_not_called()
 
     def test_non_integer_chunk_fields_are_400(self, client):
         resp = _post(client, chunk_num='abc', total_chunks='3')


### PR DESCRIPTION
﻿## AS-IS
Empty backup restore uploads and malformed chunk metadata could reach the restore-lock path before being rejected later or failing during processing.

## TO-BE
Restore uploads reject empty files and require `chunk_num` plus `total_chunks` to be submitted together before the restore lock is acquired. The backup page also blocks zero-byte restore files before upload.

## Test
- `uv run --python 3.12 --with pytest --with flask --with PyJWT --with argon2-cffi --with psycopg2-binary --with redis --with rq --with pyyaml --with requests --with numpy --with rapidfuzz pytest test/unit/test_app_backup_restore.py`
- `uv run --with ruff ruff check app_backup.py test/unit/test_app_backup_restore.py`
- `git diff --check`

## Other useful information
Split from closed #735 and limited to backup restore upload validation.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A