### PR TITLE
Memory Cleaning Hardening

### DIFF
--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -248,8 +248,8 @@ def cleanup_musicnn_sessions(onnx_sessions, context=""):
         session = onnx_sessions.pop(name, None)
         try:
             cleanup_onnx_session(session, name)
-        except Exception as e:
-            logger.warning(f"Error cleaning up {name} session: {e}")
+        except Exception:
+            logger.exception(f"Error cleaning up {name} session")
         session = None
     gc.collect()
 
@@ -411,7 +411,7 @@ def _patches_for_track(audio, sr, name):
 
 
 def _sessions_for_track(onnx_sessions, model_paths):
-    if onnx_sessions is not None:
+    if onnx_sessions:
         return onnx_sessions['embedding'], onnx_sessions['prediction'], False
     provider_options = resolve_providers()
     embedding_sess = create_onnx_session(
@@ -439,7 +439,7 @@ def _run_musicnn_models(final_patches, mood_labels_list, model_paths, onnx_sessi
             'embedding',
             name,
         )
-        if new_embedding_sess is not embedding_sess and onnx_sessions is not None:
+        if new_embedding_sess is not embedding_sess and onnx_sessions:
             onnx_sessions['embedding'] = new_embedding_sess
         embedding_sess = new_embedding_sess
 
@@ -451,7 +451,7 @@ def _run_musicnn_models(final_patches, mood_labels_list, model_paths, onnx_sessi
             'prediction',
             name,
         )
-        if new_prediction_sess is not prediction_sess and onnx_sessions is not None:
+        if new_prediction_sess is not prediction_sess and onnx_sessions:
             onnx_sessions['prediction'] = new_prediction_sess
         prediction_sess = new_prediction_sess
 

--- a/test/unit/test_memory_cleanup.py
+++ b/test/unit/test_memory_cleanup.py
@@ -16,9 +16,12 @@ Main Features:
 * Externally supplied album sessions are not cleaned up by the callee
 * analyze_album_task runs comprehensive cleanup and CLAP unload in finally
 * Database failure re-raises while still tearing down loaded models
+* Session recycle empties the old dict and frees old GPU sessions before allocating new ones
 """
 
+import gc
 import sys
+import weakref
 from unittest.mock import MagicMock, patch
 
 if "jwt" not in sys.modules:
@@ -37,8 +40,6 @@ class _FakeSession:
 
 class TestMusicnnSessionRecycleFreesGpuBeforeAlloc:
     def test_cleanup_musicnn_sessions_empties_dict_and_drops_every_reference(self):
-        import gc
-        import weakref
         from tasks.analysis.song import cleanup_musicnn_sessions
 
         sessions = {'embedding': _FakeSession(), 'prediction': _FakeSession()}
@@ -51,8 +52,6 @@ class TestMusicnnSessionRecycleFreesGpuBeforeAlloc:
         assert all(r() is None for r in refs)
 
     def test_ensure_musicnn_sessions_releases_old_gpu_sessions_before_loading_new(self):
-        import gc
-        import weakref
         from tasks.analysis import song
         from tasks.memory_utils import SessionRecycler
 


### PR DESCRIPTION
This PR is an hardening for the memory cleaning to avoid this edge case:

cleanup_musicnn_sessions now empties the dict (it pops every entry to free GPU memory). So after a recycle, the object is no longer None it's {}, **an empty-but-not-None dict**. 
If that emptied dict flows back into analyze_track, the old guard if onnx_sessions is not None: sees "not None -> use it" and runs onnx_sessions['embedding'], which crashes with KeyError because the key was popped. 
Switching to if onnx_sessions: treats an empty dict as falsy, so it skips reuse and lazy-loads fresh sessions instead. None still behaves identically (falsy). It fixes the crash without losing anything.
