### PR TITLE
Chunk MusiCNN embedding inference to keep peak memory flat

### DIFF
--- a/config.py
+++ b/config.py
@@ -622,6 +622,13 @@ CLAP_PYTHON_MULTITHREADS = os.environ.get("CLAP_PYTHON_MULTITHREADS", "False").l
 #   Cons: May see gradual VRAM growth on some systems
 PER_SONG_MODEL_RELOAD = os.environ.get("PER_SONG_MODEL_RELOAD", "true").lower() == "true"
 
+# Maximum number of spectrogram patches sent through the MusiCNN embedding
+# model in a single ONNX inference call. Running a whole track as one batch
+# (the previous behavior) makes the convolution activations peak at several
+# GB of RAM/VRAM on long tracks; small batches keep peak memory flat with no
+# measurable speed cost. Set to 0 to disable chunking (one whole-track batch).
+MUSICNN_BATCH_SIZE = int(os.environ.get("MUSICNN_BATCH_SIZE", 8))
+
 # Category weights for CLAP query generation (affects random query sampling probabilities)
 # Higher weights favor categories where CLAP excels (Genre, Instrumentation)
 # Format: JSON string with category names as keys and float weights as values

--- a/docs/PARAMETERS.md
+++ b/docs/PARAMETERS.md
@@ -75,6 +75,7 @@ These are the default parameters used when launching analysis or clustering task
 | `CLAP_ENABLED`                              | If false disable CLAP model during the analysis and the use of Text Search functionality.                                  | `true` |
 | `CLAP_PYTHON_MULTITHREADS`                  | CPU threading for CLAP analysis. False (default) = Use ONNX internal threading (recommended). True = Use Python ThreadPoolExecutor  | `false`         |
 | `PER_SONG_MODEL_RELOAD`                     | Model reloading strategy. true (default) = Unload MusiCNN and CLAP after each song (stable VRAM, slower). false = MusiCNN reloads every 20 songs, CLAP at album end (faster but may accumulate VRAM) | `true`          |
+| `MUSICNN_BATCH_SIZE`                        | Max spectrogram patches per MusiCNN embedding inference call. Small batches keep peak RAM/VRAM flat on long tracks. 0 = whole track in one batch (previous behavior) | `8`             |
 | **Analysis General**                        |                                                                                                                            |                 |
 | `NUM_RECENT_ALBUMS`                         | Number of recent albums to scan (0 for all).                                                                              | `0`             |
 | `TOP_N_MOODS`                               | Number of top moods per track for feature vector.                                                                         | `5`             |

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -36,6 +36,7 @@ import onnxruntime as ort
 
 from config import (
     AUDIO_LOAD_TIMEOUT,
+    MUSICNN_BATCH_SIZE,
     OTHER_FEATURE_LABELS,
     PER_SONG_MODEL_RELOAD,
 )
@@ -431,17 +432,24 @@ def _run_musicnn_models(final_patches, mood_labels_list, model_paths, onnx_sessi
             onnx_sessions, model_paths
         )
 
-        embeddings_per_patch, new_embedding_sess = run_inference_with_oom_fallback(
-            embedding_sess,
-            {DEFINED_TENSOR_NAMES['embedding']['input']: final_patches},
-            DEFINED_TENSOR_NAMES['embedding']['output'],
-            model_paths['embedding'],
-            'embedding',
-            name,
-        )
-        if new_embedding_sess is not embedding_sess and onnx_sessions:
-            onnx_sessions['embedding'] = new_embedding_sess
-        embedding_sess = new_embedding_sess
+        # Chunked so peak memory stays flat: a whole-track batch needs several
+        # GB of convolution activations, well past small worker memory caps.
+        batch = MUSICNN_BATCH_SIZE if MUSICNN_BATCH_SIZE > 0 else len(final_patches)
+        embedding_chunks = []
+        for start in range(0, len(final_patches), batch):
+            chunk, new_embedding_sess = run_inference_with_oom_fallback(
+                embedding_sess,
+                {DEFINED_TENSOR_NAMES['embedding']['input']: final_patches[start:start + batch]},
+                DEFINED_TENSOR_NAMES['embedding']['output'],
+                model_paths['embedding'],
+                'embedding',
+                name,
+            )
+            if new_embedding_sess is not embedding_sess and onnx_sessions:
+                onnx_sessions['embedding'] = new_embedding_sess
+            embedding_sess = new_embedding_sess
+            embedding_chunks.append(chunk)
+        embeddings_per_patch = np.concatenate(embedding_chunks, axis=0)
 
         mood_logits, new_prediction_sess = run_inference_with_oom_fallback(
             prediction_sess,

--- a/test/unit/test_musicnn_chunking.py
+++ b/test/unit/test_musicnn_chunking.py
@@ -1,0 +1,71 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""MusiCNN chunked embedding inference (MUSICNN_BATCH_SIZE).
+
+Verifies that _run_musicnn_models never sends more than MUSICNN_BATCH_SIZE
+patches to the embedding model in one inference call, that every patch is
+still processed exactly once and in order, and that the pooled outputs are
+identical to the single whole-track batch (MUSICNN_BATCH_SIZE=0).
+"""
+
+import numpy as np
+
+from tasks.analysis import song
+
+
+def _fake_inference(calls):
+    def fake(session, feed_dict, output_name, model_path, label, name):
+        (batch,) = feed_dict.values()
+        calls.append((label, batch.shape[0]))
+        if label == 'embedding':
+            # one distinctive 200-dim embedding per patch: its first cell
+            out = np.repeat(batch[:, :1, 0], 200, axis=1).astype(np.float32)
+        else:
+            out = batch[:, :50].astype(np.float32)
+        return out, session
+    return fake
+
+
+def _run(monkeypatch, batch_size, patches):
+    calls = []
+    monkeypatch.setattr(song, 'MUSICNN_BATCH_SIZE', batch_size)
+    monkeypatch.setattr(song, 'run_inference_with_oom_fallback', _fake_inference(calls))
+    embedding, moods = song._run_musicnn_models(
+        patches, [f'mood{i}' for i in range(50)],
+        {'embedding': 'unused', 'prediction': 'unused'},
+        {'embedding': object(), 'prediction': object()},
+        'test-track',
+    )
+    return embedding, moods, calls
+
+
+def test_embedding_calls_never_exceed_batch_size(monkeypatch):
+    patches = np.arange(10 * 187 * 96, dtype=np.float32).reshape(10, 187, 96)
+    _, _, calls = _run(monkeypatch, 3, patches)
+    embedding_calls = [n for label, n in calls if label == 'embedding']
+    assert embedding_calls == [3, 3, 3, 1]
+    # prediction input is the tiny (N, 200) matrix and stays a single call
+    assert [n for label, n in calls if label == 'prediction'] == [10]
+
+
+def test_chunked_output_matches_whole_track_batch(monkeypatch):
+    patches = np.random.default_rng(42).random((7, 187, 96)).astype(np.float32)
+    chunked_emb, chunked_moods, _ = _run(monkeypatch, 3, patches)
+    full_emb, full_moods, calls = _run(monkeypatch, 0, patches.copy())
+    assert [n for label, n in calls if label == 'embedding'] == [7]
+    np.testing.assert_array_equal(chunked_emb, full_emb)
+    assert chunked_moods == full_moods
+
+
+def test_every_patch_processed_once_and_in_order(monkeypatch):
+    patches = np.zeros((5, 187, 96), dtype=np.float32)
+    patches[:, 0, 0] = np.arange(5)
+    embedding, _, _ = _run(monkeypatch, 2, patches)
+    # pooled embedding is the mean of the per-patch markers 0..4
+    np.testing.assert_allclose(embedding, np.full(200, np.arange(5).mean()))

--- a/test/unit/test_musicnn_chunking.py
+++ b/test/unit/test_musicnn_chunking.py
@@ -12,6 +12,11 @@ Verifies that _run_musicnn_models never sends more than MUSICNN_BATCH_SIZE
 patches to the embedding model in one inference call, that every patch is
 still processed exactly once and in order, and that the pooled outputs are
 identical to the single whole-track batch (MUSICNN_BATCH_SIZE=0).
+
+Main Features:
+* Asserts no embedding inference call exceeds MUSICNN_BATCH_SIZE patches.
+* Checks every patch is processed exactly once and in original order.
+* Confirms chunked output matches the whole-track batch (MUSICNN_BATCH_SIZE=0).
 """
 
 import numpy as np


### PR DESCRIPTION
## Problem

`_run_musicnn_models` feeds **every spectrogram patch of a track through the embedding model in a single ONNX batch**. The convolution activations for that batch scale linearly with track length: a ~10-minute track (99 patches) peaks at **~4.7 GB RSS** on CPU. That blows past typical worker memory caps (containers commonly run with 1.5–4 GB limits), and is a likely contributor to the OOM kills / signal-9 crashes the codebase already works around (restart-after-N-jobs, `malloc_trim`, `handle_onnx_memory_error`, the GPU-OOM→CPU fallback).

## Fix

Run the embedding inference in small chunks of patches instead of one whole-track batch. Chunking happens around `run_inference_with_oom_fallback`, so the existing GPU-OOM→CPU fallback and session-swap bookkeeping still work per chunk.

New setting **`MUSICNN_BATCH_SIZE`** (env var, default `8`, documented in `docs/PARAMETERS.md`). `0` restores the previous whole-track behavior. GPU users who prefer larger batches for throughput can raise it.

Only the embedding model is chunked; the prediction model's input is the (N, 200) embedding matrix, which is tiny.

## Measurements

23 real tracks (12–99 patches each, 1257 patches total), CPU EP, Apple M4 (arm64), models from `v5.0.0-model`, calling `_run_musicnn_models` from this branch:

| | wall time | peak RSS |
|---|---|---|
| `MUSICNN_BATCH_SIZE=0` (previous behavior) | 9.6 s | **4691 MB** |
| `MUSICNN_BATCH_SIZE=8` (default) | 8.7 s | **391 MB** |

**Output parity:** pooled embeddings match the full-batch output at cosine ≥ 0.999999941 (ONNX Runtime run-to-run reduction noise), final mood scores are bit-identical, and the 200-bit simhash canonical IDs are unchanged on all 23 tracks — so existing libraries need no re-analysis and mixed old/new worker fleets stay consistent.

## How it was tested

- **Unit tests added** (`test/unit/test_musicnn_chunking.py`): embedding calls never exceed `MUSICNN_BATCH_SIZE`, every patch is processed exactly once and in order, and chunked pooled outputs are identical to the whole-track batch. Full `pytest test/unit/` passes (2575 passed) with this change; `flake8 --select=E9,F,W605,E711,E712,E713,E714,E722,E401` is clean on the touched files.
- **Functional parity:** the 23-track comparison above ran the real `_run_musicnn_models` from this branch against the previous implementation's outputs (same models, same patches), measuring peak RSS via `ru_maxrss` in separate processes. Analysis was exercised with audio decoded from a Navidrome library (MP3 + FLAC).
- To replicate: run analysis on any album with `MUSICNN_BATCH_SIZE=0` vs unset while watching worker RSS; long tracks (8+ minutes) show the difference most clearly.