### PR TITLE
fix: require finalized provider migration dry runs

### DIFF
--- a/app_provider_migration.py
+++ b/app_provider_migration.py
@@ -1214,7 +1214,9 @@ def finalize_dry_run():
     if state is None:
         return jsonify({'error': 'session not found'}), 404
 
-    dry = state.get('dry_run') or {}
+    dry = state.get('dry_run')
+    if not isinstance(dry, dict) or 'matches' not in dry:
+        return jsonify({'error': 'Run and complete a dry run before finalizing.'}), 400
 
     import importlib
 
@@ -1352,13 +1354,20 @@ def execute():
     db = get_db()
     with db.cursor() as cur:
         cur.execute(
-            "SELECT target_type, status FROM migration_session WHERE id = %s",
+            "SELECT target_type, status, state FROM migration_session WHERE id = %s",
             (session_id,),
         )
         row = cur.fetchone()
     if not row:
         return jsonify({'error': 'session not found'}), 404
     target_type, status = row[0], row[1]
+    state = row[2] if len(row) > 2 else {}
+    if isinstance(state, str):
+        try:
+            state = json.loads(state)
+        except (TypeError, ValueError):
+            state = {}
+    final_counts = state.get('final_counts') if isinstance(state, dict) else None
 
     expected = f"I want to migrate to {target_type} and delete unmatched tracks"
     if confirmation_text != expected:
@@ -1372,6 +1381,8 @@ def execute():
                 f'expected "dry_run_ready".'
             }
         ), 400
+    if not isinstance(final_counts, dict):
+        return jsonify({'error': 'Dry run results changed. Re-finalize before executing.'}), 400
 
     # Enqueue the execute job
     from rq.job import Job  # noqa: F401  (used by enqueue internals)
@@ -2005,7 +2016,7 @@ def _merge_manual_matches(session_id, new_matches):
     manual = dict(manual or {})
     manual.update(new_matches)
     # Invalidate final_counts so the user must re-finalize
-    _patch_state_keys(session_id, manual_matches=manual, final_counts=None)
+    _patch_state_keys(session_id, _set_status='in_progress', manual_matches=manual, final_counts=None)
 
 
 def _rematch_album_rows(session_id, newly_matched, newly_unmatched):
@@ -2031,6 +2042,7 @@ def _rematch_album_rows(session_id, newly_matched, newly_unmatched):
         unmatches.add(old_id)
     _patch_state_keys(
         session_id,
+        _set_status='in_progress',
         manual_matches=manual,
         manual_unmatches=sorted(unmatches),
         final_counts=None,
@@ -2042,7 +2054,7 @@ def _mark_album_skipped(session_id, old_album_key):
     skipped = list(skipped or [])
     if old_album_key and old_album_key not in skipped:
         skipped.append(old_album_key)
-    _patch_state_keys(session_id, skipped_albums=skipped, final_counts=None)
+    _patch_state_keys(session_id, _set_status='in_progress', skipped_albums=skipped, final_counts=None)
 
 
 def _count_score_rows():

--- a/tasks/provider_migration_tasks.py
+++ b/tasks/provider_migration_tasks.py
@@ -482,6 +482,12 @@ def _run_migration_transaction(
     _populate_migration_map_table(cur, mapping)
 
     cur.execute(
+        "DELETE FROM playlist p WHERE EXISTS "
+        "(SELECT 1 FROM score s WHERE s.item_id = p.item_id) "
+        "AND NOT EXISTS "
+        "(SELECT 1 FROM item_id_migration_map m WHERE m.old_id = p.item_id)"
+    )
+    cur.execute(
         "DELETE FROM score s WHERE NOT EXISTS "
         "(SELECT 1 FROM item_id_migration_map m WHERE m.old_id = s.item_id)"
     )

--- a/test/unit/test_provider_migration_blueprint.py
+++ b/test/unit/test_provider_migration_blueprint.py
@@ -378,7 +378,7 @@ class TestExecuteGate:
 
     def test_rejects_wrong_confirmation_text(self, bp_mod, client, fake_db):
         db, cur = fake_db
-        cur._fetchone_queue.append(('navidrome', 'dry_run_ready'))
+        cur._fetchone_queue.append(('navidrome', 'dry_run_ready', {'final_counts': {'matched': 1}}))
         p = self._base_payload()
         p['confirmation_text'] = 'LGTM ship it'
         resp = client.post('/api/migration/execute', json=p)
@@ -387,15 +387,22 @@ class TestExecuteGate:
 
     def test_rejects_session_not_in_dry_run_ready(self, bp_mod, client, fake_db):
         db, cur = fake_db
-        cur._fetchone_queue.append(('navidrome', 'in_progress'))
+        cur._fetchone_queue.append(('navidrome', 'in_progress', {}))
         resp = client.post('/api/migration/execute', json=self._base_payload())
         assert resp.status_code == 400
         err = resp.get_json().get('error', '').lower()
         assert 'dry' in err or 'status' in err
 
+    def test_rejects_ready_session_without_final_counts(self, bp_mod, client, fake_db):
+        db, cur = fake_db
+        cur._fetchone_queue.append(('navidrome', 'dry_run_ready', {'dry_run': {'matches': {}}}))
+        resp = client.post('/api/migration/execute', json=self._base_payload())
+        assert resp.status_code == 400
+        assert 're-finalize' in resp.get_json().get('error', '').lower()
+
     def test_happy_path_enqueues_job(self, bp_mod, client, fake_db):
         db, cur = fake_db
-        cur._fetchone_queue.append(('navidrome', 'dry_run_ready'))
+        cur._fetchone_queue.append(('navidrome', 'dry_run_ready', {'final_counts': {'matched': 1}}))
         fake_queue = MagicMock()
         fake_job = MagicMock()
         fake_job.id = 'job-xyz'
@@ -408,6 +415,41 @@ class TestExecuteGate:
         data = resp.get_json()
         assert data['task_id'] == 'job-xyz'
         assert fake_queue.enqueue.called
+
+
+class TestFinalizeDryRunGate:
+    def test_rejects_missing_dry_run_state(self, bp_mod, client):
+        with (
+            patch.object(bp_mod, '_load_state', return_value={}),
+            patch('importlib.import_module') as mock_import,
+        ):
+            resp = client.post('/api/migration/finalize-dry-run', json={'session_id': 1})
+
+        assert resp.status_code == 400
+        assert 'dry run' in resp.get_json().get('error', '').lower()
+        mock_import.assert_not_called()
+
+
+class TestManualChangesInvalidateFinalize:
+    def test_merge_manual_matches_sets_in_progress(self, bp_mod):
+        with (
+            patch.object(bp_mod, '_read_state_key', return_value=(True, {})),
+            patch.object(bp_mod, '_patch_state_keys') as patch_state,
+        ):
+            bp_mod._merge_manual_matches(1, {'old': 'new'})
+
+        assert patch_state.call_args.kwargs['_set_status'] == 'in_progress'
+        assert patch_state.call_args.kwargs['final_counts'] is None
+
+    def test_mark_album_skipped_sets_in_progress(self, bp_mod):
+        with (
+            patch.object(bp_mod, '_read_state_key', return_value=(True, [])),
+            patch.object(bp_mod, '_patch_state_keys') as patch_state,
+        ):
+            bp_mod._mark_album_skipped(1, 'album-key')
+
+        assert patch_state.call_args.kwargs['_set_status'] == 'in_progress'
+        assert patch_state.call_args.kwargs['final_counts'] is None
 
 
 class TestProbeUrlValidation:

--- a/test/unit/test_provider_migration_execute.py
+++ b/test/unit/test_provider_migration_execute.py
@@ -281,6 +281,25 @@ class TestExecuteProviderMigration:
         update_score_idx = next(i for i, s in enumerate(upper) if s.startswith('UPDATE SCORE'))
         assert delete_idx < update_score_idx, "orphan delete must precede score rewrite"
 
+    def test_playlist_orphans_are_deleted_before_score_orphans(self, mig):
+        session_row = _make_session_row(
+            state=_session_state({'old_1': 'new_1'}),
+        )
+        _, _, executed = _install_fake_psycopg2(mig, session_row)
+
+        mig.execute_provider_migration(1)
+
+        upper = [s.upper() for s in executed]
+        delete_playlist_idx = next(
+            i for i, s in enumerate(upper) if s.startswith('DELETE FROM PLAYLIST')
+        )
+        delete_score_idx = next(i for i, s in enumerate(upper) if s.startswith('DELETE FROM SCORE'))
+        update_playlist_idx = next(
+            i for i, s in enumerate(upper) if s.startswith('UPDATE PLAYLIST')
+        )
+        assert 'NOT EXISTS' in upper[delete_playlist_idx]
+        assert delete_playlist_idx < delete_score_idx < update_playlist_idx
+
     def test_fk_drop_before_update_then_readd_after(self, mig):
         session_row = _make_session_row(state=_session_state({'a': 'b'}))
         _, _, executed = _install_fake_psycopg2(mig, session_row)


### PR DESCRIPTION
﻿## AS-IS
A migration execute request could run from a `dry_run_ready` status without persisted finalized counts. Manual match changes could also leave stale finalized results in place, and playlist rows could keep references to score rows that were about to be deleted as unmatched.

## TO-BE
Finalize requires a completed dry run. Execute requires both `dry_run_ready` status and persisted `final_counts`; manual match/rematch/skip changes clear those counts and return the session to `in_progress`. During execute, playlist rows for unmatched score items are removed before orphan score rows are deleted.

## Test
- `uv run --python 3.12 --with pytest --with flask --with PyJWT --with argon2-cffi --with psycopg2-binary --with redis --with rq --with pyyaml --with requests --with numpy --with rapidfuzz pytest test/unit/test_provider_migration_blueprint.py`
- `uv run --python 3.12 --with pytest --with numpy --with psycopg2-binary pytest test/unit/test_provider_migration_execute.py`
- `uv run --with ruff ruff check app_provider_migration.py tasks/provider_migration_tasks.py test/unit/test_provider_migration_blueprint.py test/unit/test_provider_migration_execute.py`
- `git diff --check`

## Other useful information
Split from closed #735 and limited to provider migration execute/finalize guards.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A