### PR TITLE
Migration fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ analysis.md
 .claude/settings.local.json
 lyrics_model_gte_vnni.tar.gz
 native-build/windows/vendor/redis/amd64/redis-server.exe
+.claude/settings.json

--- a/Dockerfile-noavx2
+++ b/Dockerfile-noavx2
@@ -105,8 +105,6 @@ RUN uv pip install --system --no-cache --index-strategy unsafe-best-match -r /ap
     && find /usr/local/lib/python3.10/dist-packages -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true \
     && find /usr/local/lib/python3.10/dist-packages -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
 
-RUN python3 -m wn download oewn:2024 && echo "wn / OEWN 2024 corpus downloaded"
-
 RUN set -eux; \
     base_url="https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v5.0.0-model"; \
     hf_models="huggingface_models.tar.gz"; \

--- a/app.py
+++ b/app.py
@@ -326,6 +326,17 @@ if not _is_worker:
                     "Startup same-folder cleanup failed (will retry next boot): %s",
                     _folder_exc,
                 )
+            # Leave a clean catalogue after a migration: delete every row a false
+            # split (or a prior run) left bound to no server, so re-analysis re-creates
+            # it under its own id rather than stranding an orphan.
+            try:
+                from tasks.duplicate_repair import purge_orphan_catalogue_rows
+                purge_orphan_catalogue_rows()
+            except Exception as _purge_exc:
+                app.logger.warning(
+                    "Startup migration orphan purge failed (will retry next boot): %s",
+                    _purge_exc,
+                )
 
         # Finalize JWT_SECRET - must happen after DB init so the value can be
         # persisted and shared across all gunicorn workers.

--- a/app.py
+++ b/app.py
@@ -305,6 +305,10 @@ if not _is_worker:
                 prefetched_durations=_relabel.get('server_durations'),
             ) or {}
         except Exception as _repair_exc:
+            # A thrown repair proves nothing ran to completion: mark it skipped so
+            # the migration-gated steps below (same-folder split, orphan purge) do
+            # not act on a catalogue whose migration state is unknown.
+            _repair = {'skipped': 'error'}
             app.logger.warning(
                 "Startup catalogue duplicate check failed (will retry next boot): %s",
                 _repair_exc,

--- a/config.py
+++ b/config.py
@@ -190,7 +190,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 }
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v3.0.3"
+APP_VERSION = "v3.0.4"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/rq_heartbeat_worker.py
+++ b/rq_heartbeat_worker.py
@@ -6,7 +6,8 @@
 # the terms of the GNU Affero General Public License v3.0. See the LICENSE file
 # in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
 
-"""Worker class selection, with a heartbeat that keeps long jobs alive on Windows.
+"""Worker class selection, with a heartbeat that keeps long jobs alive on Windows
+and re-registers a worker that a transient Redis outage silently deregistered.
 
 RQ's forking ``Worker`` refreshes a running job's started-registry score from its
 monitor loop, so the RQ janitor can tell a live job from a dead one. ``SimpleWorker``
@@ -15,32 +16,51 @@ monitor loop, so it never refreshes that score: it is written once as
 ``now + DEFAULT_WORKER_TTL`` (420s) and then goes stale, even for ``job_timeout=-1``.
 The janitor's ``started_registry.cleanup()`` then expires the entry and either
 re-queues the job or fails it, so no analysis, clustering, cleaning or sweep running
-longer than seven minutes could ever complete on Windows.
+longer than seven minutes could ever complete on Windows. The Windows heartbeat must
+NOT be replaced by returning -1 from get_heartbeat_ttl: Execution.save would then
+EXPIRE the key with a negative TTL, deleting it the instant the job starts.
+
+Issue #784: if Redis is unreachable longer than the worker-key TTL, the key expires,
+clean_worker_registry SREMs the worker from ``rq:workers``, and on reconnect only the
+heartbeat (HSET last_heartbeat + EXPIRE) recreates the key - register() ran once at
+birth, so the live worker keeps taking jobs while invisible to the dashboard. The
+mixin re-runs register() on every heartbeat (idempotent SADD) and re-serializes the
+identity hash if the key came back as a partial, so a recovered worker rejoins.
 
 Main Features:
+* ReregisterOnHeartbeatMixin: SADDs the worker back into rq:workers on each heartbeat
+  and restores hostname/birth/queues if the key expired and was recreated partial.
 * HeartbeatSimpleWorker: runs perform_job on the main thread while a daemon thread
   calls maintain_heartbeats, giving SimpleWorker the liveness signal the forking
-  worker gets for free.
-* WorkerClass: HeartbeatSimpleWorker on win32, the stock forking Worker elsewhere.
+  worker gets for free; also carries the re-registration mixin.
+* WorkerClass: HeartbeatSimpleWorker on win32, a re-registering forking Worker elsewhere.
 """
 
 import logging
 import sys
 import threading
 
-from rq import SimpleWorker, Worker
+from rq import SimpleWorker, Worker, worker_registration
 
 logger = logging.getLogger(__name__)
 
 
-class HeartbeatSimpleWorker(SimpleWorker):
-    """SimpleWorker that keeps refreshing the started-registry score while it works.
+class ReregisterOnHeartbeatMixin:
+    def heartbeat(self, timeout=None, pipeline=None):
+        super().heartbeat(timeout=timeout, pipeline=pipeline)
+        try:
+            worker_registration.register(self, pipeline)
+            if pipeline is None and not self.connection.hexists(self.key, 'birth'):
+                self.connection.hset(self.key, mapping=self.serialize())
+        except Exception:
+            logger.exception("Worker %s: re-registration on heartbeat failed", self.name)
 
-    The heartbeat must NOT be replaced by returning -1 from get_heartbeat_ttl:
-    Execution.save would then call Redis EXPIRE with a negative TTL, which deletes
-    the key immediately and makes the job look dead the instant it starts.
-    """
 
+class ReregisteringWorker(ReregisterOnHeartbeatMixin, Worker):
+    pass
+
+
+class HeartbeatSimpleWorker(ReregisterOnHeartbeatMixin, SimpleWorker):
     def execute_job(self, job, queue):
         stop = threading.Event()
 
@@ -62,4 +82,4 @@ class HeartbeatSimpleWorker(SimpleWorker):
             stop.set()
 
 
-WorkerClass = HeartbeatSimpleWorker if sys.platform == 'win32' else Worker
+WorkerClass = HeartbeatSimpleWorker if sys.platform == 'win32' else ReregisteringWorker

--- a/rq_heartbeat_worker.py
+++ b/rq_heartbeat_worker.py
@@ -24,8 +24,15 @@ Issue #784: if Redis is unreachable longer than the worker-key TTL, the key expi
 clean_worker_registry SREMs the worker from ``rq:workers``, and on reconnect only the
 heartbeat (HSET last_heartbeat + EXPIRE) recreates the key - register() ran once at
 birth, so the live worker keeps taking jobs while invisible to the dashboard. The
-mixin re-runs register() on every heartbeat (idempotent SADD) and re-serializes the
+mixin re-runs register() on every heartbeat (idempotent SADD) and rebuilds the
 identity hash if the key came back as a partial, so a recovered worker rejoins.
+The re-registration always runs on the worker's OWN connection, never on the
+pipeline a heartbeat was given: rq 2.7.0's maintain_heartbeats reads its pipeline
+results by FIXED position (``results[7]`` is job.heartbeat's HSET), so any command
+injected into that pipeline shifts the slot onto an EXPIRE - which returns 1 for a
+live key - and RQ would delete the RUNNING job's key on every monitor beat. The
+identity mapping is built here (the same fields register_birth writes) because
+Worker.serialize does not exist on rq 2.7.0.
 
 Main Features:
 * ReregisterOnHeartbeatMixin: SADDs the worker back into rq:workers on each heartbeat
@@ -41,6 +48,7 @@ import sys
 import threading
 
 from rq import SimpleWorker, Worker, worker_registration
+from rq.utils import now, utcformat
 
 logger = logging.getLogger(__name__)
 
@@ -49,11 +57,25 @@ class ReregisterOnHeartbeatMixin:
     def heartbeat(self, timeout=None, pipeline=None):
         super().heartbeat(timeout=timeout, pipeline=pipeline)
         try:
-            worker_registration.register(self, pipeline)
-            if pipeline is None and not self.connection.hexists(self.key, 'birth'):
-                self.connection.hset(self.key, mapping=self.serialize())
+            worker_registration.register(self)
+            if not self.connection.hexists(self.key, 'birth'):
+                self.connection.hset(self.key, mapping=self._identity_mapping())
+                self.connection.expire(self.key, self.worker_ttl + 60)
         except Exception:
             logger.exception("Worker %s: re-registration on heartbeat failed", self.name)
+
+    def _identity_mapping(self):
+        stamp = utcformat(self.last_heartbeat or now())
+        return {
+            'birth': utcformat(self.birth_date) if self.birth_date else stamp,
+            'last_heartbeat': stamp,
+            'queues': ','.join(self.queue_names()),
+            'pid': self.pid or 0,
+            'hostname': self.hostname or '',
+            'ip_address': self.ip_address or '',
+            'version': self.version or '',
+            'python_version': self.python_version or '',
+        }
 
 
 class ReregisteringWorker(ReregisterOnHeartbeatMixin, Worker):

--- a/tasks/analysis/album.py
+++ b/tasks/analysis/album.py
@@ -178,11 +178,12 @@ def _stage_identity(item, plan, track_name_full, musicnn_embedding, fingerprint_
 def _stage_persist_musicnn(item, track_name_full, track_id_str, musicnn_analysis,
                            top_moods, musicnn_embedding):
     logger.info(
-        "SUCCESSFULLY ANALYZED '%s' as %s: tempo %.2f, energy %.4f, key %s %s, moods %s",
+        "SUCCESSFULLY ANALYZED '%s' as %s: tempo %.2f, energy %.4f, key %s %s",
         track_name_full, track_id_str,
         musicnn_analysis['tempo'], musicnn_analysis['energy'],
-        musicnn_analysis['key'], musicnn_analysis['scale'], top_moods,
+        musicnn_analysis['key'], musicnn_analysis['scale'],
     )
+    logger.info("-- moods %s", top_moods)
     _ah.persist_musicnn_results(
         item, musicnn_analysis, top_moods, musicnn_embedding,
         _ah.ZERO_OTHER_FEATURES,

--- a/tasks/duplicate_repair.py
+++ b/tasks/duplicate_repair.py
@@ -59,6 +59,12 @@ Main Features:
   bound to no server (false-merge splits plus pre-existing orphans), so the
   catalogue is clean after a migration; embeddings cascade, per-file Chromaprints
   are kept, and each deleted track re-analyzes under its own id if its file returns.
+  It needs no complete-listing guard (unlike the cleaning pass): it never interprets
+  a server listing, only the map table itself, and an unreachable server keeps its
+  map rows, so a track still on any server is never purged. The one accepted window
+  is a concurrently analyzing track between its score insert and its map flush on
+  the migration boot itself - hitting it costs that track one re-analysis, nothing
+  more.
 """
 
 import logging

--- a/tasks/duplicate_repair.py
+++ b/tasks/duplicate_repair.py
@@ -41,7 +41,8 @@ is stamped with a 0 sentinel so the whole catalogue is not re-listed for it on
 every boot - 0 behaves exactly like NULL for identity (never confirms a merge)
 and a later re-analysis overwrites it with the real length. Durations come from
 ONE metadata listing per server (no per-id/batch fetch, no audio downloads),
-fetched concurrently across servers. It never deletes a score or embedding row.
+fetched concurrently across servers. The duration backfill and re-verify never
+delete a score or embedding row; the separate migration-only orphan purge does.
 
 Main Features:
 * Table-derived, marker-free idempotency via score.duration - instant no-op once
@@ -54,6 +55,10 @@ Main Features:
 * split_chromaprint_false_merges: cleaning-time Path B - splits a same-server
   duplicate group whose stored Chromaprints prove its files are different
   recordings (skip-if-missing); unmaps only, never deletes a catalogue row.
+* purge_orphan_catalogue_rows: migration-only cleanup - deletes every score row
+  bound to no server (false-merge splits plus pre-existing orphans), so the
+  catalogue is clean after a migration; embeddings cascade, per-file Chromaprints
+  are kept, and each deleted track re-analyzes under its own id if its file returns.
 """
 
 import logging
@@ -86,6 +91,7 @@ _NO_SERVER_DURATION = 0.0
 _REPAIR_ADVISORY_LOCK = 726354823
 _SAME_FOLDER_ADVISORY_LOCK = 726354824
 _CHROMAPRINT_ADVISORY_LOCK = 726354825
+_ORPHAN_PURGE_ADVISORY_LOCK = 726354826
 
 
 def _empty_totals():
@@ -472,6 +478,48 @@ def repair_duplicate_track_maps(conn=None, prefetched_durations=None):
         return _run_migration(db, cur, prefetched_durations)
     finally:
         _release(cur, db, acquired, own_conn)
+
+
+def purge_orphan_catalogue_rows(conn=None):
+    own_conn = conn is None
+    db = conn or connect_raw()
+    acquired = False
+    cur = None
+    try:
+        _force_no_autocommit(db)
+        cur = db.cursor()
+        cur.execute("SELECT pg_try_advisory_lock(%s)", (_ORPHAN_PURGE_ADVISORY_LOCK,))
+        acquired = bool(cur.fetchone()[0])
+        if not acquired:
+            return {'skipped': 'locked'}
+        removed = 0
+        while True:
+            cur.execute(
+                "DELETE FROM score WHERE item_id IN ("
+                "SELECT s.item_id FROM score s "
+                "WHERE NOT EXISTS (SELECT 1 FROM track_server_map t "
+                "WHERE t.item_id = s.item_id) LIMIT %s)",
+                (_DELETE_CHUNK,),
+            )
+            deleted = cur.rowcount
+            removed += deleted
+            db.commit()
+            if deleted < _DELETE_CHUNK:
+                break
+        if removed:
+            logger.info(
+                "Migration orphan purge: deleted %d catalogue row(s) bound to no "
+                "server (embeddings cascade; per-file Chromaprints are kept for reuse; "
+                "each re-analyzes under its own id if its file returns).",
+                removed,
+            )
+        return {'purged': removed}
+    except Exception:
+        _rollback(db)
+        logger.exception("Migration orphan purge failed; it retries on the next start")
+        return {'error': 'failed'}
+    finally:
+        _release(cur, db, acquired, own_conn, _ORPHAN_PURGE_ADVISORY_LOCK)
 
 
 def _same_folder_conflicts(cur):

--- a/tasks/fingerprint_canonicalize.py
+++ b/tasks/fingerprint_canonicalize.py
@@ -39,10 +39,18 @@ identity translation fallback.
 Main Features:
 * One-time, idempotent startup relabel of legacy rows. Content ids are hashed
   from embeddings a chunk at a time and dropped; duplicate candidates come from
-  the audio IVF clusters (``_ivf_candidate_pairs``) and are confirmed one bounded
-  slice at a time, so peak memory stays flat (one confirm slice) however crowded a
-  cluster is - a whole-catalogue pass over a homogeneous library used to run the
-  container out of memory. A track the IVF does not cover keeps its own id.
+  the audio IVF clusters (``_ivf_candidate_pairs``): only tracks sharing a cell
+  are paired, pairs whose stored lengths are unknown or incompatible are dropped
+  by a vectorized compare before any embedding is fetched (the confirm would
+  reject them anyway), and the survivors are confirmed one bounded slice at a
+  time. Peak memory is LINEAR in the library - small per-track structures (id,
+  cell and duration maps, ~tens of MB per 100k tracks) plus one bounded confirm
+  slice - and never grows with how crowded a cluster is (the PAIR count), which
+  is what used to run the container out of memory. A track the IVF does not
+  cover keeps its own id; a track whose embedding yields NO signature (constant
+  or non-finite) is relabelled to the same server-scoped fp_0 unsignable id
+  analysis would mint, mapped with the 'analysis' tier, and never proposed as a
+  merge partner - it can never fail the verifier as a leftover legacy row.
 * Cosine-confirmed duplicate merge into existing canonical rows.
 * Repoints the similarity indexes at the new ids in the same transaction: a
   relabel renames tracks without moving a vector, so nothing is re-clustered.
@@ -262,40 +270,7 @@ def _confirm_slice(fetch, ids, left_slice, right_slice, duration_of):
     return left_slice[confirmed], right_slice[confirmed]
 
 
-def _confirm_candidates(cur, ids, left, right, duration_of):
-    if left.size == 0:
-        return left, right
-    order = np.lexsort((right, left))
-    left = left[order]
-    right = right[order]
-    logger.info(
-        "Legacy catalogue migration: confirming %d candidate pairs in slices of %d "
-        "(resident block capped at ~%d MB)...",
-        left.size,
-        _CONFIRM_PAIRS,
-        (2 * _CONFIRM_PAIRS * simhash.SIGNATURE_BITS * 4) // (1024 * 1024),
-    )
-    kept_left = []
-    kept_right = []
-    fetch = cur.connection.cursor()
-    try:
-        for begin in range(0, left.size, _CONFIRM_PAIRS):
-            window = slice(begin, begin + _CONFIRM_PAIRS)
-            kept_l, kept_r = _confirm_slice(
-                fetch, ids, left[window], right[window], duration_of
-            )
-            if kept_l.size:
-                kept_left.append(kept_l)
-                kept_right.append(kept_r)
-    finally:
-        fetch.close()
-    if not kept_left:
-        empty = np.empty(0, dtype=np.int64)
-        return empty, empty
-    return np.concatenate(kept_left), np.concatenate(kept_right)
-
-
-def _ivf_candidate_pairs(cur, ids, loaded, provider_durations, source_id):
+def _ivf_candidate_pairs(cur, ids, valid, loaded, provider_durations, source_id):
     from .paged_ivf import IVF_DIR_TABLE, unpack_directory
     from .index_build_helpers import load_segmented_blob
 
@@ -310,7 +285,7 @@ def _ivf_candidate_pairs(cur, ids, loaded, provider_durations, source_id):
         )
         return empty, empty
     _centroids, id2cell, index_item_ids = unpack_directory(blob)[:3]
-    row_of = {ids[row]: row for row in range(loaded)}
+    row_of = {ids[row]: row for row in range(loaded) if valid[row]}
     cell_of_row = []
     rows_present = []
     for vec_id, item_id in enumerate(index_item_ids):
@@ -333,6 +308,11 @@ def _ivf_candidate_pairs(cur, ids, loaded, provider_durations, source_id):
     group_of_pos = np.repeat(np.arange(sizes.size), sizes)
     involved = order[crowded[group_of_pos]]
     duration_of = _durations_for_rows(cur, ids, involved, provider_durations, source_id)
+    row_duration = np.full(loaded, np.nan)
+    for item_id, value in duration_of.items():
+        row = row_of.get(item_id)
+        if row is not None and value is not None:
+            row_duration[row] = value
     logger.info(
         "Legacy catalogue migration: %d IVF cluster(s) hold multiple tracks; "
         "confirming duplicates within each cluster (slices of %d)...",
@@ -340,19 +320,52 @@ def _ivf_candidate_pairs(cur, ids, loaded, provider_durations, source_id):
     )
     kept_left = []
     kept_right = []
+    pending_first = []
+    pending_second = []
+    pending = 0
     fetch = conn.cursor()
+
+    def _flush():
+        nonlocal pending
+        if not pending_first:
+            return
+        kept_l, kept_r = _confirm_slice(
+            fetch, ids,
+            np.concatenate(pending_first), np.concatenate(pending_second),
+            duration_of,
+        )
+        pending_first.clear()
+        pending_second.clear()
+        pending = 0
+        if kept_l.size:
+            kept_left.append(kept_l)
+            kept_right.append(kept_r)
+
     try:
         for first, second in simhash._iter_group_pairs(
             order, starts[crowded], sizes[crowded], limit=_CONFIRM_PAIRS
         ):
-            kept_l, kept_r = _confirm_slice(
-                fetch, ids,
-                first.astype(np.int64), second.astype(np.int64),
-                duration_of,
-            )
-            if kept_l.size:
-                kept_left.append(kept_l)
-                kept_right.append(kept_r)
+            first = first.astype(np.int64)
+            second = second.astype(np.int64)
+            left_durations = row_duration[first]
+            right_durations = row_duration[second]
+            with np.errstate(invalid='ignore'):
+                compatible = (
+                    np.isfinite(left_durations)
+                    & np.isfinite(right_durations)
+                    & (left_durations > 0)
+                    & (right_durations > 0)
+                    & (np.abs(left_durations - right_durations)
+                       <= config.DURATION_TOLERANCE_SECONDS)
+                )
+            if not compatible.any():
+                continue
+            pending_first.append(first[compatible])
+            pending_second.append(second[compatible])
+            pending += int(compatible.sum())
+            if pending >= _CONFIRM_PAIRS:
+                _flush()
+        _flush()
     finally:
         fetch.close()
     if not kept_left:
@@ -490,7 +503,7 @@ def _build_mapping(cur, source_id):
     resolved_at = time.monotonic()
 
     left, right = _ivf_candidate_pairs(
-        cur, ids, loaded, provider_durations, source_id
+        cur, ids, valid, loaded, provider_durations, source_id
     )
     # A canonical row may only ever be a merge TARGET, never a child. merge_pairs
     # refuses a merge whose target has itself already merged, so a confirmed
@@ -510,10 +523,13 @@ def _build_mapping(cur, source_id):
     duplicate_mapping = {}
     canonical_of = dict(enumerate(ids[:canonical_loaded]))
     taken = set(ids[:canonical_loaded])
+    unsignable = 0
     for row in range(canonical_loaded, loaded):
-        if not valid[row]:
-            continue
         legacy_id = ids[row]
+        if not valid[row]:
+            mapping[legacy_id] = simhash.unsignable_canonical_id(source_id, legacy_id)
+            unsignable += 1
+            continue
         target = int(parent[row])
         if target != row:
             duplicate_mapping[legacy_id] = canonical_of[target]
@@ -522,6 +538,13 @@ def _build_mapping(cur, source_id):
         canonical_of[row] = minted
         taken.add(minted)
         mapping[legacy_id] = minted
+    if unsignable:
+        logger.warning(
+            "Legacy catalogue migration: %d track(s) have no usable embedding "
+            "signature (constant or non-finite embedding); catalogued under "
+            "server-scoped fp_0 ids, excluded from duplicate matching.",
+            unsignable,
+        )
     logger.info(
         "Legacy catalogue migration: resolved %d tracks in %.1fs "
         "(%d new content ids, %d duplicates merged).",
@@ -676,12 +699,14 @@ def _copy_track_server_map(cur, source_id, all_changes, default_provider_ids,
         provider_id = str(default_provider_ids.get(str(old_id), str(old_id)))
         path = legacy_paths.get(str(old_id))
         duration = provider_durations.get(provider_id)
+        tier = 'analysis' if simhash.is_unsignable_id(canonical) else 'default'
         buffer.write(
-            "%s\t%s\t%s\t%s\t%s\n"
+            "%s\t%s\t%s\t%s\t%s\t%s\n"
             % (
                 canonical.replace('\t', ' '),
                 source_id,
                 _copy_escape(provider_id),
+                tier,
                 r'\N' if not path else _copy_escape(path),
                 r'\N' if duration is None else repr(float(duration)),
             )
@@ -689,22 +714,23 @@ def _copy_track_server_map(cur, source_id, all_changes, default_provider_ids,
     buffer.seek(0)
     cur.execute(
         "CREATE TEMP TABLE incoming_default_map "
-        "(item_id TEXT, server_id TEXT, provider_track_id TEXT, file_path TEXT, "
-        "duration DOUBLE PRECISION) "
+        "(item_id TEXT, server_id TEXT, provider_track_id TEXT, match_tier TEXT, "
+        "file_path TEXT, duration DOUBLE PRECISION) "
         "ON COMMIT DROP"
     )
     cur.copy_expert(
         "COPY incoming_default_map "
-        "(item_id, server_id, provider_track_id, file_path, duration) "
+        "(item_id, server_id, provider_track_id, match_tier, file_path, duration) "
         "FROM STDIN",
         buffer,
     )
     cur.execute(
         "INSERT INTO track_server_map "
         "(item_id, server_id, provider_track_id, match_tier, file_path, updated_at) "
-        "SELECT item_id, server_id, provider_track_id, 'default', file_path, now() "
+        "SELECT item_id, server_id, provider_track_id, match_tier, file_path, now() "
         "FROM incoming_default_map "
         "ON CONFLICT (server_id, provider_track_id) DO UPDATE SET "
+        "match_tier = EXCLUDED.match_tier, "
         "file_path = COALESCE(EXCLUDED.file_path, track_server_map.file_path)"
     )
     cur.execute(

--- a/tasks/fingerprint_canonicalize.py
+++ b/tasks/fingerprint_canonicalize.py
@@ -15,34 +15,34 @@ legacy row, at Flask container startup, and is an instant no-op afterwards;
 analysis mints canonical ids directly at analyze time so nothing here runs
 during analysis. It is NOT once per lifetime of an INSTALL: identity is derived
 from the MusiCNN embedding, so swapping the model re-mints every id and runs the
-whole rewrite again. Signatures are hashed a chunk at a time and the candidate
-scan fans its independent bands across threads, so a large legacy install
-migrates as fast as the machine allows without ever holding the whole catalogue
-in memory. The rewrite uses the same proven transactional key-rewrite the
-provider-migration feature uses (score, playlist, and all embedding tables,
-with the embedding foreign keys dropped and re-added around it). A legacy row
-merges into an existing catalogue row ONLY when its signature is within
-tolerance AND the exact raw-embedding cosine confirms it is the same audio
+whole rewrite again. Signatures are hashed a chunk at a time to mint each row's
+content id, and duplicate candidates are read straight from the audio IVF index
+the library already built - only tracks sharing an IVF cell (cluster) are
+compared - so a large legacy install migrates without ever holding the whole
+catalogue's pairs in memory. The rewrite uses the same proven transactional
+key-rewrite the provider-migration feature uses (score, playlist, and all
+embedding tables, with the embedding foreign keys dropped and re-added around
+it). A legacy row merges into an existing catalogue row ONLY when they share an
+IVF cluster AND the exact raw-embedding cosine confirms it is the same audio
 (the Similar Songs duplicate rule) AND the two track durations agree within
 DURATION_TOLERANCE_SECONDS - a homogeneous library (say, solo piano) puts
 genuinely different recordings inside the cosine threshold, and only the
 length tells them apart. Durations come from ONE paged metadata listing of
 the source server (no audio downloads) and are backfilled into
 score.duration; if the server is unreachable the migration still runs and
-simply merges nothing, which is always safe. The source server's real ids
+simply merges nothing, which is always safe (an absent IVF index does the
+same, and a track the index does not cover keeps its own id). The source server's real ids
 are preserved in track_server_map so output can be translated back; rows
 without an embedding keep their provider id and keep working via the
 identity translation fallback.
 
 Main Features:
-* One-time, idempotent startup relabel of legacy rows, resolved for the whole
-  catalogue in vectorized BATCHES: embeddings are hashed a chunk at a time and
-  dropped, and candidate pairs stream in bounded slices (a 188k-track library
-  migrates end to end in ~80s, where the per-track loop this replaces took ~10
-  minutes and a whole-catalogue pass ran the container out of memory). Peak
-  memory is LINEAR in the library, not constant: 25 B per track for the
-  signatures, plus one ``(matched_tracks, 200)`` float32 array that
-  ``_confirm_candidates`` allocates up front.
+* One-time, idempotent startup relabel of legacy rows. Content ids are hashed
+  from embeddings a chunk at a time and dropped; duplicate candidates come from
+  the audio IVF clusters (``_ivf_candidate_pairs``) and are confirmed one bounded
+  slice at a time, so peak memory stays flat (one confirm slice) however crowded a
+  cluster is - a whole-catalogue pass over a homogeneous library used to run the
+  container out of memory. A track the IVF does not cover keeps its own id.
 * Cosine-confirmed duplicate merge into existing canonical rows.
 * Repoints the similarity indexes at the new ids in the same transaction: a
   relabel renames tracks without moving a vector, so nothing is re-clustered.
@@ -215,19 +215,54 @@ def _durations_for_rows(cur, ids, rows, provider_durations, source_id):
     return durations
 
 
+def _confirm_slice(fetch, ids, left_slice, right_slice, duration_of):
+    rows = np.unique(np.concatenate((left_slice, right_slice)))
+    vectors = np.zeros((rows.size, simhash.SIGNATURE_BITS), dtype=np.float32)
+    slot_of = {ids[int(row)]: slot for slot, row in enumerate(rows)}
+    fingerprint_of = {}
+    for chunk in range(0, rows.size, _CHUNK_ROWS):
+        wanted = [ids[int(row)] for row in rows[chunk:chunk + _CHUNK_ROWS]]
+        fetch.execute(
+            "SELECT item_id, embedding FROM embedding WHERE item_id = ANY(%s)",
+            (wanted,),
+        )
+        for item_id, blob in fetch.fetchall():
+            vector = np.frombuffer(blob, dtype=np.float32)
+            if vector.size == simhash.SIGNATURE_BITS:
+                vectors[slot_of[str(item_id)]] = vector
+        if config.CHROMAPRINT_GATE_ENABLED:
+            fetch.execute(
+                "SELECT DISTINCT ON (m.item_id) m.item_id, c.fingerprint "
+                "FROM track_server_map m JOIN chromaprint c "
+                "ON c.server_id = m.server_id "
+                "AND c.provider_track_id = m.provider_track_id "
+                "WHERE m.item_id = ANY(%s) AND c.fingerprint IS NOT NULL",
+                (wanted,),
+            )
+            for item_id, blob in fetch.fetchall():
+                if blob is not None:
+                    fingerprint_of[str(item_id)] = bytes(blob)
+    confirmed = simhash.confirm_pairs(
+        vectors[np.searchsorted(rows, left_slice)],
+        vectors[np.searchsorted(rows, right_slice)],
+        left_durations=[duration_of.get(ids[int(row)]) for row in left_slice],
+        right_durations=[duration_of.get(ids[int(row)]) for row in right_slice],
+        left_fingerprints=(
+            [fingerprint_of.get(ids[int(row)]) for row in left_slice]
+            if fingerprint_of else None
+        ),
+        right_fingerprints=(
+            [fingerprint_of.get(ids[int(row)]) for row in right_slice]
+            if fingerprint_of else None
+        ),
+    )
+    if not confirmed.any():
+        empty = np.empty(0, dtype=left_slice.dtype)
+        return empty, empty
+    return left_slice[confirmed], right_slice[confirmed]
+
+
 def _confirm_candidates(cur, ids, left, right, duration_of):
-    """Keep the candidate pairs the EXACT raw-embedding cosine confirms.
-
-    Bounded memory, whatever the library's size. The embeddings are read back one
-    SLICE of pairs at a time, so the resident float32 block is capped by the slice
-    (at most ``2 * _CONFIRM_PAIRS`` tracks, ~80 MB) instead of by the number of
-    tracks a signature happened to match, which is what a whole-catalogue array
-    made linear in the library and is how this once ran a container out of memory.
-
-    The pairs are lexsorted first, so the tracks a slice touches are contiguous and
-    a track that neighbours many others is re-read a handful of times rather than
-    once per pair it appears in.
-    """
     if left.size == 0:
         return left, right
     order = np.lexsort((right, left))
@@ -246,58 +281,85 @@ def _confirm_candidates(cur, ids, left, right, duration_of):
     try:
         for begin in range(0, left.size, _CONFIRM_PAIRS):
             window = slice(begin, begin + _CONFIRM_PAIRS)
-            left_slice = left[window]
-            right_slice = right[window]
-            rows = np.unique(np.concatenate((left_slice, right_slice)))
-            vectors = np.zeros((rows.size, simhash.SIGNATURE_BITS), dtype=np.float32)
-            slot_of = {ids[int(row)]: slot for slot, row in enumerate(rows)}
-            fingerprint_of = {}
-            for chunk in range(0, rows.size, _CHUNK_ROWS):
-                wanted = [ids[int(row)] for row in rows[chunk:chunk + _CHUNK_ROWS]]
-                fetch.execute(
-                    "SELECT item_id, embedding FROM embedding WHERE item_id = ANY(%s)",
-                    (wanted,),
-                )
-                for item_id, blob in fetch.fetchall():
-                    vector = np.frombuffer(blob, dtype=np.float32)
-                    if vector.size == simhash.SIGNATURE_BITS:
-                        vectors[slot_of[str(item_id)]] = vector
-                if config.CHROMAPRINT_GATE_ENABLED:
-                    fetch.execute(
-                        "SELECT DISTINCT ON (m.item_id) m.item_id, c.fingerprint "
-                        "FROM track_server_map m JOIN chromaprint c "
-                        "ON c.server_id = m.server_id "
-                        "AND c.provider_track_id = m.provider_track_id "
-                        "WHERE m.item_id = ANY(%s) AND c.fingerprint IS NOT NULL",
-                        (wanted,),
-                    )
-                    for item_id, blob in fetch.fetchall():
-                        if blob is not None:
-                            fingerprint_of[str(item_id)] = bytes(blob)
-            confirmed = simhash.confirm_pairs(
-                vectors[np.searchsorted(rows, left_slice)],
-                vectors[np.searchsorted(rows, right_slice)],
-                left_durations=[duration_of.get(ids[int(row)]) for row in left_slice],
-                right_durations=[duration_of.get(ids[int(row)]) for row in right_slice],
-                left_fingerprints=(
-                    [fingerprint_of.get(ids[int(row)]) for row in left_slice]
-                    if fingerprint_of else None
-                ),
-                right_fingerprints=(
-                    [fingerprint_of.get(ids[int(row)]) for row in right_slice]
-                    if fingerprint_of else None
-                ),
+            kept_l, kept_r = _confirm_slice(
+                fetch, ids, left[window], right[window], duration_of
             )
-            if confirmed.any():
-                kept_left.append(left_slice[confirmed])
-                kept_right.append(right_slice[confirmed])
-            vectors = None
+            if kept_l.size:
+                kept_left.append(kept_l)
+                kept_right.append(kept_r)
     finally:
         fetch.close()
     if not kept_left:
         empty = np.empty(0, dtype=np.int64)
         return empty, empty
     return np.concatenate(kept_left), np.concatenate(kept_right)
+
+
+def _ivf_candidate_pairs(cur, ids, loaded, provider_durations, source_id):
+    from .paged_ivf import IVF_DIR_TABLE, unpack_directory
+    from .index_build_helpers import load_segmented_blob
+
+    empty = np.empty(0, dtype=np.int64)
+    conn = cur.connection
+    blob = load_segmented_blob(conn, IVF_DIR_TABLE, "%s__ivf_dir" % config.INDEX_NAME)
+    if not blob:
+        logger.warning(
+            "Legacy catalogue migration: no audio IVF index found; every legacy "
+            "track keeps its own id (no duplicate merging this run). Rebuild the "
+            "similarity index (run analysis) and restart to merge duplicates."
+        )
+        return empty, empty
+    _centroids, id2cell, index_item_ids = unpack_directory(blob)[:3]
+    row_of = {ids[row]: row for row in range(loaded)}
+    cell_of_row = []
+    rows_present = []
+    for vec_id, item_id in enumerate(index_item_ids):
+        row = row_of.get(item_id)
+        if row is not None:
+            cell_of_row.append(int(id2cell[vec_id]))
+            rows_present.append(row)
+    if len(rows_present) < 2:
+        return empty, empty
+    cells = np.asarray(cell_of_row, dtype=np.int64)
+    rows_arr = np.asarray(rows_present, dtype=np.int64)
+    order_pos = np.argsort(cells, kind="stable")
+    order = rows_arr[order_pos]
+    _uniq, starts, sizes = np.unique(
+        cells[order_pos], return_index=True, return_counts=True
+    )
+    crowded = sizes > 1
+    if not crowded.any():
+        return empty, empty
+    group_of_pos = np.repeat(np.arange(sizes.size), sizes)
+    involved = order[crowded[group_of_pos]]
+    duration_of = _durations_for_rows(cur, ids, involved, provider_durations, source_id)
+    logger.info(
+        "Legacy catalogue migration: %d IVF cluster(s) hold multiple tracks; "
+        "confirming duplicates within each cluster (slices of %d)...",
+        int(crowded.sum()), _CONFIRM_PAIRS,
+    )
+    kept_left = []
+    kept_right = []
+    fetch = conn.cursor()
+    try:
+        for first, second in simhash._iter_group_pairs(
+            order, starts[crowded], sizes[crowded], limit=_CONFIRM_PAIRS
+        ):
+            kept_l, kept_r = _confirm_slice(
+                fetch, ids,
+                first.astype(np.int64), second.astype(np.int64),
+                duration_of,
+            )
+            if kept_l.size:
+                kept_left.append(kept_l)
+                kept_right.append(kept_r)
+    finally:
+        fetch.close()
+    if not kept_left:
+        return empty, empty
+    left = np.concatenate(kept_left)
+    right = np.concatenate(kept_right)
+    return np.minimum(left, right), np.maximum(left, right)
 
 
 def _folders_for_rows(cur, ids, left, right, count):
@@ -427,20 +489,9 @@ def _build_mapping(cur, source_id):
 
     resolved_at = time.monotonic()
 
-    def _band_progress(band, bands, candidates, survivors):
-        logger.info(
-            "Legacy catalogue migration: signature blocking, band %d/%d "
-            "(%d candidate pairs examined, %d within tolerance, %.0fs elapsed).",
-            band, bands, candidates, survivors, time.monotonic() - resolved_at,
-        )
-
-    left, right = simhash.near_duplicate_pairs(packed, valid, progress=_band_progress)
-    duration_of = {}
-    if left.size:
-        duration_of = _durations_for_rows(
-            cur, ids, np.concatenate((left, right)), provider_durations, source_id
-        )
-    left, right = _confirm_candidates(cur, ids, left, right, duration_of)
+    left, right = _ivf_candidate_pairs(
+        cur, ids, loaded, provider_durations, source_id
+    )
     # A canonical row may only ever be a merge TARGET, never a child. merge_pairs
     # refuses a merge whose target has itself already merged, so a confirmed
     # canonical-vs-canonical pair (which the emit loop below discards anyway, since

--- a/tasks/fingerprint_canonicalize.py
+++ b/tasks/fingerprint_canonicalize.py
@@ -32,9 +32,11 @@ the source server (no audio downloads) and are backfilled into
 score.duration; if the server is unreachable the migration still runs and
 simply merges nothing, which is always safe (an absent IVF index does the
 same, and a track the index does not cover keeps its own id). The source server's real ids
-are preserved in track_server_map so output can be translated back; rows
-without an embedding keep their provider id and keep working via the
-identity translation fallback.
+are preserved in track_server_map so output can be translated back; a row
+whose embedding is missing or unusable (NULL, truncated, wrong size, constant,
+non-finite) is relabelled to the server-scoped fp_0 unsignable id and mapped
+with the 'analysis' tier, so no corruption shape can leave a legacy id behind
+to fail the verifier and re-run the migration forever.
 
 Main Features:
 * One-time, idempotent startup relabel of legacy rows. Content ids are hashed
@@ -135,10 +137,10 @@ def _hash_catalogue(cur, sql, params, ids, packed, valid, offset):
             batch = np.zeros((len(rows), simhash.SIGNATURE_BITS), dtype=np.float32)
             kept = 0
             for item_id, blob in rows:
-                vector = np.frombuffer(blob, dtype=np.float32)
-                if vector.size != simhash.SIGNATURE_BITS:
-                    continue
-                batch[kept] = vector
+                if blob is not None and len(blob) % 4 == 0:
+                    vector = np.frombuffer(blob, dtype=np.float32)
+                    if vector.size == simhash.SIGNATURE_BITS:
+                        batch[kept] = vector
                 ids.append(str(item_id))
                 kept += 1
             if not kept:
@@ -423,8 +425,8 @@ def _build_mapping(cur, source_id):
     head_len = simhash.CANONICAL_ID_LEN
     cur.execute(
         "SELECT COUNT(*) FROM score s "
-        "JOIN embedding e ON e.item_id = s.item_id "
-        "WHERE e.embedding IS NOT NULL AND " + _LEGACY_ROW_SQL,
+        "LEFT JOIN embedding e ON e.item_id = s.item_id "
+        "WHERE " + _LEGACY_ROW_SQL,
         (head_len,),
     )
     total = cur.fetchone()[0]
@@ -470,8 +472,8 @@ def _build_mapping(cur, source_id):
     legacy_loaded = _hash_catalogue(
         cur,
         "SELECT s.item_id, e.embedding FROM score s "
-        "JOIN embedding e ON e.item_id = s.item_id "
-        "WHERE e.embedding IS NOT NULL AND " + _LEGACY_ROW_SQL,
+        "LEFT JOIN embedding e ON e.item_id = s.item_id "
+        "WHERE " + _LEGACY_ROW_SQL,
         (head_len,), ids, packed, valid, canonical_loaded,
     )
     loaded = canonical_loaded + legacy_loaded
@@ -526,9 +528,13 @@ def _build_mapping(cur, source_id):
     for row in range(canonical_loaded, loaded):
         legacy_id = ids[row]
         if not valid[row]:
-            mapping[legacy_id] = simhash.unsignable_canonical_id(
+            minted = simhash.unsignable_canonical_id(
                 source_id, unsignable_provider_of.get(legacy_id, legacy_id)
             )
+            while minted in taken:
+                minted = simhash.unsignable_canonical_id(source_id, minted)
+            taken.add(minted)
+            mapping[legacy_id] = minted
             unsignable += 1
             continue
         target = int(parent[row])

--- a/tasks/fingerprint_canonicalize.py
+++ b/tasks/fingerprint_canonicalize.py
@@ -347,17 +347,9 @@ def _ivf_candidate_pairs(cur, ids, valid, loaded, provider_durations, source_id)
         ):
             first = first.astype(np.int64)
             second = second.astype(np.int64)
-            left_durations = row_duration[first]
-            right_durations = row_duration[second]
-            with np.errstate(invalid='ignore'):
-                compatible = (
-                    np.isfinite(left_durations)
-                    & np.isfinite(right_durations)
-                    & (left_durations > 0)
-                    & (right_durations > 0)
-                    & (np.abs(left_durations - right_durations)
-                       <= config.DURATION_TOLERANCE_SECONDS)
-                )
+            compatible = simhash.duration_mask_arrays(
+                row_duration[first], row_duration[second]
+            )
             if not compatible.any():
                 continue
             pending_first.append(first[compatible])
@@ -523,11 +515,20 @@ def _build_mapping(cur, source_id):
     duplicate_mapping = {}
     canonical_of = dict(enumerate(ids[:canonical_loaded]))
     taken = set(ids[:canonical_loaded])
+    unsignable_ids = [
+        ids[row] for row in range(canonical_loaded, loaded) if not valid[row]
+    ]
+    unsignable_provider_of = (
+        _default_provider_ids(cur, source_id, unsignable_ids)
+        if unsignable_ids else {}
+    )
     unsignable = 0
     for row in range(canonical_loaded, loaded):
         legacy_id = ids[row]
         if not valid[row]:
-            mapping[legacy_id] = simhash.unsignable_canonical_id(source_id, legacy_id)
+            mapping[legacy_id] = simhash.unsignable_canonical_id(
+                source_id, unsignable_provider_of.get(legacy_id, legacy_id)
+            )
             unsignable += 1
             continue
         target = int(parent[row])
@@ -730,7 +731,8 @@ def _copy_track_server_map(cur, source_id, all_changes, default_provider_ids,
         "SELECT item_id, server_id, provider_track_id, match_tier, file_path, now() "
         "FROM incoming_default_map "
         "ON CONFLICT (server_id, provider_track_id) DO UPDATE SET "
-        "match_tier = EXCLUDED.match_tier, "
+        "match_tier = CASE WHEN EXCLUDED.match_tier = 'analysis' "
+        "THEN EXCLUDED.match_tier ELSE track_server_map.match_tier END, "
         "file_path = COALESCE(EXCLUDED.file_path, track_server_map.file_path)"
     )
     cur.execute(
@@ -1025,7 +1027,7 @@ def canonicalize_fingerprinted_ids(conn=None, log_fn=None, source_server_id=None
         # racing the same key rewrite and DDL through the FK drop/re-add.
         cur.execute("SELECT pg_advisory_xact_lock(%s)", (_RELABEL_ADVISORY_LOCK,))
         source_id = source_server_id or registry.get_default_server_id(db)
-        if source_id is None:
+        if not source_id:
             logger.warning(
                 "Canonicalization skipped: no default server row exists to preserve the "
                 "provider ids; relabelling now would lose them"

--- a/tasks/simhash.py
+++ b/tasks/simhash.py
@@ -436,6 +436,14 @@ def signature_from_canonical_id(item_id):
         return None
 
 
+def is_unsignable_id(item_id):
+    return (
+        isinstance(item_id, str)
+        and len(item_id) == CANONICAL_ID_LEN
+        and item_id.startswith(_UNSIGNABLE_HEAD)
+    )
+
+
 def is_fingerprint_id(item_id):
     return isinstance(item_id, str) and item_id.startswith(_ID_PREFIX)
 

--- a/tasks/simhash.py
+++ b/tasks/simhash.py
@@ -257,13 +257,7 @@ def folder_conflict_in_group(paths):
     return False
 
 
-def _duration_mask(left_durations, right_durations, size):
-    left = np.full(size, np.nan) if left_durations is None else np.asarray(
-        [np.nan if d is None else d for d in left_durations], dtype=np.float64
-    )
-    right = np.full(size, np.nan) if right_durations is None else np.asarray(
-        [np.nan if d is None else d for d in right_durations], dtype=np.float64
-    )
+def duration_mask_arrays(left, right):
     with np.errstate(invalid='ignore'):
         return (
             np.isfinite(left)
@@ -272,6 +266,16 @@ def _duration_mask(left_durations, right_durations, size):
             & (right > 0)
             & (np.abs(left - right) <= DURATION_TOLERANCE_SECONDS)
         )
+
+
+def _duration_mask(left_durations, right_durations, size):
+    left = np.full(size, np.nan) if left_durations is None else np.asarray(
+        [np.nan if d is None else d for d in left_durations], dtype=np.float64
+    )
+    right = np.full(size, np.nan) if right_durations is None else np.asarray(
+        [np.nan if d is None else d for d in right_durations], dtype=np.float64
+    )
+    return duration_mask_arrays(left, right)
 
 
 def confirm_pairs(left_vectors, right_vectors, left_durations=None, right_durations=None,
@@ -439,7 +443,7 @@ def signature_from_canonical_id(item_id):
 def is_unsignable_id(item_id):
     return (
         isinstance(item_id, str)
-        and len(item_id) == CANONICAL_ID_LEN
+        and len(item_id) == len(_UNSIGNABLE_HEAD) + _HEX_LEN
         and item_id.startswith(_UNSIGNABLE_HEAD)
     )
 

--- a/test/integration/test_canonicalize_integration.py
+++ b/test/integration/test_canonicalize_integration.py
@@ -538,6 +538,47 @@ class TestRealCanonicalization:
             "the fp_0 row never re-triggers the migration"
         )
 
+    def test_no_corruption_shape_of_the_embedding_can_brick_the_migration(self, db):
+        from tasks import fingerprint_canonicalize as fc
+
+        tracks = [
+            ('jf-missing', '/music/A/01.flac', _distinct_embedding(1)),
+            ('jf-null', '/music/B/02.flac', _distinct_embedding(2)),
+            ('jf-truncated', '/music/C/03.flac', _distinct_embedding(3)),
+            ('jf-wrong-size', '/music/D/04.flac', _distinct_embedding(4)),
+            ('jf-ok', '/music/E/05.flac', _distinct_embedding(5)),
+        ]
+        _build(db, tracks)
+        with db.cursor() as cur:
+            cur.execute("DELETE FROM embedding WHERE item_id = 'jf-missing'")
+            cur.execute("UPDATE embedding SET embedding = NULL WHERE item_id = 'jf-null'")
+            cur.execute(
+                "UPDATE embedding SET embedding = %s WHERE item_id = 'jf-truncated'",
+                (psycopg2.Binary(b'\x00\x01\x02'),),
+            )
+            cur.execute(
+                "UPDATE embedding SET embedding = %s WHERE item_id = 'jf-wrong-size'",
+                (psycopg2.Binary(np.zeros(10, dtype=np.float32).tobytes()),),
+            )
+        db.commit()
+
+        result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        assert result['relabelled'] == 5, "every corruption shape still relabels"
+        maps = {p: item for p, item, _f in _maps(db)}
+        for provider in ('jf-missing', 'jf-null', 'jf-truncated', 'jf-wrong-size'):
+            assert maps[provider] == simhash.unsignable_canonical_id('srv', provider)
+        assert maps['jf-ok'].startswith(simhash.CURRENT_ID_HEAD)
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM track_server_map WHERE match_tier = 'analysis'"
+            )
+            assert cur.fetchone()[0] == 4
+        second = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+        assert second == {'relabelled': 0, 'duplicates': 0}, (
+            "no corruption shape leaves a legacy id behind to re-run the migration"
+        )
+
     def test_unsignable_fp0_uses_the_source_servers_provider_id_when_mapped(self, db):
         from tasks import fingerprint_canonicalize as fc
 

--- a/test/integration/test_canonicalize_integration.py
+++ b/test/integration/test_canonicalize_integration.py
@@ -18,8 +18,10 @@ Main Features:
 * A legacy catalogue is relabelled for real: provider ids become content ids,
   the provider ids survive in track_server_map, and the legacy score.file_path
   moves onto the server's own map row.
-* Identical audio with matching duration merges into ONE catalogue row and the
-  merged row keeps its path; a different or unknown duration always splits.
+* Duplicate candidates come from the audio IVF cluster directory (seeded here):
+  identical audio in one cluster with matching duration merges into ONE catalogue
+  row and keeps its path; a different or unknown duration splits; and a track the
+  index does not cover - or a missing index entirely - merges nothing (fail-safe).
 * The verification gate ROLLS BACK a rewrite that violates its invariants, leaving
   the catalogue byte-for-byte as it was.
 * The embedding cascade is re-added even when no constraint existed to find.
@@ -71,7 +73,8 @@ _SCHEMA = [
     "CREATE TABLE map_projection_data (index_name VARCHAR(255) PRIMARY KEY, "
     "projection_data BYTEA NOT NULL, id_map_json TEXT NOT NULL, "
     "embedding_dimension INTEGER NOT NULL)",
-    "CREATE TABLE ivf_dir (name TEXT PRIMARY KEY, blob_data BYTEA NOT NULL)",
+    "CREATE TABLE ivf_dir (name TEXT PRIMARY KEY, blob_data BYTEA NOT NULL, "
+    "created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP)",
 ]
 
 _EMBEDDING_FK = (
@@ -139,6 +142,28 @@ def _build(conn, tracks, embedding_ddl=_EMBEDDING_FK):
                 (item_id, psycopg2.Binary(vector.astype(np.float32).tobytes())),
             )
     conn.commit()
+
+
+def _seed_ivf(conn, entries):
+    from tasks.paged_ivf import pack_directory
+    import config as cfg
+
+    item_ids = [item_id for item_id, _cell in entries]
+    id2cell = np.array([cell for _item_id, cell in entries], dtype=np.uint32)
+    n_cells = int(id2cell.max()) + 1 if id2cell.size else 1
+    centroids = np.zeros((n_cells, simhash.SIGNATURE_BITS), dtype=np.float32)
+    blob = pack_directory(centroids, id2cell, item_ids, simhash.SIGNATURE_BITS, 'angular')
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO ivf_dir (name, blob_data) VALUES (%s, %s) "
+            "ON CONFLICT (name) DO UPDATE SET blob_data = EXCLUDED.blob_data",
+            ('%s__ivf_dir' % cfg.INDEX_NAME, psycopg2.Binary(blob)),
+        )
+    conn.commit()
+
+
+def _seed_ivf_all(conn, tracks):
+    _seed_ivf(conn, [(item_id, 0) for item_id, _path, _vec in tracks])
 
 
 def _score(conn):
@@ -261,6 +286,7 @@ class TestRealCanonicalization:
             ('jf-3', '/music/Other/03.flac', _distinct_embedding(9)),
         ]
         _build(db, tracks)
+        _seed_ivf_all(db, tracks)
 
         result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
 
@@ -307,6 +333,7 @@ class TestRealCanonicalization:
             ('jf-3', '/music/Album/03.flac', same.copy()),
         ]
         _build(db, tracks)
+        _seed_ivf_all(db, tracks)
 
         result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
 
@@ -338,6 +365,7 @@ class TestRealCanonicalization:
             ('jf-2', '/music/Arrau/nocturne.flac', same.copy()),
         ]
         _build(db, tracks)
+        _seed_ivf_all(db, tracks)
 
         result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
 
@@ -360,6 +388,7 @@ class TestRealCanonicalization:
             ('jf-2', '/music/Best Of/07 Rio.flac', same.copy()),
         ]
         _build(db, tracks)
+        _seed_ivf_all(db, tracks)
 
         result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
 
@@ -367,6 +396,62 @@ class TestRealCanonicalization:
             "without durations nothing can be proven identical, so nothing merges"
         )
         assert len(_score(db)) == 2
+
+    def test_without_an_ivf_index_every_track_stays_unique(self, db, monkeypatch):
+        from tasks import fingerprint_canonicalize as fc
+
+        monkeypatch.setattr(
+            fc, '_fetch_provider_durations',
+            lambda source_id, conn: {'jf-1': 200.0, 'jf-2': 200.0},
+        )
+        same = _distinct_embedding(7)
+        tracks = [
+            ('jf-1', '/music/Album/01 Rio.flac', same),
+            ('jf-2', '/music/Best Of/07 Rio.flac', same.copy()),
+        ]
+        _build(db, tracks)
+
+        result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        assert result['duplicates'] == 0, (
+            "with no IVF index there are no clusters to compare, so nothing merges"
+        )
+        assert len(_score(db)) == 2
+        assert {p for p, _i, _f in _maps(db)} == {'jf-1', 'jf-2'}, "both files stay mapped"
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT count(*) FROM score s WHERE NOT EXISTS "
+                "(SELECT 1 FROM track_server_map t WHERE t.item_id = s.item_id)"
+            )
+            assert cur.fetchone()[0] == 0, "the fail-safe leaves no orphan"
+
+    def test_a_track_missing_from_the_ivf_index_stays_unique_while_others_merge(
+        self, db, monkeypatch
+    ):
+        from tasks import fingerprint_canonicalize as fc
+
+        monkeypatch.setattr(
+            fc, '_fetch_provider_durations',
+            lambda source_id, conn: {'jf-1': 200.0, 'jf-2': 200.0, 'jf-3': 200.0},
+        )
+        same = _distinct_embedding(7)
+        tracks = [
+            ('jf-1', '/music/Album/01.flac', same),
+            ('jf-2', '/music/Best Of/07.flac', same.copy()),
+            ('jf-3', '/music/Live/03.flac', same.copy()),
+        ]
+        _build(db, tracks)
+        _seed_ivf(db, [('jf-1', 0), ('jf-2', 0)])
+
+        result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        assert result['duplicates'] == 1, "the two indexed copies merge"
+        assert len(_score(db)) == 2, "jf-3 is not in the index, so it keeps its own id"
+        by_provider = {p: item for p, item, _f in _maps(db)}
+        assert by_provider['jf-1'] == by_provider['jf-2']
+        assert by_provider['jf-3'] != by_provider['jf-1'], (
+            "a track missing from the index is never merged"
+        )
 
     def test_a_rewrite_that_fails_its_own_checks_is_rolled_back(self, db, monkeypatch):
         """The point of no return. A rewrite that would commit a corrupt catalogue

--- a/test/integration/test_canonicalize_integration.py
+++ b/test/integration/test_canonicalize_integration.py
@@ -538,6 +538,64 @@ class TestRealCanonicalization:
             "the fp_0 row never re-triggers the migration"
         )
 
+    def test_unsignable_fp0_uses_the_source_servers_provider_id_when_mapped(self, db):
+        from tasks import fingerprint_canonicalize as fc
+
+        flat = np.full(simhash.SIGNATURE_BITS, 0.5, dtype=np.float32)
+        tracks = [
+            ('old-key', '/music/T/tone.flac', flat),
+            ('jf-1', '/music/A/song.flac', _distinct_embedding(1)),
+        ]
+        _build(db, tracks)
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO track_server_map "
+                "(item_id, server_id, provider_track_id, match_tier) "
+                "VALUES ('old-key', 'srv', 'nav-123', 'default')"
+            )
+        db.commit()
+
+        fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        expected = simhash.unsignable_canonical_id('srv', 'nav-123')
+        maps = {p: item for p, item, _f in _maps(db)}
+        assert maps['nav-123'] == expected, (
+            "the fp_0 id is minted from the server's REAL provider id, not the "
+            "legacy score key, so a later re-analysis resolves to the same row"
+        )
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT match_tier FROM track_server_map "
+                "WHERE provider_track_id = 'nav-123'"
+            )
+            assert cur.fetchone()[0] == 'analysis'
+        second = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+        assert second == {'relabelled': 0, 'duplicates': 0}
+
+    def test_relabel_preserves_an_existing_provider_migration_tier(self, db):
+        from tasks import fingerprint_canonicalize as fc
+
+        tracks = [('jf-1', '/music/A/song.flac', _distinct_embedding(1))]
+        _build(db, tracks)
+        with db.cursor() as cur:
+            cur.execute(
+                "INSERT INTO track_server_map "
+                "(item_id, server_id, provider_track_id, match_tier) "
+                "VALUES ('jf-1', 'srv', 'jf-1', 'exact')"
+            )
+        db.commit()
+
+        fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT match_tier FROM track_server_map "
+                "WHERE provider_track_id = 'jf-1'"
+            )
+            assert cur.fetchone()[0] == 'exact', (
+                "a signable row's relabel must not clobber the stored match tier"
+            )
+
     def test_a_rewrite_that_fails_its_own_checks_is_rolled_back(self, db, monkeypatch):
         """The point of no return. A rewrite that would commit a corrupt catalogue
         must instead leave it byte-for-byte unchanged and fail the boot loudly."""

--- a/test/integration/test_canonicalize_integration.py
+++ b/test/integration/test_canonicalize_integration.py
@@ -453,6 +453,91 @@ class TestRealCanonicalization:
             "a track missing from the index is never merged"
         )
 
+    def test_unsignable_embeddings_never_propose_or_receive_merges(self, db):
+        from tasks import fingerprint_canonicalize as fc
+
+        flat = np.full(simhash.SIGNATURE_BITS, 0.5, dtype=np.float32)
+        near_flat = flat.copy()
+        near_flat[0] += 1e-3
+        same = _distinct_embedding(7)
+        tracks = [
+            ('jf-flat', '/music/A/tone.flac', flat),
+            ('jf-nearflat', '/music/B/tone2.flac', near_flat),
+            ('jf-r1', '/music/C/song.flac', same),
+            ('jf-r2', '/music/D/song.flac', same.copy()),
+        ]
+        _build(db, tracks)
+        _seed_ivf_all(db, tracks)
+        with db.cursor() as cur:
+            cur.execute("UPDATE score SET duration = 200.0")
+        db.commit()
+
+        ids = [item_id for item_id, _path, _vec in tracks]
+        valid = np.array(
+            [simhash.embedding_signature(vec) is not None for _i, _p, vec in tracks]
+        )
+        assert not valid[0], "precondition: a constant embedding has no signature"
+        assert valid[1:].all()
+
+        with db.cursor() as cur:
+            left, right = fc._ivf_candidate_pairs(cur, ids, valid, len(ids), {}, 'srv')
+
+        pairs = set(zip(left.tolist(), right.tolist()))
+        assert pairs == {(2, 3)}, (
+            "only the two real copies pair; the signatureless constant embedding "
+            "proposes nothing and receives nothing, even though its cosine to the "
+            "near-constant track is ~1.0"
+        )
+
+    def test_a_constant_embedding_row_migrates_to_fp0_and_cannot_brick_the_boot(
+        self, db, monkeypatch
+    ):
+        from tasks import fingerprint_canonicalize as fc
+
+        monkeypatch.setattr(
+            fc, '_fetch_provider_durations',
+            lambda source_id, conn: {'jf-flat': 90.0, 'jf-1': 200.0, 'jf-2': 200.0},
+        )
+        flat = np.full(simhash.SIGNATURE_BITS, 0.5, dtype=np.float32)
+        same = _distinct_embedding(7)
+        tracks = [
+            ('jf-flat', '/music/T/tone.flac', flat),
+            ('jf-1', '/music/A/song.flac', same),
+            ('jf-2', '/music/B/song.flac', same.copy()),
+        ]
+        _build(db, tracks)
+        _seed_ivf_all(db, tracks)
+
+        result = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+
+        assert result['relabelled'] == 3
+        assert result['duplicates'] == 1
+        expected = simhash.unsignable_canonical_id('srv', 'jf-flat')
+        assert expected.startswith('fp_0')
+        maps = {p: item for p, item, _f in _maps(db)}
+        assert maps['jf-flat'] == expected, (
+            "the signatureless track gets the SAME server-scoped fp_0 id "
+            "analysis would mint for it"
+        )
+        assert maps['jf-1'] == maps['jf-2'], "the real duplicate still merges"
+        with db.cursor() as cur:
+            cur.execute(
+                "SELECT match_tier FROM track_server_map "
+                "WHERE provider_track_id = 'jf-flat'"
+            )
+            assert cur.fetchone()[0] == 'analysis', (
+                "the analysis tier is what exempts fp_0 rows from the legacy count"
+            )
+            cur.execute(
+                "SELECT count(*) FROM embedding WHERE item_id = %s", (expected,)
+            )
+            assert cur.fetchone()[0] == 1, "its analysis rows follow the relabel"
+
+        second = fc.canonicalize_fingerprinted_ids(conn=db, source_server_id='srv')
+        assert second == {'relabelled': 0, 'duplicates': 0}, (
+            "the fp_0 row never re-triggers the migration"
+        )
+
     def test_a_rewrite_that_fails_its_own_checks_is_rolled_back(self, db, monkeypatch):
         """The point of no return. A rewrite that would commit a corrupt catalogue
         must instead leave it byte-for-byte unchanged and fail the boot loudly."""

--- a/test/integration/test_duplicate_repair_integration.py
+++ b/test/integration/test_duplicate_repair_integration.py
@@ -501,3 +501,83 @@ class TestChromaprintCleanup:
         db.commit()
         # The group is now unmapped, so it is no longer a duplicate group to check.
         assert dr.split_chromaprint_false_merges(conn=db) == {'split': 0, 'removed': 0}
+
+
+class TestOrphanPurge:
+    def test_orphans_are_deleted_mapped_rows_and_chromaprints_survive(self, db):
+        from tasks import duplicate_repair as dr
+
+        mapped = _fp_id('m')
+        orphan1 = _fp_id('o')
+        orphan2 = _fp_id('p')
+        with db.cursor() as cur:
+            _seed_group(cur, mapped, ['pm'])
+            for orphan in (orphan1, orphan2):
+                cur.execute(
+                    "INSERT INTO score (item_id, title) VALUES (%s, %s)",
+                    (orphan, orphan),
+                )
+                cur.execute(
+                    "INSERT INTO embedding (item_id, embedding) VALUES (%s, %s)",
+                    (orphan, b'\x00\x00'),
+                )
+            cur.execute(
+                "INSERT INTO chromaprint (server_id, provider_track_id, fingerprint) "
+                "VALUES ('srv', 'porphan', %s)",
+                (b'\x01\x02',),
+            )
+        db.commit()
+
+        result = dr.purge_orphan_catalogue_rows(conn=db)
+        db.commit()
+
+        assert result == {'purged': 2}
+        with db.cursor() as cur:
+            cur.execute("SELECT item_id FROM score ORDER BY item_id")
+            assert [row[0] for row in cur.fetchall()] == [mapped], (
+                "only the row bound to no server is deleted"
+            )
+            cur.execute("SELECT count(*) FROM embedding")
+            assert cur.fetchone()[0] == 1, "orphan embeddings cascade away"
+            cur.execute("SELECT count(*) FROM chromaprint")
+            assert cur.fetchone()[0] == 1, "per-file Chromaprints are kept for reuse"
+
+        assert dr.purge_orphan_catalogue_rows(conn=db) == {'purged': 0}, (
+            "a second run finds nothing to purge"
+        )
+
+    def test_path_b_false_merge_orphan_is_cleared_by_the_migration_purge(
+        self, db, monkeypatch
+    ):
+        from tasks import duplicate_repair as dr
+
+        real = _fp_id('a')
+        false = _fp_id('b')
+        with db.cursor() as cur:
+            _seed_group(cur, real, ['pr1', 'pr2'])
+            _seed_group(cur, false, ['pf1', 'pf2'])
+        db.commit()
+
+        _run(db, monkeypatch, {'pr1': 200.0, 'pr2': 201.0, 'pf1': 120.0, 'pf2': 240.0})
+        db.commit()
+
+        def _orphans():
+            with db.cursor() as cur:
+                cur.execute(
+                    "SELECT count(*) FROM score s WHERE NOT EXISTS "
+                    "(SELECT 1 FROM track_server_map t WHERE t.item_id = s.item_id)"
+                )
+                return cur.fetchone()[0]
+
+        assert _orphans() == 1, "Path B unmaps the false merge, leaving it an orphan"
+
+        result = dr.purge_orphan_catalogue_rows(conn=db)
+        db.commit()
+
+        assert result == {'purged': 1}
+        assert _orphans() == 0, "the migration purge leaves no orphan"
+        with db.cursor() as cur:
+            cur.execute("SELECT count(*) FROM score")
+            assert cur.fetchone()[0] == 1, "only the real duplicate survives"
+            cur.execute("SELECT count(*) FROM embedding")
+            assert cur.fetchone()[0] == 1, "the orphan's embedding cascaded away"

--- a/test/unit/test_catalogue_is_never_deleted.py
+++ b/test/unit/test_catalogue_is_never_deleted.py
@@ -16,17 +16,21 @@ catalogue, and is hidden from that server's results by the availability filter; 
 later sweep re-binds it with no re-analysis. Removing a server or migrating
 providers change only `track_server_map`.
 
-Two deleters are sanctioned, and both only remove a row whose audio is gone from
+Three deleters are sanctioned, and each only removes a row whose audio is gone from
 every library or already preserved elsewhere:
 * the fingerprint canonicalizer's duplicate MERGE, which folds a row into the
   canonical row that already holds the same audio's analysis (nothing lost);
 * the cleaning pass, which deletes a row bound to NO server (an orphan) - the file
   is gone from every library, so the analysis is re-created if it ever returns -
   and only when every server was read completely, so an incomplete view can never
-  delete a track still on a server.
+  delete a track still on a server;
+* the migration orphan purge, which runs only after a migration and deletes only
+  rows bound to NO server (false-merge splits plus pre-existing orphans), so the
+  catalogue is left clean and each deleted track re-analyzes under its own id.
 
 Main Features:
-* Only the canonicalizer merge and the cleaning orphan-delete may DELETE FROM score
+* Only the canonicalizer merge, the cleaning orphan-delete and the migration orphan
+  purge may DELETE FROM score
 * embedding / clap_embedding / lyrics_embedding cascade from score, so they are
   covered by the same rule
 """
@@ -44,11 +48,13 @@ _SKIP_DIRS = {
 }
 
 # The sanctioned deleters: the canonicalizer's duplicate merge (deletes a row only
-# after folding it into the canonical row for the same audio), and the cleaning pass
-# (deletes only orphans bound to no server, and only on a complete server view).
+# after folding it into the canonical row for the same audio), the cleaning pass
+# (deletes only orphans bound to no server, and only on a complete server view), and
+# the migration orphan purge (deletes only rows bound to no server, migration-only).
 _SANCTIONED = {
     'tasks/fingerprint_canonicalize.py': 'duplicate merge into the canonical row',
     'tasks/cleaning.py': 'orphan delete: tracks bound to no server, complete view only',
+    'tasks/duplicate_repair.py': 'migration orphan purge: rows bound to no server',
 }
 
 _DELETE_SCORE = re.compile(r'DELETE\s+FROM\s+score\b', re.IGNORECASE)

--- a/test/unit/test_multi_server.py
+++ b/test/unit/test_multi_server.py
@@ -781,9 +781,23 @@ def _legacy_cursor(legacy_rows, canonical_rows=()):
     hash their signatures a batch at a time, then fetches embeddings BACK for
     the candidate pairs it asks the cosine to confirm.
     """
+    import numpy as np
+    from tasks import simhash as _sh
+    from tasks.paged_ivf import pack_directory
+
     canonical_rows = list(canonical_rows)
     legacy_rows = list(legacy_rows)
     blobs = {str(item_id): blob for item_id, blob in canonical_rows + legacy_rows}
+
+    all_ids = list(blobs.keys())
+    ivf_blob = (
+        pack_directory(
+            np.zeros((1, _sh.SIGNATURE_BITS), dtype=np.float32),
+            np.zeros(len(all_ids), dtype=np.uint32),
+            all_ids, _sh.SIGNATURE_BITS, 'angular',
+        )
+        if all_ids else None
+    )
 
     class ScanCursor:
         def __init__(self, rows):
@@ -802,10 +816,24 @@ def _legacy_cursor(legacy_rows, canonical_rows=()):
     class FetchCursor:
         def __init__(self):
             self._rows = []
+            self._one = None
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
 
         def execute(self, sql, params=None):
+            if 'ivf_dir' in sql:
+                self._one = (ivf_blob,) if ('name = %s' in sql and ivf_blob) else None
+                self._rows = []
+                return
             wanted = list(params[0]) if params else []
             self._rows = [(i, blobs[i]) for i in wanted if i in blobs]
+
+        def fetchone(self):
+            return self._one
 
         def fetchall(self):
             return self._rows

--- a/test/unit/test_simhash.py
+++ b/test/unit/test_simhash.py
@@ -109,6 +109,19 @@ class TestCanonicalId:
         assert simhash.is_fingerprint_id('fp_' + 'a' * 16)
         assert not simhash.is_fingerprint_id('plain')
 
+    def test_unsignable_ids_are_scheme_zero_and_never_decode_as_signatures(self):
+        fp0 = simhash.unsignable_canonical_id('srv', 'track-1')
+        assert simhash.is_unsignable_id(fp0)
+        assert simhash.is_fingerprint_id(fp0)
+        assert not simhash.is_signature_id(fp0)
+        assert simhash.signature_from_canonical_id(fp0) is None
+        signature_id = simhash.canonical_id_str(
+            simhash.embedding_signature(_embedding(9))
+        )
+        assert not simhash.is_unsignable_id(signature_id)
+        assert not simhash.is_unsignable_id(fp0[:-1])
+        assert not simhash.is_unsignable_id(None)
+
 
 class TestSignatureIndex:
     def test_finds_exact_and_near(self):

--- a/test/unit/test_simhash.py
+++ b/test/unit/test_simhash.py
@@ -121,6 +121,7 @@ class TestCanonicalId:
         assert not simhash.is_unsignable_id(signature_id)
         assert not simhash.is_unsignable_id(fp0[:-1])
         assert not simhash.is_unsignable_id(None)
+        assert simhash.is_unsignable_id('fp_0' + 'a' * 50)
 
 
 class TestSignatureIndex:

--- a/test/unit/test_worker_reregistration.py
+++ b/test/unit/test_worker_reregistration.py
@@ -19,6 +19,9 @@ Main Features:
 * A heartbeat re-adds the worker to rq:workers and rq:workers:<queue> and restores
   the identity hash (birth/hostname/queues) when the key came back partial.
 * Re-registration is idempotent and does not rewrite the hash during normal beats.
+* Nothing is ever queued into rq's own heartbeat pipeline: rq 2.7.0 reads that
+  pipeline's results by fixed index, and an injected command would make it delete
+  the running job's key.
 """
 
 import types
@@ -148,12 +151,37 @@ def test_heartbeat_reregistration_is_idempotent_when_already_registered(worker_c
 
 
 @pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
-def test_pipeline_heartbeat_queues_reregistration_without_restore(worker_cls):
+def test_pipelined_heartbeat_never_queues_into_rqs_pipeline(worker_cls):
     worker, fake = _make_worker(worker_cls)
     fake.hashes[worker.key] = {'last_heartbeat': 'stale'}
     fake.sets['rq:workers'] = set()
+    pipe = FakeRedis()
 
-    worker.heartbeat(pipeline=fake)
+    worker.heartbeat(pipeline=pipe)
 
+    assert pipe.sets == {}, (
+        "rq 2.7.0 reads maintain_heartbeats pipeline results by FIXED index "
+        "(results[7] = job.heartbeat); an injected command would shift it onto an "
+        "EXPIRE and delete the running job's key every monitor beat"
+    )
+    assert set(pipe.hashes.get(worker.key, {})) <= {'last_heartbeat'}
     assert worker.key in fake.smembers('rq:workers')
-    assert 'birth' not in fake.hashes[worker.key]
+    assert worker.key in fake.smembers('rq:workers:default')
+
+
+@pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
+def test_pipelined_heartbeat_still_restores_identity_on_the_raw_connection(worker_cls):
+    worker, fake = _make_worker(worker_cls)
+    fake.hashes[worker.key] = {'last_heartbeat': 'stale'}
+    fake.sets['rq:workers'] = set()
+    pipe = FakeRedis()
+
+    worker.heartbeat(pipeline=pipe)
+
+    restored = fake.hashes[worker.key]
+    assert restored.get('birth')
+    assert restored.get('queues') == 'default'
+    assert fake.ttls.get(worker.key), (
+        "the recreated key must carry a TTL so a dead worker cannot leave a "
+        "zombie key behind"
+    )

--- a/test/unit/test_worker_reregistration.py
+++ b/test/unit/test_worker_reregistration.py
@@ -1,0 +1,159 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""Issue #784: a worker deregistered by a transient Redis outage rejoins on heartbeat.
+
+When Redis is unreachable longer than the worker-key TTL, the key expires,
+clean_worker_registry SREMs the worker from rq:workers, and on reconnect the
+heartbeat recreates only a partial hash - historically the live worker kept taking
+jobs while invisible to the dashboard. These tests drive the real worker classes
+against an in-memory Redis stand-in and assert the heartbeat re-registers.
+
+Main Features:
+* Both the forking Worker and the Windows SimpleWorker carry the mixin and rejoin.
+* A heartbeat re-adds the worker to rq:workers and rq:workers:<queue> and restores
+  the identity hash (birth/hostname/queues) when the key came back partial.
+* Re-registration is idempotent and does not rewrite the hash during normal beats.
+"""
+
+import types
+
+import pytest
+from rq.utils import now
+
+import rq_heartbeat_worker as rhw
+
+
+class FakeRedis:
+    def __init__(self):
+        self.hashes = {}
+        self.sets = {}
+        self.ttls = {}
+        self.connection_pool = types.SimpleNamespace(connection_kwargs={})
+
+    def hset(self, name, key=None, value=None, mapping=None):
+        h = self.hashes.setdefault(name, {})
+        added = 0
+        if mapping:
+            for k, v in mapping.items():
+                if k not in h:
+                    added += 1
+                h[k] = '' if v is None else str(v)
+        if key is not None:
+            if key not in h:
+                added += 1
+            h[key] = '' if value is None else str(value)
+        return added
+
+    def hexists(self, name, key):
+        return key in self.hashes.get(name, {})
+
+    def sadd(self, name, *members):
+        s = self.sets.setdefault(name, set())
+        before = len(s)
+        s.update(members)
+        return len(s) - before
+
+    def srem(self, name, *members):
+        s = self.sets.setdefault(name, set())
+        before = len(s)
+        for m in members:
+            s.discard(m)
+        return before - len(s)
+
+    def smembers(self, name):
+        return set(self.sets.get(name, set()))
+
+    def scard(self, name):
+        return len(self.sets.get(name, set()))
+
+    def exists(self, *keys):
+        return sum(1 for k in keys if k in self.hashes or k in self.sets)
+
+    def expire(self, name, ttl):
+        self.ttls[name] = ttl
+        return 1
+
+    def delete(self, *keys):
+        removed = 0
+        for k in keys:
+            if k in self.hashes:
+                del self.hashes[k]
+                removed += 1
+            if k in self.sets:
+                del self.sets[k]
+                removed += 1
+        return removed
+
+
+def _make_worker(worker_cls):
+    fake = FakeRedis()
+    worker = worker_cls(
+        ['default'],
+        connection=fake,
+        prepare_for_work=False,
+        worker_ttl=120,
+        job_monitoring_interval=30,
+        name='w784',
+    )
+    worker.birth_date = now()
+    worker.last_heartbeat = now()
+    worker.hostname = 'testhost'
+    worker.pid = 4321
+    worker.ip_address = '10.0.0.9'
+    return worker, fake
+
+
+@pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
+def test_partial_key_after_outage_rejoins_registry_on_heartbeat(worker_cls):
+    worker, fake = _make_worker(worker_cls)
+    fake.hashes[worker.key] = {'last_heartbeat': 'stale', 'successful_job_count': '400'}
+    fake.sets['rq:workers'] = set()
+
+    worker.heartbeat()
+
+    assert worker.key in fake.smembers('rq:workers')
+    assert worker.key in fake.smembers('rq:workers:default')
+
+
+@pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
+def test_partial_key_identity_hash_is_restored_on_heartbeat(worker_cls):
+    worker, fake = _make_worker(worker_cls)
+    fake.hashes[worker.key] = {'last_heartbeat': 'stale', 'successful_job_count': '400'}
+    fake.sets['rq:workers'] = set()
+
+    worker.heartbeat()
+
+    restored = fake.hashes[worker.key]
+    assert restored.get('birth')
+    assert restored.get('hostname') == 'testhost'
+    assert restored.get('queues') == 'default'
+
+
+@pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
+def test_heartbeat_reregistration_is_idempotent_when_already_registered(worker_cls):
+    worker, fake = _make_worker(worker_cls)
+    fake.hashes[worker.key] = {'birth': 'ORIGINAL', 'last_heartbeat': 'stale'}
+    fake.sets['rq:workers'] = {worker.key}
+
+    worker.heartbeat()
+
+    assert fake.scard('rq:workers') == 1
+    assert fake.hashes[worker.key]['birth'] == 'ORIGINAL'
+
+
+@pytest.mark.parametrize('worker_cls', [rhw.ReregisteringWorker, rhw.HeartbeatSimpleWorker])
+def test_pipeline_heartbeat_queues_reregistration_without_restore(worker_cls):
+    worker, fake = _make_worker(worker_cls)
+    fake.hashes[worker.key] = {'last_heartbeat': 'stale'}
+    fake.sets['rq:workers'] = set()
+
+    worker.heartbeat(pipeline=fake)
+
+    assert worker.key in fake.smembers('rq:workers')
+    assert 'birth' not in fake.hashes[worker.key]


### PR DESCRIPTION
This PR is to fix and improve migration by:

- Avoid OOM during migration by using the already computed IVF - #777 
- Automatically removing false orphan created by migration, without the need of extra clenaing phase - #773

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30099868017/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29720153230/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29720153230/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29720153230/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/29720153230/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30101497853/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-792`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-792-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-792-noavx2`
<!-- pr-test-build:end -->