### PR TITLE
fix: render dynamic UI data with text nodes

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,10 +1,3 @@
-// Escape user/library-derived strings before inserting them into innerHTML.
-// Playlist names and track title/author come from media-server metadata, which
-// is attacker-influenceable, so they must be HTML-escaped to prevent stored XSS.
-const escapeHtml = (str) => String(str ?? '').replace(/[&<>"']/g, c => (
-    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
-));
-
 // --- DOM Element References ---
 const mainContent = document.getElementById('main-content');
 
@@ -479,7 +472,11 @@ async function fetchPlaylists() {
         renderPlaylists(playlistsData);
     } catch (error) {
         console.error('Error fetching playlists:', error);
-        playlistsContainer.innerHTML = `<p class="status-failure">Error fetching playlists: ${error.message}</p>`;
+        playlistsContainer.innerHTML = '';
+        const message = document.createElement('p');
+        message.className = 'status-failure';
+        message.textContent = 'Error fetching playlists: ' + error.message;
+        playlistsContainer.appendChild(message);
     }
 }
 
@@ -492,21 +489,35 @@ function renderPlaylists(playlistsData) {
     for (const [playlistName, songs] of Object.entries(playlistsData)) {
         const playlistDiv = document.createElement('div');
         playlistDiv.className = 'playlist-item';
-        playlistDiv.innerHTML = `
-            <div class="playlist-header">
-                <strong class="playlist-name">${escapeHtml(playlistName)}</strong>
-                <span class="playlist-song-count">(${songs.length} songs)</span>
-                <button class="show-songs-btn">SHOW</button>
-            </div>
-            <ul class="song-list" style="display: none;">
-                ${songs.map(song => `<li>${escapeHtml(song.title)} by ${escapeHtml(song.author)}</li>`).join('')}
-            </ul>`;
-        playlistDiv.querySelector('.show-songs-btn').addEventListener('click', e => {
+        const header = document.createElement('div');
+        header.className = 'playlist-header';
+        const name = document.createElement('strong');
+        name.className = 'playlist-name';
+        name.textContent = playlistName;
+        const count = document.createElement('span');
+        count.className = 'playlist-song-count';
+        count.textContent = `(${songs.length} songs)`;
+        const toggle = document.createElement('button');
+        toggle.className = 'show-songs-btn';
+        toggle.textContent = 'SHOW';
+        header.appendChild(name);
+        header.appendChild(count);
+        header.appendChild(toggle);
+        const list = document.createElement('ul');
+        list.className = 'song-list';
+        list.style.display = 'none';
+        songs.forEach(song => {
+            const item = document.createElement('li');
+            item.textContent = `${song.title} by ${song.author}`;
+            list.appendChild(item);
+        });
+        toggle.addEventListener('click', e => {
             const btn = e.target;
-            const list = btn.closest('.playlist-item').querySelector('.song-list');
             list.style.display = list.style.display === 'none' ? 'block' : 'none';
             btn.textContent = list.style.display === 'none' ? 'SHOW' : 'HIDE';
         });
+        playlistDiv.appendChild(header);
+        playlistDiv.appendChild(list);
         playlistsContainer.appendChild(playlistDiv);
     }
 }
@@ -517,7 +528,20 @@ function showMessageBox(title, message) {
     const messageBox = document.createElement('div');
     messageBox.id = boxId;
     messageBox.style.cssText = 'position: fixed; top: 20px; right: 20px; background-color: #fff; color: #1F2937; padding: 20px; border-radius: 8px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); z-index: 1000; border: 1px solid #E5E7EB; max-width: 400px; text-align: left;';
-    messageBox.innerHTML = `<h3 style="font-weight: 600; margin-top:0; margin-bottom: 10px; color: #111827;">${escapeHtml(title)}</h3><p style="margin:0;">${escapeHtml(message)}</p><button style="position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: #9CA3AF; cursor: pointer;" onclick="this.parentNode.remove()">&times;</button>`;
+    const heading = document.createElement('h3');
+    heading.style.cssText = 'font-weight: 600; margin-top:0; margin-bottom: 10px; color: #111827;';
+    heading.textContent = title;
+    const body = document.createElement('p');
+    body.style.margin = '0';
+    body.textContent = message;
+    const closeBtn = document.createElement('button');
+    closeBtn.type = 'button';
+    closeBtn.style.cssText = 'position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: #9CA3AF; cursor: pointer;';
+    closeBtn.textContent = 'X';
+    closeBtn.addEventListener('click', () => messageBox.remove());
+    messageBox.appendChild(heading);
+    messageBox.appendChild(body);
+    messageBox.appendChild(closeBtn);
     
     setTimeout(() => {
         messageBox.remove();

--- a/static/sunburst.js
+++ b/static/sunburst.js
@@ -241,7 +241,11 @@ const SunburstChart = (() => {
                 path.unshift(nd.name.charAt(0).toUpperCase() + nd.name.slice(1));
                 nd = findParent(tree, nd);
             }
-            selDiv.innerHTML = '<strong>\u2713 Selected:</strong> ' + path.join(' \u2014 ');
+            selDiv.innerHTML = '';
+            const label = document.createElement('strong');
+            label.textContent = '\u2713 Selected:';
+            selDiv.appendChild(label);
+            selDiv.appendChild(document.createTextNode(' ' + path.join(' \u2014 ')));
             if (onSelect) onSelect(node, best);
         }
 

--- a/templates/alchemy.html
+++ b/templates/alchemy.html
@@ -292,13 +292,21 @@
                     anchorsTable.innerHTML = '';
                     _alchemyAnchorsCache.forEach(anchor => {
                         const tr = document.createElement('tr');
-                        tr.innerHTML = `
-                            <td>${anchor.name}</td>
-                            <td>
-                                <button type="button" class="btn btn-sm btn-ghost btn-rename-anchor" data-id="${anchor.id}">Rename</button>
-                                <button type="button" class="btn btn-sm btn-danger btn-delete-anchor" data-id="${anchor.id}">Delete</button>
-                            </td>
-                        `;
+                        const nameTd = tr.insertCell();
+                        nameTd.textContent = anchor.name || '';
+                        const actionsTd = tr.insertCell();
+                        const renameBtn = document.createElement('button');
+                        renameBtn.type = 'button';
+                        renameBtn.className = 'btn btn-sm btn-ghost btn-rename-anchor';
+                        renameBtn.dataset.id = anchor.id;
+                        renameBtn.textContent = 'Rename';
+                        const deleteBtn = document.createElement('button');
+                        deleteBtn.type = 'button';
+                        deleteBtn.className = 'btn btn-sm btn-danger btn-delete-anchor';
+                        deleteBtn.dataset.id = anchor.id;
+                        deleteBtn.textContent = 'Delete';
+                        actionsTd.appendChild(renameBtn);
+                        actionsTd.appendChild(deleteBtn);
                         anchorsTable.appendChild(tr);
                     });
                 }
@@ -517,13 +525,22 @@
                     finally { acLoading = false; }
                 };
 
+                const addResultText = (parent, className, value) => {
+                    const node = document.createElement('div');
+                    node.className = className;
+                    node.textContent = value || '';
+                    parent.appendChild(node);
+                };
+
                 const appendTrackResults = (tracks) => {
                     const existingSentinel = resultsEl.querySelector('.autocomplete-load-more');
                     if (existingSentinel) existingSentinel.remove();
                     tracks.forEach(track => {
                         const itemDiv = document.createElement('div');
                         itemDiv.className = 'autocomplete-item';
-                        itemDiv.innerHTML = `<div class="title">${track.title}</div><div class="artist">${track.author}</div><div class="album">${track.album ? track.album : ''}</div>`;
+                        addResultText(itemDiv, 'title', track.title);
+                        addResultText(itemDiv, 'artist', track.author);
+                        addResultText(itemDiv, 'album', track.album);
                         itemDiv.addEventListener('click', () => {
                             const allIds = Array.from(document.querySelectorAll('.song-id')).map(i => i.value).filter(Boolean);
                             if (allIds.includes(track.item_id) && idEl.value !== track.item_id) {
@@ -607,7 +624,14 @@
                 artists.forEach(artist => {
                     const itemDiv = document.createElement('div');
                     itemDiv.className = 'autocomplete-item';
-                    itemDiv.innerHTML = `<div class="title">${artist.artist}</div><div class="artist">${artist.track_count} tracks</div>`;
+                    const titleDiv = document.createElement('div');
+                    titleDiv.className = 'title';
+                    titleDiv.textContent = artist.artist || '';
+                    const countDiv = document.createElement('div');
+                    countDiv.className = 'artist';
+                    countDiv.textContent = `${artist.track_count || 0} tracks`;
+                    itemDiv.appendChild(titleDiv);
+                    itemDiv.appendChild(countDiv);
                     itemDiv.addEventListener('click', () => {
                         idEl.value = artist.artist_id || artist.artist;
                         selectedSongNameEl.textContent = artist.artist;
@@ -1196,7 +1220,20 @@
             messageBox.id = boxId;
             // Using styles from style.css for consistency where possible, with inline for positioning
             messageBox.style.cssText = 'position: fixed; top: 20px; right: 20px; background-color: var(--bg-card); color: var(--text-main); padding: 20px; border-radius: 8px; box-shadow: var(--shadow-card); z-index: 1000; border: 1px solid var(--border-color); max-width: 400px; text-align: left;';
-            messageBox.innerHTML = `<h3 style="font-weight: 600; margin-top:0; margin-bottom: 10px; color: var(--text-title);">${title}</h3><p style="margin:0;">${message}</p><button style="position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: var(--text-muted); cursor: pointer;" onclick="this.parentNode.remove()">&times;</button>`;
+            const heading = document.createElement('h3');
+            heading.style.cssText = 'font-weight: 600; margin-top:0; margin-bottom: 10px; color: var(--text-title);';
+            heading.textContent = title;
+            const body = document.createElement('p');
+            body.style.margin = '0';
+            body.textContent = message;
+            const closeBtn = document.createElement('button');
+            closeBtn.type = 'button';
+            closeBtn.style.cssText = 'position: absolute; top: 10px; right: 10px; background: none; border: none; font-size: 1.5rem; color: var(--text-muted); cursor: pointer;';
+            closeBtn.textContent = 'X';
+            closeBtn.addEventListener('click', () => messageBox.remove());
+            messageBox.appendChild(heading);
+            messageBox.appendChild(body);
+            messageBox.appendChild(closeBtn);
             document.body.appendChild(messageBox);
             setTimeout(() => messageBox.remove(), 5000);
         }
@@ -1237,14 +1274,46 @@
         const buildRadioRow = (radio) => {
             const tr = document.createElement('tr');
             tr.dataset.id = radio.id;
-            tr.innerHTML = `
-                <td style="text-align:center;"><input type="checkbox" class="radio-enabled" ${radio.enabled ? 'checked' : ''}></td>
-                <td class="radio-name"></td>
-                <td><input type="number" class="radio-temperature" step="0.1" min="0" max="10" value="${radio.temperature}"></td>
-                <td><input type="number" class="radio-n-results" min="1" max="${maxN}" value="${radio.n_results}"></td>
-                <td style="text-align:right;"><button type="button" class="btn btn-sm btn-danger btn-delete-radio" title="Delete radio">✕</button></td>
-            `;
-            tr.querySelector('.radio-name').textContent = radio.name;
+
+            const enabledTd = tr.insertCell();
+            enabledTd.style.textAlign = 'center';
+            const enabledInput = document.createElement('input');
+            enabledInput.type = 'checkbox';
+            enabledInput.className = 'radio-enabled';
+            enabledInput.checked = !!radio.enabled;
+            enabledTd.appendChild(enabledInput);
+
+            const nameTd = tr.insertCell();
+            nameTd.className = 'radio-name';
+            nameTd.textContent = radio.name || '';
+
+            const tempTd = tr.insertCell();
+            const tempInput = document.createElement('input');
+            tempInput.type = 'number';
+            tempInput.className = 'radio-temperature';
+            tempInput.step = '0.1';
+            tempInput.min = '0';
+            tempInput.max = '10';
+            tempInput.value = radio.temperature;
+            tempTd.appendChild(tempInput);
+
+            const countTd = tr.insertCell();
+            const countInput = document.createElement('input');
+            countInput.type = 'number';
+            countInput.className = 'radio-n-results';
+            countInput.min = '1';
+            countInput.max = String(maxN);
+            countInput.value = radio.n_results;
+            countTd.appendChild(countInput);
+
+            const actionsTd = tr.insertCell();
+            actionsTd.style.textAlign = 'right';
+            const deleteBtn = document.createElement('button');
+            deleteBtn.type = 'button';
+            deleteBtn.className = 'btn btn-sm btn-danger btn-delete-radio';
+            deleteBtn.title = 'Delete radio';
+            deleteBtn.textContent = 'X';
+            actionsTd.appendChild(deleteBtn);
             return tr;
         };
 

--- a/templates/clap_search.html
+++ b/templates/clap_search.html
@@ -294,7 +294,11 @@ document.addEventListener('DOMContentLoaded', function() {
             displayResults(currentResults, query);
             
         } catch (error) {
-            resultsList.innerHTML = `<div class="error-message">❌ ${error.message}</div>`;
+            resultsList.innerHTML = '';
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'error-message';
+            errorDiv.textContent = 'Error: ' + error.message;
+            resultsList.appendChild(errorDiv);
         }
     });
     

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -349,6 +349,30 @@
     }
     function fmtTime(iso) { return iso ? iso.replace('T', ' ').substring(0, 19) : '–'; }
     function setText(id, value) { const el = document.getElementById(id); if (el) el.textContent = value; }
+    function appendTextCell(row, value) {
+        const td = row.insertCell();
+        td.textContent = value == null || value === '' ? '–' : String(value);
+        return td;
+    }
+    function appendCodeCell(row, value) {
+        const td = row.insertCell();
+        if (value == null || value === '') {
+            td.textContent = '–';
+        } else {
+            const code = document.createElement('code');
+            code.textContent = String(value);
+            td.appendChild(code);
+        }
+        return td;
+    }
+    function appendBadgeCell(row, label, className) {
+        const td = row.insertCell();
+        const span = document.createElement('span');
+        span.className = 'badge ' + className;
+        span.textContent = label == null || label === '' ? '?' : String(label);
+        td.appendChild(span);
+        return td;
+    }
 
     // Custom plugin: draws the label name + percentage inside each slice
     // of a pie/doughnut chart, so we can hide the side legend entirely.
@@ -489,22 +513,21 @@
             return;
         }
         workers.forEach(w => {
-            const stateBadge = w.state === 'busy'
-                ? '<span class="badge badge-progress">busy</span>'
-                : w.state === 'idle'
-                    ? '<span class="badge badge-ok">idle</span>'
-                    : `<span class="badge badge-unknown">${w.state || 'unknown'}</span>`;
+            const state = w.state || 'unknown';
+            const stateClass = state === 'busy'
+                ? 'badge-progress'
+                : state === 'idle'
+                    ? 'badge-ok'
+                    : 'badge-unknown';
             const queues = (w.queues || []).join(', ') || '–';
-            const job = w.current_job_id ? '<code>' + w.current_job_id + '</code>' : '–';
 
             const tr = document.createElement('tr');
-            tr.innerHTML = `
-                <td>${w.hostname || '–'}</td>
-                <td>${stateBadge}</td>
-                <td>${queues}</td>
-                <td>${w.successful_jobs ?? 0}</td>
-                <td>${w.failed_jobs ?? 0}</td>
-                <td>${job}</td>`;
+            appendTextCell(tr, w.hostname);
+            appendBadgeCell(tr, state, stateClass);
+            appendTextCell(tr, queues);
+            appendTextCell(tr, w.successful_jobs ?? 0);
+            appendTextCell(tr, w.failed_jobs ?? 0);
+            appendCodeCell(tr, w.current_job_id);
             tbody.appendChild(tr);
         });
     }
@@ -518,12 +541,11 @@
         }
         tasks.forEach(t => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `
-                <td>${t.task_type || '–'}</td>
-                <td><span class="badge ${statusBadgeClass(t.status)}">${t.status || '?'}</span></td>
-                <td>${fmtDuration(t.duration_seconds)}</td>
-                <td>${fmtTime(t.timestamp)}</td>
-                <td>${t.note || ''}</td>`;
+            appendTextCell(tr, t.task_type);
+            appendBadgeCell(tr, t.status, statusBadgeClass(t.status));
+            appendTextCell(tr, fmtDuration(t.duration_seconds));
+            appendTextCell(tr, fmtTime(t.timestamp));
+            appendTextCell(tr, t.note || '');
             tbody.appendChild(tr);
         });
     }
@@ -553,7 +575,9 @@
         }
         rows.forEach(r => {
             const tr = document.createElement('tr');
-            tr.innerHTML = `<td>${r.task_type}</td><td>${r.runs}</td><td>${fmtDuration(r.avg_seconds)}</td>`;
+            appendTextCell(tr, r.task_type);
+            appendTextCell(tr, r.runs);
+            appendTextCell(tr, fmtDuration(r.avg_seconds));
             tbody.appendChild(tr);
         });
     }
@@ -648,15 +672,11 @@
         }
         rows.forEach(c => {
             const tr = document.createElement('tr');
-            const enabled = c.enabled
-                ? '<span class="badge badge-ok">enabled</span>'
-                : '<span class="badge badge-unknown">disabled</span>';
-            tr.innerHTML = `
-                <td>${c.name || '–'}</td>
-                <td>${c.task_type || '–'}</td>
-                <td><code>${c.cron_expr || '–'}</code></td>
-                <td>${enabled}</td>
-                <td>${c.last_run || '–'}</td>`;
+            appendTextCell(tr, c.name);
+            appendTextCell(tr, c.task_type);
+            appendCodeCell(tr, c.cron_expr);
+            appendBadgeCell(tr, c.enabled ? 'enabled' : 'disabled', c.enabled ? 'badge-ok' : 'badge-unknown');
+            appendTextCell(tr, c.last_run);
             tbody.appendChild(tr);
         });
     }

--- a/templates/lyrics_search.html
+++ b/templates/lyrics_search.html
@@ -398,6 +398,22 @@ document.addEventListener('DOMContentLoaded', function () {
             sgHide();
         };
 
+        const sgTrackNode = (track) => {
+            const item = document.createElement('div');
+            item.className = 'autocomplete-item';
+            [
+                ['title', track.title || 'N/A'],
+                ['artist', track.author || 'N/A'],
+                ['album', 'Album: ' + (track.album || 'Unknown')],
+            ].forEach(([className, text]) => {
+                const row = document.createElement('div');
+                row.className = className;
+                row.textContent = text;
+                item.appendChild(row);
+            });
+            return item;
+        };
+
         const sgShow = (tracks, append) => {
             if (!append) sgResults.innerHTML = '';
             const sentinel = sgResults.querySelector('.autocomplete-load-more');
@@ -407,9 +423,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 sgResults.innerHTML = '<div class="autocomplete-item"><em>No results found</em></div>';
             } else {
                 tracks.forEach(t => {
-                    const d = document.createElement('div');
-                    d.className = 'autocomplete-item';
-                    d.innerHTML = `<div class="title">${escapeHtml(t.title||'N/A')}</div><div class="artist">${escapeHtml(t.author||'N/A')}</div><div class="album">Album: ${escapeHtml(t.album||'Unknown')}</div>`;
+                    const d = sgTrackNode(t);
                     d.addEventListener('click', () => sgSelect(t));
                     sgResults.appendChild(d);
                 });
@@ -502,7 +516,11 @@ document.addEventListener('DOMContentLoaded', function () {
             currentResults = data.results || [];
             displayResults(currentResults, queryLabel);
         } catch (err) {
-            resultsList.innerHTML = `<div class="error-message">❌ ${err.message}</div>`;
+            resultsList.innerHTML = '';
+            const errorDiv = document.createElement('div');
+            errorDiv.className = 'error-message';
+            errorDiv.textContent = 'Error: ' + err.message;
+            resultsList.appendChild(errorDiv);
         }
     }
 

--- a/templates/map.html
+++ b/templates/map.html
@@ -172,6 +172,60 @@ function applyPlotlyTheme() {
     Plotly.relayout(gd, update).catch(() => {});
 }
 
+function renderGenreLegend(legendDiv, genreList, colorMap) {
+    legendDiv.innerHTML = '';
+    const controls = document.createElement('span');
+    controls.style.marginRight = '12px';
+    controls.style.fontSize = '14px';
+    controls.style.color = 'var(--text-muted)';
+    const hideLink = document.createElement('a');
+    hideLink.href = '#';
+    hideLink.style.color = 'var(--color-primary)';
+    hideLink.textContent = 'Hide all';
+    hideLink.addEventListener('click', event => {
+        event.preventDefault();
+        hideAllGenres();
+    });
+    const showLink = document.createElement('a');
+    showLink.href = '#';
+    showLink.style.color = 'var(--color-primary)';
+    showLink.textContent = 'Show all';
+    showLink.addEventListener('click', event => {
+        event.preventDefault();
+        showAllGenres();
+    });
+    controls.appendChild(hideLink);
+    controls.appendChild(document.createTextNode('  |  '));
+    controls.appendChild(showLink);
+    legendDiv.appendChild(controls);
+
+    const hiddenGenres = window._hiddenGenres || new Set();
+    genreList.slice(0, 50).forEach(g => {
+        const encoded = encodeURIComponent(g);
+        const item = document.createElement('span');
+        item.className = 'genre-item';
+        item.dataset.genre = encoded;
+        item.style.marginRight = '8px';
+        item.style.cursor = 'pointer';
+        item.style.color = 'var(--text-main)';
+        if (hiddenGenres.has(g)) item.style.textDecoration = 'line-through';
+        item.addEventListener('click', () => toggleGenre(encoded));
+
+        const swatch = document.createElement('span');
+        swatch.style.display = 'inline-block';
+        swatch.style.width = '12px';
+        swatch.style.height = '12px';
+        swatch.style.background = colorMap[g];
+        swatch.style.marginRight = '6px';
+        swatch.style.verticalAlign = 'middle';
+        swatch.style.borderRadius = '2px';
+        item.appendChild(swatch);
+        item.appendChild(document.createTextNode(g));
+        legendDiv.appendChild(item);
+    });
+    applyLegendStyles();
+}
+
 // Watch for dark mode class changes to update Plotly theme and legend palette dynamically
 (function() {
     const observer = new MutationObserver(function(mutations) {
@@ -186,15 +240,7 @@ function applyPlotlyTheme() {
                     if (legendDiv) {
                         var colorMap = window._colorMap;
                         var genreList = window._genreList;
-                        var controlsHtml = '<span style="margin-right:12px;font-size:14px;color:var(--text-muted)"><a href="#" onclick="hideAllGenres();return false;" style="color:var(--color-primary)">Hide all</a> &nbsp;|&nbsp; <a href="#" onclick="showAllGenres();return false;" style="color:var(--color-primary)">Show all</a></span>';
-                        var genreHtml = genreList.slice(0,50).map(function(g) {
-                            var enc = encodeURIComponent(g);
-                            var swatch = '<span style="display:inline-block;width:12px;height:12px;background:' + colorMap[g] + ';margin-right:6px;vertical-align:middle;border-radius:2px"></span>';
-                            var hidden = (window._hiddenGenres && window._hiddenGenres.has(g)) ? 'text-decoration:line-through' : '';
-                            return '<span class="genre-item" data-genre="' + enc + '" onclick="toggleGenre(\'' + enc + '\')" style="margin-right:8px;cursor:pointer;color:var(--text-main);' + hidden + '">' + swatch + g + '</span>';
-                        }).join('');
-                        legendDiv.innerHTML = controlsHtml + genreHtml;
-                        applyLegendStyles();
+                        renderGenreLegend(legendDiv, genreList, colorMap);
                     }
                     applyGenreFilterAndRerender();
                 }
@@ -271,19 +317,7 @@ async function loadAndPlot(n_or_pct) {
 
     // render a compact, clickable legend manually (click genre to hide/show)
     const legendDiv = document.getElementById('map-projection-label');
-    // Build a small control set (Hide all / Show all) and the genre items. Each genre span includes a data-genre attribute
-    // so we can update its style when hidden.
-    const controlsHtml = `<span style="margin-right:12px;font-size:14px;color:var(--text-muted)"><a href="#" onclick="hideAllGenres();return false;" style="color:var(--color-primary)">Hide all</a> &nbsp;|&nbsp; <a href="#" onclick="showAllGenres();return false;" style="color:var(--color-primary)">Show all</a></span>`;
-    const genreHtml = genreList.slice(0,50).map(g => {
-        const enc = encodeURIComponent(g);
-        const swatch = `<span style=\"display:inline-block;width:12px;height:12px;background:${colorMap[g]};margin-right:6px;vertical-align:middle;border-radius:2px\"></span>`;
-        // allow initial hidden state styling
-        const hidden = (window._hiddenGenres && window._hiddenGenres.has(g)) ? 'text-decoration:line-through' : '';
-        return `<span class=\"genre-item\" data-genre=\"${enc}\" onclick=\"toggleGenre('${enc}')\" style=\"margin-right:8px;cursor:pointer;color:var(--text-main);${hidden}\">${swatch}${g}</span>`;
-    }).join('');
-    legendDiv.innerHTML = controlsHtml + genreHtml;
-    // Apply final legend styles in case window._hiddenGenres was set
-    applyLegendStyles();
+    renderGenreLegend(legendDiv, genreList, colorMap);
 
         const layout = {
             hovermode: 'closest',
@@ -505,7 +539,15 @@ function renderSelectionPanel() {
             const row = document.createElement('div');
             row.className = 'selection-list-item';
             const left = document.createElement('div');
-            left.innerHTML = `<span style="color:var(--text-muted);margin-right:6px">[${p.genre}]</span> ${p.title} - ${p.artist}`;
+            const genre = document.createElement('span');
+            const genreName = p.genre || 'unknown';
+            const title = p.title || '(unknown)';
+            const artist = p.artist || '(unknown)';
+            genre.style.color = 'var(--text-muted)';
+            genre.style.marginRight = '6px';
+            genre.textContent = '[' + genreName + ']';
+            left.appendChild(genre);
+            left.appendChild(document.createTextNode(' ' + title + ' - ' + artist));
             const btn = document.createElement('button'); btn.className = 'btn btn-danger btn-sm'; btn.textContent = 'REMOVE'; btn.style.marginLeft = '8px'; btn.onclick = (()=>{
                 return function() { removeFromSelection(id); };
             })();
@@ -672,7 +714,20 @@ window.addEventListener('load', () => { setActivePctButton('btn-pct-25'); loadAn
             div.id = 'map-ac-opt-' + (acIdSeq++);
             div._track = t;
             div.style.padding = '6px'; div.style.cursor = 'pointer'; div.style.borderBottom = '1px solid var(--border-color)';
-            div.innerHTML = `<div style="font-weight:600">${t.title || '(unknown)'}</div><div style="font-size:12px;color:var(--text-muted)">${t.author || ''}</div><div style="font-size:12px;color:var(--text-muted)">${t.album ? t.album : ''}</div>`;
+            const title = document.createElement('div');
+            title.style.fontWeight = '600';
+            title.textContent = t.title || '(unknown)';
+            const author = document.createElement('div');
+            author.style.fontSize = '12px';
+            author.style.color = 'var(--text-muted)';
+            author.textContent = t.author || '';
+            const album = document.createElement('div');
+            album.style.fontSize = '12px';
+            album.style.color = 'var(--text-muted)';
+            album.textContent = t.album || '';
+            div.appendChild(title);
+            div.appendChild(author);
+            div.appendChild(album);
             div.addEventListener('click', ()=> selectMapTrack(t));
             c.appendChild(div);
         }

--- a/templates/path.html
+++ b/templates/path.html
@@ -328,13 +328,22 @@
                     }
                 };
 
+                const writeTrackLine = (container, className, text) => {
+                    const row = document.createElement('div');
+                    row.className = className;
+                    row.textContent = text || '';
+                    container.appendChild(row);
+                };
+
                 const appendResults = (tracks) => {
                     const existingSentinel = resultsEl.querySelector('.autocomplete-load-more');
                     if (existingSentinel) existingSentinel.remove();
                     tracks.forEach(track => {
                         const itemDiv = document.createElement('div');
                         itemDiv.className = 'autocomplete-item';
-                        itemDiv.innerHTML = `<div class="title">${track.title}</div><div class="artist">${track.author}</div><div class="album">${track.album ? track.album : ''}</div>`;
+                        writeTrackLine(itemDiv, 'title', track.title);
+                        writeTrackLine(itemDiv, 'artist', track.author);
+                        writeTrackLine(itemDiv, 'album', track.album);
                         itemDiv.addEventListener('click', () => {
                             displayTitleEl.textContent = 'Title: ' + track.title;
                             displayArtistEl.textContent = 'Artist: ' + track.author;

--- a/templates/similarity.html
+++ b/templates/similarity.html
@@ -370,6 +370,25 @@
                 }
             };
 
+            const makeTrackOption = (track) => {
+                const itemDiv = document.createElement('div');
+                itemDiv.className = 'autocomplete-item';
+                itemDiv.setAttribute('role', 'option');
+                itemDiv.id = 'ac-opt-' + (acSeq++);
+                itemDiv._track = track;
+                [
+                    ['title', track.title || 'N/A'],
+                    ['artist', track.author || 'N/A'],
+                    ['album', 'Album: ' + (track.album || 'Unknown')],
+                ].forEach(([className, text]) => {
+                    const row = document.createElement('div');
+                    row.className = className;
+                    row.textContent = text;
+                    itemDiv.appendChild(row);
+                });
+                return itemDiv;
+            };
+
             const showAutocomplete = (tracks, append) => {
                 if (!append) { autocompleteResults.innerHTML = ''; activeIndex = -1; acSeq = 0; searchInput.removeAttribute('aria-activedescendant'); }
                 // Remove existing sentinel if any
@@ -380,12 +399,7 @@
                     autocompleteResults.innerHTML = '<div class="autocomplete-item"><em>No results found</em></div>';
                 } else {
                     tracks.forEach(track => {
-                        const itemDiv = document.createElement('div');
-                        itemDiv.className = 'autocomplete-item';
-                        itemDiv.setAttribute('role', 'option');
-                        itemDiv.id = 'ac-opt-' + (acSeq++);
-                        itemDiv._track = track;
-                        itemDiv.innerHTML = '<div class="title">' + (track.title || 'N/A') + '</div><div class="artist">' + (track.author || 'N/A') + '</div><div class="album">Album: ' + (track.album || 'Unknown') + '</div>';
+                        const itemDiv = makeTrackOption(track);
                         itemDiv.addEventListener('click', () => selectTrack(track));
                         autocompleteResults.appendChild(itemDiv);
                     });

--- a/templates/waveform.html
+++ b/templates/waveform.html
@@ -169,6 +169,29 @@
                 }
             };
 
+            const createTrackResult = (track) => {
+                const itemDiv = document.createElement('div');
+                itemDiv.className = 'autocomplete-item';
+                const title = document.createElement('div');
+                title.className = 'title';
+                title.textContent = track.title || '';
+                const artist = document.createElement('div');
+                artist.className = 'artist';
+                artist.textContent = track.author || '';
+                itemDiv.appendChild(title);
+                itemDiv.appendChild(artist);
+                if (track.album) {
+                    const album = document.createElement('div');
+                    album.className = 'album';
+                    album.appendChild(document.createTextNode('Album: '));
+                    const name = document.createElement('span');
+                    name.textContent = track.album;
+                    album.appendChild(name);
+                    itemDiv.appendChild(album);
+                }
+                return itemDiv;
+            };
+
             const showAutocomplete = (tracks, append) => {
                 if (!append) autocompleteResults.innerHTML = '';
                 const existingSentinel = autocompleteResults.querySelector('.autocomplete-load-more');
@@ -178,12 +201,7 @@
                     autocompleteResults.innerHTML = '<div class="autocomplete-item"><em>No results found</em></div>';
                 } else {
                     tracks.forEach(track => {
-                        const itemDiv = document.createElement('div');
-                        itemDiv.className = 'autocomplete-item';
-                        itemDiv.innerHTML =
-                            '<div class="title">' + track.title + '</div>' +
-                            '<div class="artist">' + track.author + '</div>' +
-                            (track.album ? '<div class="album">Album: <span>' + track.album + '</span></div>' : '');
+                        const itemDiv = createTrackResult(track);
                         itemDiv.addEventListener('click', () => selectTrack(track));
                         autocompleteResults.appendChild(itemDiv);
                     });


### PR DESCRIPTION
﻿## AS-IS
Several UI paths rendered API or library metadata by interpolating it into HTML strings. Some error and selection messages also used inline HTML event handlers or string-built table rows.

## TO-BE
High-risk UI paths now render dynamic names, messages, table cells, autocomplete rows, map legend entries, playlist rows, and selected labels with DOM nodes and `textContent` instead of interpolated HTML.

## Test
- `node --check static/script.js`
- `node --check static/sunburst.js`
- `git diff --cached --check`
- `rg -n 'onclick=' static/script.js static/sunburst.js templates/alchemy.html templates/clap_search.html templates/dashboard.html templates/lyrics_search.html templates/map.html templates/path.html templates/similarity.html templates/waveform.html` returned no matches.
- Reviewed scoped `innerHTML` template-literal grep; remaining matches are static layout snippets or existing generated markup that does not interpolate API text directly.

## Other useful information
Split from closed #735 and limited to safe rendering in static/template UI code.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [ ] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A