### PR TITLE
fix: revalidate JWT session users

### DIFF
--- a/app_auth.py
+++ b/app_auth.py
@@ -318,6 +318,31 @@ def verify_additional_user(username, password):
     return _normalize_role(role) or USER_ROLE_USER
 
 
+def _session_role_for_user(username):
+    if not isinstance(username, str) or not username:
+        return None
+    db = None
+    try:
+        db = _get_db()
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT role FROM audiomuse_users WHERE username = %s",
+                (username,),
+            )
+            row = cur.fetchone()
+    except Exception:
+        logger.exception("Failed to validate session user %r", username)
+        if db is not None:
+            try:
+                db.rollback()
+            except Exception:
+                pass
+        return None
+    if not row:
+        return None
+    return _normalize_role(row[0])
+
+
 def upsert_admin_user(username, password):
     """Create an admin row, or update the password and force admin role when
     the username already exists. Returns ``(ok, error_message)``.
@@ -526,10 +551,18 @@ def check_auth_needed(jwt_secret):
     if token and jwt_secret:
         try:
             payload = pyjwt.decode(token, jwt_secret, algorithms=['HS256'])
-            # Backward-compat: tokens issued before the multi-user feature
-            # have no 'role' claim; treat them as admin.
-            g.auth_role = payload.get('role', 'admin')
-            g.auth_user = payload.get('sub')
+            username = payload.get('sub')
+            if username:
+                role = _session_role_for_user(username)
+                if role is None:
+                    raise pyjwt.InvalidTokenError("session user no longer exists")
+                g.auth_role = role
+                g.auth_user = username
+            else:
+                # Backward-compat: tokens issued before the multi-user feature
+                # have no 'sub' claim; treat them as admin.
+                g.auth_role = payload.get('role', 'admin')
+                g.auth_user = None
             return None
         except pyjwt.InvalidTokenError:
             pass

--- a/test/unit/test_app_auth.py
+++ b/test/unit/test_app_auth.py
@@ -61,13 +61,30 @@ class TestCheckAuthNeededJwt:
 
         monkeypatch.setattr(config, 'AUTH_ENABLED', True)
         monkeypatch.setattr(config, 'API_TOKEN', '')
+        db, cur = _fake_db(fetchone=('user',))
+        monkeypatch.setattr(app_auth, '_get_db', lambda: db)
         secret = 'unit-secret'
-        token = pyjwt.encode({'sub': 'alice', 'role': 'user'}, secret, algorithm='HS256')
+        token = pyjwt.encode({'sub': 'alice', 'role': 'admin'}, secret, algorithm='HS256')
         with app.test_request_context('/api/foo', headers={'Cookie': f'audiomuse_jwt={token}'}):
             result = app_auth.check_auth_needed(secret)
             assert result is None
             assert g.auth_role == 'user'
             assert g.auth_user == 'alice'
+        assert cur.execute.call_args[0][1] == ('alice',)
+
+    def test_deleted_user_token_is_unauthorized(self, app, monkeypatch):
+        import config
+
+        monkeypatch.setattr(config, 'AUTH_ENABLED', True)
+        monkeypatch.setattr(config, 'API_TOKEN', '')
+        db, _cur = _fake_db(fetchone=None)
+        monkeypatch.setattr(app_auth, '_get_db', lambda: db)
+        secret = 'unit-secret'
+        token = pyjwt.encode({'sub': 'alice', 'role': 'admin'}, secret, algorithm='HS256')
+        with app.test_request_context('/api/foo', headers={'Cookie': f'audiomuse_jwt={token}'}):
+            result = app_auth.check_auth_needed(secret)
+            assert result is not None
+            assert result[1] == 401
 
     def test_empty_secret_rejects_present_cookie(self, app, monkeypatch):
         import config


### PR DESCRIPTION
﻿## AS-IS
JWT cookies trusted the role claim already stored in the token. If a user's role changed or the user row was removed after login, an existing token could keep using stale authorization until it expired.

## TO-BE
JWT cookies with a `sub` now re-read the user's role from `audiomuse_users` on each authenticated request and reject sessions for deleted users. Legacy tokens without `sub` keep the existing admin-compatible fallback.

## Test
- `uv run --python 3.12 --with pytest --with flask --with PyJWT --with argon2-cffi --with psycopg2-binary --with redis --with rq --with pyyaml --with requests --with numpy --with rapidfuzz pytest test/unit/test_app_auth.py`
- `uv run --with ruff ruff check app_auth.py test/unit/test_app_auth.py`
- `git diff --check`

## Other useful information
Split from closed #735 and limited to JWT session user/role validation.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A