### PR TITLE
[GPU] Add initial acceleration for AMD (ROCm 7.2.4, MiGraphX)

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -13,6 +13,7 @@
 #   caf         -> test-fixture strings in test/unit (not "calf")
 #   embbeding   -> part of the real filename query/read_bytea_embbeding.sql referenced in a comment
 #   acapella    -> deliberate user-query spelling variant matched in _VOCALNESS_RE (tasks/ai/planner.py), alongside "a cappella"
-ignore-words-list = idel,re-uses,nd,datas,embeding,unparseable,caf,embbeding,acapella
+#   renderd     -> /dev/dri/renderD* device glob in docs/GPU-AMD.md (not "rendered")
+ignore-words-list = idel,re-uses,nd,datas,embeding,unparseable,caf,embbeding,acapella,renderd
 # Binary/vendored/generated trees and local caches kept out of the scan.
 skip = .git,*.lock,*.min.js,*.map,*.svg,*.egg-info,.mypy_cache,.pytest_cache,.ruff_cache,model,dist,native-build,.venv,.venv-windows,screenshot,test/songs,static,mood_centroids_real_080_clap.json

--- a/Dockerfile-rocm
+++ b/Dockerfile-rocm
@@ -1,0 +1,143 @@
+# syntax=docker/dockerfile:1
+# AudioMuse-AI ROCm (AMD GPU) Dockerfile
+#
+# Second GPU image next to the NVIDIA one (Dockerfile + BASE_IMAGE=nvidia/cuda).
+# Accelerates ONNX analysis (musicnn) via MIGraphX, and lyrics transcription via
+# faster-whisper/CTranslate2's ROCm backend (MIGraphX can't parse the Whisper
+# decoder or the DCLAP Resize op, see docs/GPU-AMD.md). Tested on RX 9070 XT
+# (gfx1201/RDNA4). GPU clustering (RAPIDS cuML) has no ROCm port, stays CPU.
+#
+# Build:
+#   docker build -f Dockerfile-rocm -t audiomuse-ai-rocm .
+# Run (passes the GPU): see deployment/docker-compose-rocm.yaml
+ARG BASE_IMAGE=rocm/onnxruntime:rocm7.2.4_ub24.04_ort1.23_torch2.10.0
+# Published CPU image already bundles the models; copy instead of re-downloading.
+ARG MODELS_IMAGE=ghcr.io/neptunehub/audiomuse-ai:latest
+
+# ============================================================================
+# Stage 1: models - pull the already-downloaded models from the published image
+# ============================================================================
+FROM ${MODELS_IMAGE} AS models
+
+# ============================================================================
+# Stage 2: runner - ROCm base (MIGraphX ONNX Runtime) + app deps
+# ============================================================================
+FROM ${BASE_IMAGE} AS runner
+
+SHELL ["/bin/bash", "-c"]
+
+# Runtime libs + CLI tools the entrypoint/supervisord/debugging rely on. No
+# version pins: the ROCm base's package set differs from the plain image.
+RUN set -ux; \
+    n=0; \
+    until [ "$n" -ge 5 ]; do \
+        if DEBIAN_FRONTEND=noninteractive apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            python3 python3-pip python3-venv \
+            libfftw3-double3 libyaml-0-2 libsamplerate0 libsndfile1 \
+            libopenblas0 liblapack3 libgomp1 libpq5 \
+            ffmpeg wget curl supervisor procps \
+            git vim redis-tools strace iputils-ping \
+            postgresql-common ca-certificates tzdata \
+            && /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -y \
+            && DEBIAN_FRONTEND=noninteractive apt-get update \
+            && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends postgresql-client-18; then \
+            break; \
+        fi; \
+        n=$((n+1)); \
+        echo "apt-get attempt $n failed - retrying in $((n*n))s"; \
+        sleep $((n*n)); \
+    done; \
+    rm -rf /var/lib/apt/lists/* && \
+    apt-get remove -y python3-numpy || true && \
+    apt-get autoremove -y || true && \
+    rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/uv
+
+WORKDIR /app
+COPY requirements/ /app/requirements/
+
+# Install into the base image's venv (/opt/venv), which already has onnxruntime
+# built with MIGraphXExecutionProvider. Target the venv interpreter explicitly
+# (not system python3.12) so deps land where the app actually runs; onnxruntime
+# stays out of rocm.txt/common.txt so it's never reinstalled/clobbered.
+ENV VIRTUAL_ENV=/opt/venv
+RUN set -eux; \
+    uv pip install --python "$VIRTUAL_ENV/bin/python3" --no-cache --index-strategy unsafe-best-match \
+        -r /app/requirements/rocm.txt -r /app/requirements/common.txt; \
+    "$VIRTUAL_ENV/bin/python3" -c "import onnxruntime as ort; p=ort.get_available_providers(); print('ORT providers:', p); assert 'MIGraphXExecutionProvider' in p, 'MIGraphX EP missing'"; \
+    "$VIRTUAL_ENV/bin/python3" -c "import psycopg2; print('psycopg2 OK')"; \
+    find "$VIRTUAL_ENV/lib" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+# faster-whisper on the AMD GPU via CTranslate2's ROCm HIP backend (see
+# lyrics/whisper_faster.py). The wheel ships only as a GitHub release asset
+# (not on PyPI). Installed --no-deps: its onnxruntime dependency would
+# otherwise clobber the base MIGraphX ORT with a CPU-only build.
+ARG CT2_VERSION=4.7.1
+RUN set -eux; \
+    cd /tmp; \
+    wget -q "https://github.com/OpenNMT/CTranslate2/releases/download/v${CT2_VERSION}/rocm-python-wheels-Linux.zip"; \
+    "$VIRTUAL_ENV/bin/python3" -c "import zipfile; zipfile.ZipFile('rocm-python-wheels-Linux.zip').extractall('ct2whl')"; \
+    whl="$(find ct2whl -name "ctranslate2-${CT2_VERSION}-cp312-cp312-*.whl" | head -1)"; \
+    test -n "$whl"; \
+    uv pip install --python "$VIRTUAL_ENV/bin/python3" --no-cache "$whl"; \
+    uv pip install --python "$VIRTUAL_ENV/bin/python3" --no-cache --no-deps "faster-whisper==1.2.1"; \
+    rm -rf /tmp/rocm-python-wheels-Linux.zip /tmp/ct2whl; \
+    "$VIRTUAL_ENV/bin/python3" -c "import ctranslate2; print('ctranslate2', ctranslate2.__version__)"; \
+    "$VIRTUAL_ENV/bin/python3" -c "from faster_whisper import WhisperModel; print('faster_whisper import OK')"; \
+    "$VIRTUAL_ENV/bin/python3" -c "import onnxruntime as ort; p=ort.get_available_providers(); assert 'MIGraphXExecutionProvider' in p, 'MIGraphX EP lost after faster-whisper install'; print('MIGraphX EP intact:', p)"; \
+    find "$VIRTUAL_ENV/lib" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Environment (baked into the image, not compose)
+# ---------------------------------------------------------------------------
+ENV LANG=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    DEBIAN_FRONTEND=noninteractive \
+    TZ=UTC \
+    IVF_DISK_CACHE_DIR=/app/ivf_cache \
+    HF_HOME=/app/.cache/huggingface \
+    HF_HUB_DISABLE_XET=1 \
+    HF_XET_DISABLE=1 \
+    NUMBA_CACHE_DIR=/tmp/numba_cache \
+    PYTHONPATH=/app
+
+# HSA_ENABLE_INTERRUPT=1: interrupt-driven GPU completion instead of CPU
+# busy-polling. MIOPEN_*: kernel compile cache dir, mounted as a volume by
+# compose to persist across restarts.
+ENV HSA_ENABLE_INTERRUPT=1 \
+    MIOPEN_USER_DB_PATH=/app/.cache/miopen \
+    MIOPEN_CUSTOM_CACHE_DIR=/app/.cache/miopen \
+    LYRICS_WHISPER_BACKEND=faster
+RUN mkdir -p /app/.cache/miopen && chmod 777 /app/.cache/miopen
+
+# Copy the pre-downloaded models + HF cache from the published image.
+COPY --from=models /app/model/ /app/model/
+COPY --from=models /app/.cache/huggingface/ /app/.cache/huggingface/
+
+# Embed DCLAP's external-data sidecar into the model itself: the MIGraphX EP
+# re-parses the graph from an in-memory buffer, losing the model's directory,
+# so it can't resolve model_epoch_36.onnx.data by path.
+RUN set -eux; \
+    /opt/venv/bin/python3 -c "import onnx, os; p='/app/model/model_epoch_36.onnx'; m=onnx.load(p, load_external_data=True); onnx.save(m, p, save_as_external_data=False); [os.remove(d) for d in (p+'.data', os.path.splitext(p)[0]+'.data') if os.path.exists(d)]; print('Embedded DCLAP external data; model is now self-contained')"; \
+    /opt/venv/bin/python3 -c "import onnxruntime as ort; ort.InferenceSession('/app/model/model_epoch_36.onnx', providers=['CPUExecutionProvider']); print('DCLAP model loads standalone OK')"
+
+# Pre-fetch the faster-whisper model so the image is self-contained. Verified
+# loadable on CPU here; the build host has no GPU so the GPU path runs at
+# runtime instead.
+RUN set -eux; \
+    "$VIRTUAL_ENV/bin/python3" -c "from huggingface_hub import snapshot_download; snapshot_download('Systran/faster-whisper-small', local_dir='/app/model/faster-whisper-small')"; \
+    test -f /app/model/faster-whisper-small/model.bin; \
+    "$VIRTUAL_ENV/bin/python3" -c "from faster_whisper import WhisperModel; WhisperModel('/app/model/faster-whisper-small', device='cpu', compute_type='int8'); print('faster-whisper model loads standalone OK (CPU)')"
+
+# Application code (last, for cache hits on code-only changes).
+COPY . /app
+COPY deployment/docker-entrypoint.sh /app/docker-entrypoint.sh
+COPY deployment/supervisord-rocm.conf /etc/supervisor/conf.d/supervisord.conf
+RUN chmod +x /app/docker-entrypoint.sh && \
+    test -f /etc/supervisor/conf.d/supervisord.conf
+
+EXPOSE 8000
+WORKDIR /workspace
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD []

--- a/Dockerfile-rocm
+++ b/Dockerfile-rocm
@@ -78,7 +78,8 @@ RUN set -eux; \
     cd /tmp; \
     wget -q "https://github.com/OpenNMT/CTranslate2/releases/download/v${CT2_VERSION}/rocm-python-wheels-Linux.zip"; \
     "$VIRTUAL_ENV/bin/python3" -c "import zipfile; zipfile.ZipFile('rocm-python-wheels-Linux.zip').extractall('ct2whl')"; \
-    whl="$(find ct2whl -name "ctranslate2-${CT2_VERSION}-cp312-cp312-*.whl" | head -1)"; \
+    py_ver="$("$VIRTUAL_ENV/bin/python3" -c 'import sys; print(f"cp{sys.version_info.major}{sys.version_info.minor}")')"; \
+    whl="$(find ct2whl -name "ctranslate2-${CT2_VERSION}-${py_ver}-${py_ver}-*.whl" | head -1)"; \
     test -n "$whl"; \
     uv pip install --python "$VIRTUAL_ENV/bin/python3" --no-cache "$whl"; \
     uv pip install --python "$VIRTUAL_ENV/bin/python3" --no-cache --no-deps "faster-whisper==1.2.1"; \

--- a/config.py
+++ b/config.py
@@ -424,6 +424,19 @@ LYRICS_WHISPER_MODEL_DIR = os.environ.get(
     os.path.join(os.environ.get("LYRICS_MODEL_DIR", "/app/model"), "whisper-small-onnx"),
 )
 LYRICS_MODEL_DIR = os.environ.get("LYRICS_MODEL_DIR", "/app/model")
+# Which ASR backend transcribes lyrics: "onnx" (whisper_onnx, default) or
+# "faster" (faster-whisper/CTranslate2, used on the AMD/ROCm image since
+# MIGraphX can't parse the ONNX Whisper decoder). See lyrics/_asr_backend.py.
+LYRICS_WHISPER_BACKEND = os.environ.get("LYRICS_WHISPER_BACKEND", "onnx").strip().lower()
+# faster-whisper backend settings (lyrics/whisper_faster.py). CTranslate2
+# mirrors the CUDA API on ROCm, so device="cuda" also targets an AMD GPU.
+LYRICS_WHISPER_FASTER_DEVICE = os.environ.get("LYRICS_WHISPER_FASTER_DEVICE", "cuda").strip() or "cuda"
+LYRICS_WHISPER_FASTER_COMPUTE_TYPE = os.environ.get(
+    "LYRICS_WHISPER_FASTER_COMPUTE_TYPE", "float16"
+).strip() or "float16"
+LYRICS_WHISPER_FASTER_MODEL_DIR = os.environ.get(
+    "LYRICS_WHISPER_FASTER_MODEL_DIR", "/app/model/faster-whisper-small"
+).strip()
 LYRICS_MAX_SONGS_TO_ANALYZE = 1000
 LYRICS_SUPPORTED_AUDIO_EXTENSIONS = {
     '.wav', '.mp3', '.m4a', '.flac', '.ogg', '.opus', '.aac', '.aiff', '.aif', '.mp4'

--- a/deployment/docker-compose-rocm.yaml
+++ b/deployment/docker-compose-rocm.yaml
@@ -1,0 +1,115 @@
+# AudioMuse-AI - AMD ROCm (MIGraphX) local build + test compose.
+#
+# Builds Dockerfile-rocm from the repo root and passes an AMD GPU to the worker.
+# Prereqs: ROCm 7.x kernel driver (amdgpu), host user in `render`/`video` groups.
+#
+# Usage (from repo root):
+#   docker compose -f deployment/docker-compose-rocm.yaml up --build
+#
+# See docs/GPU-AMD.md for details and verification steps.
+
+x-rocm-build: &rocm-build
+  context: ..
+  dockerfile: Dockerfile-rocm
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: audiomuse-redis
+    environment:
+      TZ: "${TZ:-UTC}"
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    volumes:
+      - redis-data:/data
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:15-alpine
+    container_name: audiomuse-postgres
+    environment:
+      TZ: "${TZ:-UTC}"
+      POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_DB: "audiomusedb"
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    restart: unless-stopped
+
+  audiomuse-ai-flask:
+    build: *rocm-build
+    image: audiomuse-ai-rocm:local
+    container_name: audiomuse-ai-flask-rocm
+    ports:
+      - "${FRONTEND_PORT:-8000}:8000"
+    environment:
+      SERVICE_TYPE: "flask"
+      TZ: "${TZ:-UTC}"
+      POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_DB: "audiomusedb"
+      POSTGRES_HOST: "postgres"
+      POSTGRES_PORT: "5432"
+      REDIS_URL: "redis://redis:6379/0"
+      TEMP_DIR: "/app/temp_audio"
+    volumes:
+      - temp-audio-flask:/app/temp_audio
+      - plugins-flask:/app/plugin/installed
+    depends_on:
+      - redis
+      - postgres
+    restart: unless-stopped
+
+  audiomuse-ai-worker:
+    build: *rocm-build
+    image: audiomuse-ai-rocm:local
+    container_name: audiomuse-ai-worker-rocm
+    environment:
+      SERVICE_TYPE: "worker"
+      TZ: "${TZ:-UTC}"
+      POSTGRES_USER: ${POSTGRES_USER:-audiomuse}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-audiomusepassword}
+      POSTGRES_DB: "audiomusedb"
+      POSTGRES_HOST: "postgres"
+      POSTGRES_PORT: "5432"
+      REDIS_URL: "redis://redis:6379/0"
+      TEMP_DIR: "/app/temp_audio"
+      # cuML has no ROCm port; GPU clustering stays CPU. ONNX analysis uses the GPU.
+      USE_GPU_CLUSTERING: "false"
+      # Uncomment to pin to a specific AMD GPU (index or UUID):
+      # HIP_VISIBLE_DEVICES: "0"
+    # --- AMD GPU passthrough ---
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    # Base image has no `render` group; pass host's numeric GIDs instead.
+    # Find yours with: getent group render video
+    group_add:
+      - "${RENDER_GID:-105}"
+      - "${VIDEO_GID:-39}"
+    security_opt:
+      - seccomp:unconfined
+    ipc: host
+    cap_add:
+      - SYS_PTRACE
+    volumes:
+      - temp-audio-worker:/app/temp_audio
+      - plugins-worker:/app/plugin/installed
+      # Persist the MIOpen kernel cache so GPU kernels are not recompiled on every
+      # restart (matches MIOPEN_CUSTOM_CACHE_DIR baked into Dockerfile-rocm).
+      - miopen-cache:/app/.cache/miopen
+    depends_on:
+      - redis
+      - postgres
+    restart: unless-stopped
+
+volumes:
+  redis-data:
+  postgres-data:
+  temp-audio-flask:
+  temp-audio-worker:
+  plugins-flask:
+  plugins-worker:
+  miopen-cache:

--- a/deployment/supervisord-rocm.conf
+++ b/deployment/supervisord-rocm.conf
@@ -1,0 +1,86 @@
+; ROCm variant of supervisord.conf: commands use /opt/venv/bin (the base
+; image's venv) instead of /usr/bin/python3, which is empty in this layout.
+[supervisord]
+nodaemon=true
+logfile=/dev/null           ; Run supervisord in the foreground
+logfile_maxbytes=0
+pidfile=/tmp/supervisord.pid
+childlogdir=/tmp
+
+[unix_http_server]
+file=/tmp/supervisor.sock
+chmod=0777
+
+[supervisorctl]
+serverurl=unix:///tmp/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[program:flask]
+command=/opt/venv/bin/gunicorn --bind 0.0.0.0:8000 --workers 1 --threads 4 --worker-class gthread --keep-alive 5 --timeout 300 --capture-output --error-logfile - --access-logfile - app:app
+autostart=false
+autorestart=true
+stopsignal=TERM
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:rq-worker-high]
+command=/opt/venv/bin/python3 -u /app/rq_worker_high_priority.py
+autostart=false
+autorestart=true
+stopsignal=TERM             ; Send SIGTERM to the process on stop
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=5
+environment=PYTHONUNBUFFERED=1
+stdout_logfile=/dev/stdout  ; Redirect stdout to container's stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr  ; Redirect stderr to container's stderr
+stderr_logfile_maxbytes=0
+
+[program:rq-worker-default]
+command=/opt/venv/bin/python3 -u /app/rq_worker.py
+autostart=false
+autorestart=true
+stopsignal=TERM             ; Send SIGTERM to the process on stop
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=5
+environment=PYTHONUNBUFFERED=1
+stdout_logfile=/dev/stdout  ; Redirect stdout to container's stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr  ; Redirect stderr to container's stderr
+stderr_logfile_maxbytes=0
+
+[program:rq-janitor]
+command=/opt/venv/bin/python3 -u /app/rq_janitor.py
+autostart=false
+autorestart=true
+stopsignal=TERM
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=5
+environment=PYTHONUNBUFFERED=1
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0
+
+[program:config-restart-listener]
+command=/opt/venv/bin/python3 /app/restart_listener.py
+autostart=true
+autorestart=true
+stopsignal=TERM
+stopasgroup=true
+killasgroup=true
+stopwaitsecs=5
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/docs/GPU-AMD.md
+++ b/docs/GPU-AMD.md
@@ -1,0 +1,113 @@
+# AMD GPU deployment (ROCm / MIGraphX)
+
+AMD GPU **EXPERIMENTAL** support for the analysis task in the worker process,
+using the ROCm MIGraphX execution provider. This can significantly speed up
+processing of tracks on AMD hardware, the same way the NVIDIA image does for
+CUDA (see [GPU.md](GPU.md) for the NVIDIA path).
+
+It ships as a **second image** built from `Dockerfile-rocm`, separate from the
+CPU / NVIDIA `Dockerfile`. Tested on a Radeon RX 9070 XT (gfx1201 / RDNA4).
+
+## What is accelerated (and what is not)
+
+Not every model can run on MIGraphX — ONNX Runtime dropped its ROCm execution
+provider, and MIGraphX (the ROCm 7.x replacement) can't parse every graph:
+
+- **musicnn** (mood/embedding CNN) runs on GPU via `MIGraphXExecutionProvider`.
+  Main win on AMD.
+- **CLAP audio analysis** (DCLAP) runs on **CPU** here. Its `Resize` op with
+  `keep_aspect_ratio_policy` isn't parseable by MIGraphX. Still GPU on CUDA.
+- **GPU clustering** (RAPIDS cuML) is **NVIDIA-only** — no ROCm port. Leave
+  `USE_GPU_CLUSTERING=false` on this image (CPU fallback is automatic).
+- **Lyrics transcription (Whisper) does run on GPU here**, but not via ONNX:
+  the decoder's dynamic `If`/KV-cache subgraphs aren't parseable by MIGraphX
+  either, so this image uses **faster-whisper/CTranslate2** instead, which has
+  a native ROCm HIP backend. Selected via `LYRICS_WHISPER_BACKEND=faster`
+  (baked into the image); falls back to CPU/int8 if GPU load fails. NVIDIA/CPU
+  images keep the default ONNX Whisper backend.
+
+## Requirements
+
+- AMD GPU supported by ROCm 7.x. RDNA4 (gfx1201, e.g. RX 9070 XT) is natively
+  supported — no `HSA_OVERRIDE_GFX_VERSION` needed. Older/unsupported cards may
+  need that override; see AMD's ROCm compatibility matrix.
+- ROCm-capable kernel driver (`amdgpu`) on the host.
+- ~8 GB VRAM recommended (same guidance as the NVIDIA image; on less you may hit
+  the non-blocking OutOfMemory path that falls back to CPU).
+- Docker with `/dev/kfd` and `/dev/dri` available on the host.
+
+## Quick start
+
+From the repository root:
+
+```bash
+docker compose -f deployment/docker-compose-rocm.yaml up --build
+```
+
+This builds `Dockerfile-rocm` locally and starts Redis, PostgreSQL, the Flask
+app, and a GPU-enabled worker.
+
+### GPU device permissions (important)
+
+The compose file mounts `/dev/kfd` and `/dev/dri` and adds the host's
+device-owning groups by **numeric GID** (the base image has no `render`
+group by name). Find your host's GIDs:
+
+```bash
+getent group render video
+```
+
+`render` owns `/dev/kfd` + `/dev/dri/renderD*` (compute, the one that
+matters); `video` owns `/dev/dri/card*` (display).
+
+Compose defaults to `RENDER_GID=105` and `VIDEO_GID=39`. If yours differ, set
+them (e.g. in `deployment/.env` or the shell):
+
+```bash
+RENDER_GID=$(getent group render | cut -d: -f3) \
+VIDEO_GID=$(getent group video | cut -d: -f3) \
+docker compose -f deployment/docker-compose-rocm.yaml up --build
+```
+
+## Verify the GPU is used
+
+```bash
+# GPU visible inside the worker
+docker exec audiomuse-ai-worker-rocm rocminfo | grep -i gfx
+
+# MIGraphX provider available to ONNX Runtime
+docker exec audiomuse-ai-worker-rocm /opt/venv/bin/python3 \
+  -c "import onnxruntime as o; print(o.get_available_providers())"
+# -> ['MIGraphXExecutionProvider', 'CPUExecutionProvider']
+```
+
+When an analysis run starts, the worker logs `ONNX provider chain: ['MIGraphXExecutionProvider', ...]`.
+The first inference compiles the models for MIGraphX (a one-off delay); the
+MIOpen kernel cache is persisted to a Docker volume so restarts skip recompiles.
+
+## Environment (baked into the image)
+
+`Dockerfile-rocm` sets these so you do not have to:
+
+- `HSA_ENABLE_INTERRUPT=1` — interrupt-driven GPU completion instead of CPU
+  busy-polling, keeping worker CPU free.
+- `MIOPEN_USER_DB_PATH` / `MIOPEN_CUSTOM_CACHE_DIR=/app/.cache/miopen` — kernel
+  compile cache dir, mounted as a volume by compose to persist across restarts.
+- `LYRICS_WHISPER_BACKEND=faster` — routes lyrics ASR to faster-whisper/
+  CTranslate2 (GPU). Override to `onnx` to force CPU. Also tunable:
+  `LYRICS_WHISPER_FASTER_DEVICE` (default `cuda`), `LYRICS_WHISPER_FASTER_COMPUTE_TYPE`
+  (default `float16`), `LYRICS_WHISPER_FASTER_MODEL_DIR`
+  (default `/app/model/faster-whisper-small`).
+
+To pin to a specific GPU on a multi-GPU host, set `HIP_VISIBLE_DEVICES` on the
+worker service (commented example in the compose file).
+
+## Notes
+
+- ONNX Runtime with the MIGraphX provider is supplied by the
+  `rocm/onnxruntime` base image itself; the image does not re-install onnxruntime
+  (doing so would replace the GPU build with a CPU-only one).
+- ML models and the HuggingFace cache are copied from the published CPU image
+  (`ghcr.io/neptunehub/audiomuse-ai:latest`) at build time.
+- To move ROCm versions, bump `BASE_IMAGE` in `Dockerfile-rocm` to a tag from
+  <https://hub.docker.com/r/rocm/onnxruntime>.

--- a/docs/GPU-AMD.md
+++ b/docs/GPU-AMD.md
@@ -10,14 +10,14 @@ CPU / NVIDIA `Dockerfile`. Tested on a Radeon RX 9070 XT (gfx1201 / RDNA4).
 
 ## What is accelerated (and what is not)
 
-Not every model can run on MIGraphX — ONNX Runtime dropped its ROCm execution
+Not every model can run on MIGraphX -- ONNX Runtime dropped its ROCm execution
 provider, and MIGraphX (the ROCm 7.x replacement) can't parse every graph:
 
 - **musicnn** (mood/embedding CNN) runs on GPU via `MIGraphXExecutionProvider`.
   Main win on AMD.
 - **CLAP audio analysis** (DCLAP) runs on **CPU** here. Its `Resize` op with
   `keep_aspect_ratio_policy` isn't parseable by MIGraphX. Still GPU on CUDA.
-- **GPU clustering** (RAPIDS cuML) is **NVIDIA-only** — no ROCm port. Leave
+- **GPU clustering** (RAPIDS cuML) is **NVIDIA-only** -- no ROCm port. Leave
   `USE_GPU_CLUSTERING=false` on this image (CPU fallback is automatic).
 - **Lyrics transcription (Whisper) does run on GPU here**, but not via ONNX:
   the decoder's dynamic `If`/KV-cache subgraphs aren't parseable by MIGraphX
@@ -29,7 +29,7 @@ provider, and MIGraphX (the ROCm 7.x replacement) can't parse every graph:
 ## Requirements
 
 - AMD GPU supported by ROCm 7.x. RDNA4 (gfx1201, e.g. RX 9070 XT) is natively
-  supported — no `HSA_OVERRIDE_GFX_VERSION` needed. Older/unsupported cards may
+  supported -- no `HSA_OVERRIDE_GFX_VERSION` needed. Older/unsupported cards may
   need that override; see AMD's ROCm compatibility matrix.
 - ROCm-capable kernel driver (`amdgpu`) on the host.
 - ~8 GB VRAM recommended (same guidance as the NVIDIA image; on less you may hit
@@ -89,11 +89,11 @@ MIOpen kernel cache is persisted to a Docker volume so restarts skip recompiles.
 
 `Dockerfile-rocm` sets these so you do not have to:
 
-- `HSA_ENABLE_INTERRUPT=1` — interrupt-driven GPU completion instead of CPU
+- `HSA_ENABLE_INTERRUPT=1` -- interrupt-driven GPU completion instead of CPU
   busy-polling, keeping worker CPU free.
-- `MIOPEN_USER_DB_PATH` / `MIOPEN_CUSTOM_CACHE_DIR=/app/.cache/miopen` — kernel
+- `MIOPEN_USER_DB_PATH` / `MIOPEN_CUSTOM_CACHE_DIR=/app/.cache/miopen` -- kernel
   compile cache dir, mounted as a volume by compose to persist across restarts.
-- `LYRICS_WHISPER_BACKEND=faster` — routes lyrics ASR to faster-whisper/
+- `LYRICS_WHISPER_BACKEND=faster` -- routes lyrics ASR to faster-whisper/
   CTranslate2 (GPU). Override to `onnx` to force CPU. Also tunable:
   `LYRICS_WHISPER_FASTER_DEVICE` (default `cuda`), `LYRICS_WHISPER_FASTER_COMPUTE_TYPE`
   (default `float16`), `LYRICS_WHISPER_FASTER_MODEL_DIR`

--- a/lyrics/__init__.py
+++ b/lyrics/__init__.py
@@ -82,10 +82,13 @@ def is_lyrics_loaded() -> bool:
     if not _LYRICS_ENABLED:
         return False
     try:
-        from . import whisper_onnx, gte_onnx, silero_onnx
+        from ._asr_backend import get_asr_backend
+        from . import gte_onnx, silero_onnx
+
+        whisper_mod = get_asr_backend()
     except Exception:
         return False
-    for mod in (whisper_onnx, gte_onnx, silero_onnx):
+    for mod in (whisper_mod, gte_onnx, silero_onnx):
         try:
             if mod.is_loaded():
                 return True
@@ -100,12 +103,13 @@ def unload_lyrics_models() -> bool:
     released_any = False
     try:
         try:
-            from . import whisper_onnx
+            from ._asr_backend import get_asr_backend
 
-            if whisper_onnx.is_loaded():
-                released_any = bool(_safe_call('whisper_onnx.unload', whisper_onnx.unload))
+            whisper_mod = get_asr_backend()
+            if whisper_mod.is_loaded():
+                released_any = bool(_safe_call('whisper.unload', whisper_mod.unload))
         except Exception as exc:
-            _logger.warning("Lyrics whisper_onnx release failed: %s", exc)
+            _logger.warning("Lyrics whisper release failed: %s", exc)
 
         try:
             from . import gte_onnx

--- a/lyrics/_asr_backend.py
+++ b/lyrics/_asr_backend.py
@@ -1,0 +1,31 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""Selects the Whisper ASR backend for the lyrics pipeline.
+
+Default is onnx (whisper_onnx). LYRICS_WHISPER_BACKEND=faster switches to
+faster-whisper/CTranslate2, used on the AMD/ROCm image since MIGraphX can't
+run the ONNX Whisper decoder. Both modules share the same public surface.
+"""
+
+from __future__ import annotations
+
+import os
+
+_FASTER = {"faster", "faster-whisper", "faster_whisper", "ct2", "ctranslate2"}
+
+
+def get_asr_backend():
+    choice = os.environ.get("LYRICS_WHISPER_BACKEND", "onnx").strip().lower()
+    if choice in _FASTER:
+        from . import whisper_faster
+
+        return whisper_faster
+    from . import whisper_onnx
+
+    return whisper_onnx

--- a/lyrics/_asr_backend.py
+++ b/lyrics/_asr_backend.py
@@ -15,14 +15,13 @@ run the ONNX Whisper decoder. Both modules share the same public surface.
 
 from __future__ import annotations
 
-import os
+from config import LYRICS_WHISPER_BACKEND
 
 _FASTER = {"faster", "faster-whisper", "faster_whisper", "ct2", "ctranslate2"}
 
 
 def get_asr_backend():
-    choice = os.environ.get("LYRICS_WHISPER_BACKEND", "onnx").strip().lower()
-    if choice in _FASTER:
+    if LYRICS_WHISPER_BACKEND in _FASTER:
         from . import whisper_faster
 
         return whisper_faster

--- a/lyrics/lyrics_transcriber.py
+++ b/lyrics/lyrics_transcriber.py
@@ -218,9 +218,9 @@ _axis_embeddings: Optional[Dict] = None
 def load_asr_model(num_threads: Optional[int] = None):
     threads = num_threads or get_lyrics_threads()
     _apply_thread_env(threads)
-    from .whisper_onnx import load_whisper_model as _load
+    from ._asr_backend import get_asr_backend
 
-    return _load()
+    return get_asr_backend().load_whisper_model()
 
 
 def load_topic_embedding_model(model_name: Optional[str] = None):
@@ -704,9 +704,9 @@ def _transcribe(
 ) -> Dict[str, object]:
     if audio is None or len(audio) == 0:
         return {'text': '', 'language': language or '', 'duration': 0.0}
-    from .whisper_onnx import transcribe as _whisper_transcribe
+    from ._asr_backend import get_asr_backend
 
-    return _whisper_transcribe(audio, sr, language=language)
+    return get_asr_backend().transcribe(audio, sr, language=language)
 
 
 def _embed_text(text: str, tokenizer, model) -> Optional[np.ndarray]:

--- a/lyrics/whisper_faster.py
+++ b/lyrics/whisper_faster.py
@@ -1,0 +1,176 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""faster-whisper (CTranslate2) backend for lyrics ASR.
+
+Drop-in alternative to whisper_onnx, used on the AMD/ROCm image since MIGraphX
+can't parse the Whisper decoder's dynamic If/KV-cache subgraphs. CTranslate2
+has a native ROCm HIP backend instead. Selected via LYRICS_WHISPER_BACKEND=faster
+(lyrics/_asr_backend.py); mirrors whisper_onnx's public surface.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import Dict, Optional
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+SAMPLE_RATE = 16000
+
+# CTranslate2 mirrors the CUDA API on ROCm, so "cuda" targets the AMD GPU here.
+_DEVICE = os.environ.get("LYRICS_WHISPER_FASTER_DEVICE", "cuda").strip() or "cuda"
+_COMPUTE_TYPE = os.environ.get("LYRICS_WHISPER_FASTER_COMPUTE_TYPE", "float16").strip() or "float16"
+_MODEL_DIR = os.environ.get(
+    "LYRICS_WHISPER_FASTER_MODEL_DIR", "/app/model/faster-whisper-small"
+).strip()
+_BEAM_SIZE = int(os.environ.get("LYRICS_WHISPER_BEAM_SIZE", "5"))
+
+_model = None
+_model_dir: Optional[str] = None
+_load_lock = threading.Lock()
+
+
+class WhisperLoadRefused(RuntimeError):
+    """Raised when the model cannot be loaded; transcribe() degrades to empty."""
+
+
+def load_whisper_model():
+    global _model, _model_dir
+    if _model is not None and _model_dir == _MODEL_DIR:
+        return _model
+    with _load_lock:
+        if _model is not None and _model_dir == _MODEL_DIR:
+            return _model
+        try:
+            from faster_whisper import WhisperModel
+        except Exception as exc:  # library missing on non-ROCm images
+            raise WhisperLoadRefused(f"faster_whisper import failed: {exc}") from exc
+
+        model_src = _MODEL_DIR if os.path.isdir(_MODEL_DIR) else "small"
+        device = _DEVICE
+        compute_type = _COMPUTE_TYPE
+        try:
+            _model = WhisperModel(model_src, device=device, compute_type=compute_type)
+        except Exception as exc:
+            # Fall back to CPU/int8 rather than failing the whole lyrics run.
+            logger.warning(
+                "faster-whisper GPU load failed (device=%s, compute=%s): %s - "
+                "falling back to CPU/int8",
+                device,
+                compute_type,
+                exc,
+            )
+            try:
+                _model = WhisperModel(model_src, device="cpu", compute_type="int8")
+            except Exception as exc2:
+                raise WhisperLoadRefused(
+                    f"faster_whisper load failed on GPU and CPU: {exc2}"
+                ) from exc2
+        _model_dir = _MODEL_DIR
+        logger.info(
+            "faster-whisper loaded (src=%s, device=%s, compute=%s)",
+            model_src,
+            device,
+            compute_type,
+        )
+        return _model
+
+
+def transcribe(
+    wav: np.ndarray, sr: int, language: Optional[str] = None
+) -> Dict[str, object]:
+    if sr != SAMPLE_RATE:
+        import librosa
+
+        wav = librosa.resample(wav.astype(np.float32), orig_sr=sr, target_sr=SAMPLE_RATE)
+        sr = SAMPLE_RATE
+    audio = np.ascontiguousarray(wav, dtype=np.float32)
+    duration = len(audio) / SAMPLE_RATE
+
+    try:
+        model = load_whisper_model()
+    except WhisperLoadRefused as exc:
+        logger.warning("faster-whisper load refused: %s", exc)
+        return {"text": "", "language": "", "duration": duration, "avg_logprob": float("-inf")}
+
+    # language=None lets faster-whisper auto-detect; we do our own VAD upstream
+    # (silero_onnx), so leave faster-whisper's vad_filter off.
+    segments, info = model.transcribe(
+        audio,
+        language=language or None,
+        beam_size=_BEAM_SIZE,
+        vad_filter=False,
+    )
+
+    texts = []
+    logprobs = []
+    for seg in segments:  # generator - consuming it runs the decode
+        t = (seg.text or "").strip()
+        if t:
+            texts.append(t)
+        lp = getattr(seg, "avg_logprob", None)
+        if lp is not None:
+            logprobs.append(float(lp))
+
+    full_text = " ".join(texts).strip()
+    detected = getattr(info, "language", "") or ""
+    avg_logprob = float(np.mean(logprobs)) if logprobs else float("-inf")
+    info_dur = getattr(info, "duration", None)
+    logger.info(
+        "faster-whisper: %.1fs audio (lang=%r, beam=%d, avg_logprob=%.2f)",
+        info_dur if info_dur else duration,
+        detected,
+        _BEAM_SIZE,
+        avg_logprob,
+    )
+    return {
+        "text": full_text,
+        "language": detected,
+        "duration": float(info_dur) if info_dur else duration,
+        "avg_logprob": avg_logprob,
+    }
+
+
+def is_loaded() -> bool:
+    return _model is not None
+
+
+def unload() -> bool:
+    global _model, _model_dir
+    if _model is None and _model_dir is None:
+        return False
+    model = _model
+    _model = None
+    _model_dir = None
+    try:
+        del model
+    except Exception:
+        logger.exception("Error dropping faster-whisper model")
+    try:
+        import gc
+
+        gc.collect()
+    except Exception:
+        logger.exception("Error during faster-whisper GC")
+    try:
+        from tasks.memory_utils import comprehensive_memory_cleanup
+
+        comprehensive_memory_cleanup(force_cuda=False, reset_onnx_pool=False)
+    except Exception:
+        logger.exception("Error during memory cleanup on faster-whisper unload")
+    logger.info("faster-whisper: model unloaded")
+    return True
+
+
+def reset_session() -> None:
+    unload()

--- a/lyrics/whisper_faster.py
+++ b/lyrics/whisper_faster.py
@@ -23,17 +23,14 @@ from typing import Dict, Optional
 
 import numpy as np
 
+from config import LYRICS_ASR_BEAM_SIZE as _BEAM_SIZE
+from config import LYRICS_WHISPER_FASTER_COMPUTE_TYPE as _COMPUTE_TYPE
+from config import LYRICS_WHISPER_FASTER_DEVICE as _DEVICE
+from config import LYRICS_WHISPER_FASTER_MODEL_DIR as _MODEL_DIR
+
 logger = logging.getLogger(__name__)
 
 SAMPLE_RATE = 16000
-
-# CTranslate2 mirrors the CUDA API on ROCm, so "cuda" targets the AMD GPU here.
-_DEVICE = os.environ.get("LYRICS_WHISPER_FASTER_DEVICE", "cuda").strip() or "cuda"
-_COMPUTE_TYPE = os.environ.get("LYRICS_WHISPER_FASTER_COMPUTE_TYPE", "float16").strip() or "float16"
-_MODEL_DIR = os.environ.get(
-    "LYRICS_WHISPER_FASTER_MODEL_DIR", "/app/model/faster-whisper-small"
-).strip()
-_BEAM_SIZE = int(os.environ.get("LYRICS_WHISPER_BEAM_SIZE", "5"))
 
 _model = None
 _model_dir: Optional[str] = None

--- a/lyrics/whisper_faster.py
+++ b/lyrics/whisper_faster.py
@@ -111,13 +111,21 @@ def transcribe(
 
     texts = []
     logprobs = []
-    for seg in segments:  # generator - consuming it runs the decode
-        t = (seg.text or "").strip()
-        if t:
-            texts.append(t)
-        lp = getattr(seg, "avg_logprob", None)
-        if lp is not None:
-            logprobs.append(float(lp))
+    try:
+        for seg in segments:  # generator - consuming it runs the decode
+            t = (seg.text or "").strip()
+            if t:
+                texts.append(t)
+            lp = getattr(seg, "avg_logprob", None)
+            if lp is not None:
+                logprobs.append(float(lp))
+    except Exception:
+        # Decode runs lazily inside the generator; a mid-stream failure (GPU OOM,
+        # CTranslate2 error) keeps whatever segments already decoded.
+        logger.exception(
+            "faster-whisper decode failed after %d segment(s) - returning partial text",
+            len(texts),
+        )
 
     full_text = " ".join(texts).strip()
     detected = getattr(info, "language", "") or ""

--- a/lyrics/whisper_onnx.py
+++ b/lyrics/whisper_onnx.py
@@ -266,11 +266,17 @@ class _OnnxWhisperPipeline:
         try:
             from tasks.analysis_helper import create_onnx_session
 
+            # MIGraphX can't parse the decoder's dynamic If/KV-cache subgraphs.
+            # Only matters if LYRICS_WHISPER_BACKEND=onnx is forced on ROCm
+            # (default there is faster-whisper, which does use the GPU);
+            # this keeps that override on CPU instead of failing. CUDA unaffected.
             self.encoder_session = create_onnx_session(
-                str(encoder_path), sess_options=sess_opts, label='whisper_encoder'
+                str(encoder_path), sess_options=sess_opts, label='whisper_encoder',
+                allow_migraphx=False,
             )
             self.decoder_session = create_onnx_session(
-                str(decoder_path), sess_options=sess_opts, label='whisper_decoder'
+                str(decoder_path), sess_options=sess_opts, label='whisper_decoder',
+                allow_migraphx=False,
             )
         except Exception as exc:
             logger.warning('Whisper: provider helper unavailable (%s) - CPU only', exc)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
   - Deployment: DEPLOYMENT.md
   - FAQ: FAQ.md
   - GPU: GPU.md
+  - GPU (AMD/ROCm): GPU-AMD.md
   - Parameters: PARAMETERS.md
   - Authentication: AUTH.md
 

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,0 +1,9 @@
+# ROCm (AMD GPU) extra requirements, installed alongside common.txt by
+# Dockerfile-rocm. Deliberately empty of ONNX/GPU wheels:
+#
+#   * onnxruntime -> supplied by the rocm/onnxruntime base image. Adding it
+#                    here would clobber the MIGraphX build with a CPU-only one.
+#   * cupy / cuml -> RAPIDS cuML has no ROCm port; GPU clustering stays CPU.
+#   * faster-whisper / ctranslate2 -> installed by hand in Dockerfile-rocm
+#                    (ROCm wheel is a GitHub release asset, not on PyPI).
+tqdm

--- a/tasks/analysis_helper.py
+++ b/tasks/analysis_helper.py
@@ -90,7 +90,7 @@ def sigmoid(x):
     return 1 / (1 + np.exp(-x))
 
 
-def resolve_providers(allow_coreml=False, role=None, cuda_options=None):
+def resolve_providers(allow_coreml=False, role=None, cuda_options=None, allow_migraphx=True):
     available = ort.get_available_providers()
     chain = []
     accel_ok = role != 'flask'
@@ -108,6 +108,12 @@ def resolve_providers(allow_coreml=False, role=None, cuda_options=None):
                 },
             )
         )
+
+    # MIGraphX: ROCm's GPU provider (ORT dropped its ROCm EP). Only present on
+    # the ROCm image, so it never competes with CUDA above. allow_migraphx=False
+    # opts a model out (e.g. graphs MIGraphX can't parse) without affecting CUDA.
+    if accel_ok and allow_migraphx and 'MIGraphXExecutionProvider' in available:
+        chain.append(('MIGraphXExecutionProvider', {'device_id': 0}))
 
     if accel_ok and allow_coreml and 'CoreMLExecutionProvider' in available:
         chain.append(
@@ -189,9 +195,12 @@ def _default_sess_options():
 
 
 def create_onnx_session(
-    model_path, provider_options=None, label="", sess_options=None, allow_coreml=False
+    model_path, provider_options=None, label="", sess_options=None, allow_coreml=False,
+    allow_migraphx=True,
 ):
-    opts = provider_options or resolve_providers(allow_coreml=allow_coreml)
+    opts = provider_options or resolve_providers(
+        allow_coreml=allow_coreml, allow_migraphx=allow_migraphx
+    )
     if sess_options is None:
         sess_options = _default_sess_options()
     extra = {'sess_options': sess_options}

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -108,8 +108,11 @@ def _load_audio_model():
 
     from tasks.analysis_helper import resolve_providers
 
+    # DCLAP's Resize op (keep_aspect_ratio_policy) isn't parseable by MIGraphX,
+    # so this model runs on CPU on ROCm; CUDA is unaffected.
     provider_options = resolve_providers(
         allow_coreml=True,
+        allow_migraphx=False,
         cuda_options={
             'device_id': 0,
             'arena_extend_strategy': 'kSameAsRequested',
@@ -213,6 +216,12 @@ def _load_text_model():
         logger.info(
             f"CUDA provider available - will attempt to use GPU (device_id={gpu_device_id})"
         )
+    elif 'MIGraphXExecutionProvider' in available_providers:
+        provider_options = [
+            ('MIGraphXExecutionProvider', {'device_id': 0}),
+            ('CPUExecutionProvider', {}),
+        ]
+        logger.info("MIGraphX provider available - will attempt to use GPU (AMD ROCm)")
     else:
         provider_options = [('CPUExecutionProvider', {})]
         logger.info("CUDA provider not available - using CPU only")

--- a/tasks/memory_utils.py
+++ b/tasks/memory_utils.py
@@ -94,6 +94,9 @@ def reset_onnx_memory_pool() -> bool:
         if 'CUDAExecutionProvider' in providers:
             preferred_provider = 'CUDAExecutionProvider'
             logger.debug("Using CUDA provider for ONNX memory pool reset")
+        elif 'MIGraphXExecutionProvider' in providers:
+            preferred_provider = 'MIGraphXExecutionProvider'
+            logger.debug("Using MIGraphX provider for ONNX memory pool reset (AMD ROCm)")
         elif 'CPUExecutionProvider' in providers:
             preferred_provider = 'CPUExecutionProvider'
             logger.debug("Using CPU provider for ONNX memory pool reset")


### PR DESCRIPTION
## AS-IS
AMD GPUs fall back to CPU acceleration for inference

## TO-BE
Not everything is GPU-accelerated on AMD:
  - musicnn — GPU (MIGraphX)
  - CLAP audio (DCLAP) — CPU only; its Resize op with keep_aspect_ratio_policy isn't parseable by MIGraphX as far as I can tell
  - Whisper — GPU, but via faster-whisper/CTranslate2 instead of ONNX, since MIGraphX can't parse the decoder's dynamic If/KV-cache subgraphs => hopefully this change isn't too invasive
  - Clustering (RAPIDS cuML) — CPU only, no ROCm port exists => only things I found for cuML on AMD were experimental and need building ourselves

Essentially, this means some acceleration is achieved, but there's unfortunately still some CPU bottlenecks. I'm not sure they're solveable this point in time. 

## Test
I ran the deployment YAML I added locally to start a worker. The image builds, the worker is relatively fast on my RX 9070 XT and I confirmed via rocm-smi that it's absolutely using the GPU. 

Definitely need some people to test this on different architectures.

## Other useful information
I only have the RNDA4 card atm and I'm building with the latest ROCm version. I cannot test older hardware or use an older ROCm base version. So there's a chance this PR isn't good enough to be accepted. 

I'm also unsure about building the image. I'm fairly certain building via GitHub CI will fail due to the sheer size of the image. I wasn't able to figure out how you currently build and push your images.

## Checklist
<!-- Not all items are mandatory - just check the ones that apply to your case. -->

**Type of change:**
- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Breaking change

**Tested on architecture:**
- [ ] Intel
- [ ] ARM
- [ ] -noavx2
- [ ] NVIDIA image
- [x] ROCm image :smile:  

**Tested on media server:**
- [x] Navidrome
- [ ] Jellyfin
- [ ] Emby
- [ ] Lyrion

**Updated:**
- [x] Documentation
- [ ] Unit test
- [ ] Integration test

**Other:**
- [x] CONTRIBUTING.md read and accepted
- [ ] Checked performance on a big library (> 150k songs) works without issues => it works pretty much the same as before, I'm not sure what I could've tested different, so I'm leaving this one unchecked.

**Related ISSUE:** Closes #xx
