### PR TITLE
GPU OOM Improvement

### DIFF
--- a/config.py
+++ b/config.py
@@ -185,7 +185,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 }
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v3.0.1"
+APP_VERSION = "v3.0.2"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -244,11 +244,13 @@ def cleanup_musicnn_sessions(onnx_sessions, context=""):
         return
     suffix = f" ({context})" if context else ""
     logger.info(f"Cleaning up {len(onnx_sessions)} MusiCNN model sessions{suffix}")
-    for name, session in onnx_sessions.items():
+    for name in list(onnx_sessions.keys()):
+        session = onnx_sessions.pop(name, None)
         try:
             cleanup_onnx_session(session, name)
         except Exception as e:
             logger.warning(f"Error cleaning up {name} session: {e}")
+        session = None
     gc.collect()
 
 

--- a/test/unit/test_memory_cleanup.py
+++ b/test/unit/test_memory_cleanup.py
@@ -31,6 +31,57 @@ import pytest
 import numpy as np
 
 
+class _FakeSession:
+    pass
+
+
+class TestMusicnnSessionRecycleFreesGpuBeforeAlloc:
+    def test_cleanup_musicnn_sessions_empties_dict_and_drops_every_reference(self):
+        import gc
+        import weakref
+        from tasks.analysis.song import cleanup_musicnn_sessions
+
+        sessions = {'embedding': _FakeSession(), 'prediction': _FakeSession()}
+        refs = [weakref.ref(s) for s in sessions.values()]
+
+        cleanup_musicnn_sessions(sessions, context="recycle")
+        gc.collect()
+
+        assert sessions == {}
+        assert all(r() is None for r in refs)
+
+    def test_ensure_musicnn_sessions_releases_old_gpu_sessions_before_loading_new(self):
+        import gc
+        import weakref
+        from tasks.analysis import song
+        from tasks.memory_utils import SessionRecycler
+
+        old_sessions = {'embedding': _FakeSession(), 'prediction': _FakeSession()}
+        old_ref = weakref.ref(old_sessions['embedding'])
+        observed = {}
+
+        def fake_load(model_paths):
+            gc.collect()
+            observed['old_alive_when_new_allocated'] = old_ref() is not None
+            return {'embedding': _FakeSession(), 'prediction': _FakeSession()}
+
+        recycler = SessionRecycler(recycle_interval=1)
+        recycler.increment()
+
+        with patch.object(song, 'load_musicnn_sessions', side_effect=fake_load), \
+                patch.object(song, 'comprehensive_memory_cleanup', return_value={}):
+            new_sessions = song.ensure_musicnn_sessions(
+                old_sessions,
+                {'embedding': 'e.onnx', 'prediction': 'p.onnx'},
+                recycler,
+                "Album",
+            )
+
+        assert observed['old_alive_when_new_allocated'] is False
+        assert new_sessions is not old_sessions
+        assert old_ref() is None
+
+
 class TestAnalyzeTrackMemoryCleanup:
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     @patch('tasks.analysis.song.librosa')


### PR DESCRIPTION
This PR should improve the use of GPU VRAM, by:

- Improving the release of memory between one album and another.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29677936279/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29645820430/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29645820430/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29645820430/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29645820430/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29677936303/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-769`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-769-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-769-noavx2`
<!-- pr-test-build:end -->