### PR TITLE
fix: avoid duplicate CLAP tail segments

### DIFF
--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -50,6 +50,20 @@ _label_text_embeddings_cache = None
 _SEGMENT_LENGTH_SAMPLES = 480000
 
 
+def _split_audio_segments(audio_data, segment_length=_SEGMENT_LENGTH_SAMPLES, hop_length=240000):
+    total_length = len(audio_data)
+    if total_length <= segment_length:
+        padded = np.pad(audio_data, (0, segment_length - total_length), mode='constant')
+        return [padded]
+
+    starts = list(range(0, total_length - segment_length + 1, hop_length))
+    tail_start = total_length - segment_length
+    if starts[-1] != tail_start:
+        starts.append(tail_start)
+
+    return [audio_data[start : start + segment_length] for start in starts]
+
+
 def _static_shape_model_bytes(model_path):
     import onnx
     from onnxruntime.tools.onnx_model_utils import make_dim_param_fixed
@@ -450,18 +464,7 @@ def analyze_audio_file(audio_path: str) -> Tuple[Optional[np.ndarray], float, in
 
         duration_sec = len(audio_data) / SAMPLE_RATE
 
-        segments = []
-        total_length = len(audio_data)
-
-        if total_length <= SEGMENT_LENGTH:
-            padded = np.pad(audio_data, (0, SEGMENT_LENGTH - total_length), mode='constant')
-            segments.append(padded)
-        else:
-            for start in range(0, total_length - SEGMENT_LENGTH + 1, HOP_LENGTH):
-                segments.append(audio_data[start : start + SEGMENT_LENGTH])
-            last_start = len(segments) * HOP_LENGTH
-            if last_start < total_length:
-                segments.append(audio_data[-SEGMENT_LENGTH:])
+        segments = _split_audio_segments(audio_data, SEGMENT_LENGTH, HOP_LENGTH)
 
         num_segments = len(segments)
         logger.info(f"CLAP: Processing {num_segments} segments ({duration_sec:.1f}s audio)")

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -48,9 +48,14 @@ _tokenizer = None
 _label_text_embeddings_cache = None
 
 _SEGMENT_LENGTH_SAMPLES = 480000
+_HOP_LENGTH_SAMPLES = 240000
 
 
-def _split_audio_segments(audio_data, segment_length=_SEGMENT_LENGTH_SAMPLES, hop_length=240000):
+def _split_audio_segments(
+    audio_data: np.ndarray,
+    segment_length: int = _SEGMENT_LENGTH_SAMPLES,
+    hop_length: int = _HOP_LENGTH_SAMPLES,
+) -> list[np.ndarray]:
     total_length = len(audio_data)
     if total_length <= segment_length:
         padded = np.pad(audio_data, (0, segment_length - total_length), mode='constant')
@@ -447,9 +452,6 @@ def analyze_audio_file(audio_path: str) -> Tuple[Optional[np.ndarray], float, in
         session = get_clap_audio_model()
 
         SAMPLE_RATE = 48000
-        SEGMENT_LENGTH = _SEGMENT_LENGTH_SAMPLES
-        HOP_LENGTH = 240000
-
         from tasks.analysis import robust_load_audio_with_fallback
 
         audio_data, sr = robust_load_audio_with_fallback(audio_path, target_sr=SAMPLE_RATE)
@@ -464,7 +466,7 @@ def analyze_audio_file(audio_path: str) -> Tuple[Optional[np.ndarray], float, in
 
         duration_sec = len(audio_data) / SAMPLE_RATE
 
-        segments = _split_audio_segments(audio_data, SEGMENT_LENGTH, HOP_LENGTH)
+        segments = _split_audio_segments(audio_data)
 
         num_segments = len(segments)
         logger.info(f"CLAP: Processing {num_segments} segments ({duration_sec:.1f}s audio)")

--- a/test/integration/verify_onnx_embeddings.py
+++ b/test/integration/verify_onnx_embeddings.py
@@ -26,6 +26,8 @@ import librosa.feature
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
+from tasks.clap_analyzer import _split_audio_segments
+
 
 def compare_pytorch_vs_onnx():
     print("=" * 80)
@@ -248,26 +250,7 @@ def compare_pytorch_vs_onnx():
 
                 print(f"Loaded: {len(audio_data) / sr:.2f}s at {sr}Hz")
 
-                SEGMENT_LENGTH = 480000
-                HOP_LENGTH = 240000
-
-                segments = []
-                total_length = len(audio_data)
-
-                if total_length <= SEGMENT_LENGTH:
-                    padded_audio = np.pad(
-                        audio_data, (0, SEGMENT_LENGTH - total_length), mode='constant'
-                    )
-                    segments.append(padded_audio)
-                else:
-                    for start in range(0, total_length - SEGMENT_LENGTH + 1, HOP_LENGTH):
-                        segment = audio_data[start : start + SEGMENT_LENGTH]
-                        segments.append(segment)
-
-                    last_start = len(segments) * HOP_LENGTH
-                    if last_start < total_length:
-                        last_segment = audio_data[-SEGMENT_LENGTH:]
-                        segments.append(last_segment)
+                segments = _split_audio_segments(audio_data)
 
                 print(f"Split into {len(segments)} segments (10s with 5s overlap)")
 

--- a/test/unit/test_clap_analyzer_segments.py
+++ b/test/unit/test_clap_analyzer_segments.py
@@ -1,0 +1,56 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""CLAP audio segmentation tests.
+
+Covers the window slicing used before ONNX CLAP audio embedding so exact
+hop-aligned durations do not duplicate the final segment.
+
+Main Features:
+* Short audio pads to one full segment.
+* Hop-aligned tails are emitted once.
+* Non-aligned tails still keep the final window.
+"""
+
+import numpy as np
+
+from tasks.clap_analyzer import _split_audio_segments
+
+
+SEGMENT_LENGTH = 480000
+HOP_LENGTH = 240000
+
+
+def _audio(length):
+    return np.arange(length, dtype=np.float32)
+
+
+def test_short_audio_pads_to_one_segment():
+    segments = _split_audio_segments(_audio(4), segment_length=8, hop_length=4)
+
+    assert len(segments) == 1
+    assert segments[0].tolist() == [0.0, 1.0, 2.0, 3.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def test_hop_aligned_tail_is_not_duplicated():
+    audio = _audio(SEGMENT_LENGTH + HOP_LENGTH)
+
+    segments = _split_audio_segments(audio, SEGMENT_LENGTH, HOP_LENGTH)
+
+    assert len(segments) == 2
+    assert segments[0][0] == 0
+    assert segments[1][0] == HOP_LENGTH
+
+
+def test_non_aligned_tail_keeps_final_window():
+    audio = _audio(SEGMENT_LENGTH + HOP_LENGTH + 1)
+
+    segments = _split_audio_segments(audio, SEGMENT_LENGTH, HOP_LENGTH)
+
+    assert len(segments) == 3
+    assert segments[-1][0] == HOP_LENGTH + 1


### PR DESCRIPTION
## AS-IS
CLAP audio analysis slices 10 second windows with a 5 second hop, then averages every segment embedding and normalizes the final track embedding.

For tracks whose resampled length lands exactly on the hop grid after the first 10 second window, the current tail handling adds the final window twice. Example: a 15 second track is sliced as `[0s-10s, 5s-15s, 5s-15s]` instead of `[0s-10s, 5s-15s]`.

## TO-BE
The final CLAP window is appended only when it is not already present. Non-aligned tails still keep the final window, and short tracks are still padded to one 10 second segment.

The same helper is used by the ONNX verification script so the verification path and production analysis path slice audio the same way.

## Test
- `uv run --python 3.12 --with pytest --with numpy pytest test/unit/test_clap_analyzer_segments.py`
- `uv run --with ruff ruff check tasks/clap_analyzer.py test/integration/verify_onnx_embeddings.py test/unit/test_clap_analyzer_segments.py`
- `uv run --with ruff ruff check .`
- `git diff --check main...HEAD`

## Other useful information
This is a correctness fix, not a claimed model-quality tuning. It removes an accidental duplicate segment and the extra weight that duplicate gives to the end of hop-aligned tracks.

Pros:
- Removes duplicate tail weighting for exact hop-aligned tracks.
- Saves one CLAP audio-model inference for those affected tracks.
- Keeps segment lists unchanged for short tracks and non-hop-aligned tracks.

Cons / impact:
- Stored CLAP embeddings for affected hop-aligned tracks will differ after recomputation because the final segment no longer has double weight.
- Existing stored embeddings remain readable; this does not require a DB migration.
- A full library analysis is not required for the app to keep working. To make all stored CLAP embeddings match the new method, only tracks whose resampled sample count satisfies `len(audio) > 480000` and `(len(audio) - 480000) % 240000 == 0` need CLAP recomputation. If the app cannot target those tracks directly, a full CLAP analysis is the broad fallback, but the change does not force it functionally.

Segment-count experiment, using the production 48 kHz / 10 s segment / 5 s hop values:

| Duration | Old segments | New segments | CLAP inferences saved | Segment list changed |
| --- | ---: | ---: | ---: | --- |
| 9 s | 1 | 1 | 0.00% | no |
| 10 s | 1 | 1 | 0.00% | no |
| 15 s | 3 | 2 | 33.33% | yes, duplicate tail removed |
| 20 s | 4 | 3 | 25.00% | yes, duplicate tail removed |
| 25 s | 5 | 4 | 20.00% | yes, duplicate tail removed |
| 30 s | 6 | 5 | 16.67% | yes, duplicate tail removed |
| 60 s | 12 | 11 | 8.33% | yes, duplicate tail removed |
| 180 s | 36 | 35 | 2.78% | yes, duplicate tail removed |
| 300 s | 60 | 59 | 1.67% | yes, duplicate tail removed |
| 15.1 s | 3 | 3 | 0.00% | no |
| 20.1 s | 4 | 4 | 0.00% | no |

Embedding impact:
- For unaffected durations, the segment list is identical, so the final CLAP embedding is unchanged.
- For affected durations, the old final embedding is `normalize((sum(unique_segment_embeddings) + final_segment_embedding) / (n + 1))`; the new final embedding is `normalize(sum(unique_segment_embeddings) / n)`.
- Deterministic aggregation experiment with 512-dim correlated segment embeddings (seed 734, correlation 0.90) gives these cosine distances between old/new final embeddings: 15 s `0.00034994`, 20 s `0.00024606`, 30 s `0.00014341`, 60 s `0.00003727`, 180 s `0.00000450`, 300 s `0.00000168`. Actual CLAP deltas depend on the audio/model output, but the changed weighting formula above is exact.

## Checklist
**Type of change:**
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image

**Tested on media server:**
- [ ] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [ ] Documentation
- [x] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues

**Related ISSUE:** N/A