### PR TITLE
Menu fix

### DIFF
--- a/app.py
+++ b/app.py
@@ -171,6 +171,22 @@ def inject_globals():
             plugin_menu_items.append({**item, 'url': item_url})
     except Exception:
         plugin_menu_items = []
+    # Sidebar server picker, rendered server-side so it paints with the page
+    # instead of popping in at DOMContentLoaded. Credentials are never included.
+    nav_music_servers = None
+    try:
+        payload = app_server_context.servers_for_ui()
+        nav_music_servers = {
+            'multi_server_enabled': bool(payload.get('multi_server_enabled')),
+            'default_id': payload.get('default_id'),
+            'servers': [
+                {'server_id': s['server_id'], 'name': s['name'], 'is_default': s['is_default']}
+                for s in payload.get('servers', [])
+            ],
+        }
+    except Exception:
+        logger.exception("Could not build the sidebar server picker data")
+        nav_music_servers = None
     return dict(
         app_version=APP_VERSION,
         clap_enabled=CLAP_ENABLED,
@@ -180,6 +196,7 @@ def inject_globals():
         is_admin=(auth_role == 'admin'),
         current_user=current_user,
         plugin_menu_items=plugin_menu_items,
+        nav_music_servers=nav_music_servers,
     )
 
 

--- a/static/menu.js
+++ b/static/menu.js
@@ -118,26 +118,6 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
 
-    // Donate button
-    const donateLink = document.createElement('a');
-    donateLink.className = 'donate-button';
-    donateLink.href = 'https://liberapay.com/NeptuneHub/donate';
-    donateLink.target = '_blank';
-    donateLink.rel = 'noopener noreferrer';
-    donateLink.setAttribute('aria-label', 'Donate to AudioMuse-AI');
-    donateLink.innerHTML = '<svg class="donate-heart" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg><span>Donate</span>';
-    sidebar.appendChild(donateLink);
-
-    // Display App Version from meta tag
-    const versionMeta = document.querySelector('meta[name="app-version"]');
-    if (versionMeta && versionMeta.content) {
-        const appVersion = versionMeta.content;
-        const versionElement = document.createElement('div');
-        versionElement.className = 'app-version'; // For styling
-        versionElement.textContent = `AudioMuse-AI - ${appVersion}`;
-        sidebar.appendChild(versionElement);
-    }
-
     /* --- Dark Mode Logic --- */
     const darkModeToggle = document.getElementById('dark-mode-toggle');
     const body = document.body;

--- a/static/server_selector.js
+++ b/static/server_selector.js
@@ -180,30 +180,62 @@
         window.location.reload();
     }
 
-    function load() {
-        chainedFetch.call(window, '/api/servers', { headers: { 'Accept': 'application/json' } })
+    function setState(data) {
+        state.loaded = true;
+        if (!data) {
+            // Not authenticated or endpoint unavailable; leave UI untouched
+            // and stop the optimistic pre-load injection (fail-safe).
+            return false;
+        }
+        state.enabled = !!data.multi_server_enabled;
+        state.servers = data.servers || [];
+        state.defaultId = data.default_id;
+        var current = selectedId();
+        if (current && !state.servers.some(function (s) { return s.server_id === current; })) {
+            localStorage.removeItem(STORAGE_KEY);
+        }
+        return true;
+    }
+
+    function applyDom() {
+        document.body.classList.toggle('multi-server', state.servers.length >= 2);
+        render();
+        renderScopeChip();
+    }
+
+    function inlineData() {
+        var el = document.getElementById('server-selector-data');
+        if (!el) {
+            return null;
+        }
+        try {
+            return JSON.parse(el.textContent);
+        } catch (e) {
+            return null;
+        }
+    }
+
+    // The page embeds the server list as JSON right above this script, so the
+    // picker data is known synchronously at parse time and no /api/servers
+    // request is needed. Pages without the JSON (login, errors) fall back to
+    // the fetch, started immediately so it overlaps document parsing.
+    var inline = inlineData();
+    var ready;
+    if (inline !== null) {
+        ready = Promise.resolve(setState(inline));
+    } else {
+        ready = chainedFetch.call(window, '/api/servers', { headers: { 'Accept': 'application/json' } })
             .then(function (r) { return r.ok ? r.json() : null; })
-            .then(function (data) {
-                state.loaded = true;
-                if (!data) {
-                    return;
-                }
-                state.enabled = !!data.multi_server_enabled;
-                state.servers = data.servers || [];
-                state.defaultId = data.default_id;
-                var current = selectedId();
-                if (current && !state.servers.some(function (s) { return s.server_id === current; })) {
-                    localStorage.removeItem(STORAGE_KEY);
-                }
-                document.body.classList.toggle('multi-server', state.servers.length >= 2);
-                render();
-                renderScopeChip();
-            })
-            .catch(function () {
-                // Not authenticated or endpoint unavailable; leave UI untouched
-                // and stop the optimistic pre-load injection (fail-safe).
-                state.loaded = true;
-            });
+            .catch(function () { return null; })
+            .then(setState);
+    }
+
+    function load() {
+        ready.then(function (ok) {
+            if (ok) {
+                applyDom();
+            }
+        });
     }
 
     if (document.readyState === 'loading') {

--- a/static/server_selector.js
+++ b/static/server_selector.js
@@ -102,7 +102,8 @@
             return;
         }
         var current = selectedId() || state.defaultId || '';
-        var html = '<select id="server-selector" class="server-selector" aria-label="Music server">';
+        var html = '<label for="server-selector" class="sr-only">Music server</label>'
+            + '<select id="server-selector" class="server-selector">';
         state.servers.forEach(function (s) {
             var label = s.name + (s.is_default ? ' (default)' : '');
             var sel = (s.server_id === current) ? ' selected' : '';
@@ -204,7 +205,7 @@
     }
 
     function inlineData() {
-        var el = document.getElementById('server-selector-data');
+        const el = document.getElementById('server-selector-data');
         if (!el) {
             return null;
         }
@@ -219,8 +220,8 @@
     // picker data is known synchronously at parse time and no /api/servers
     // request is needed. Pages without the JSON (login, errors) fall back to
     // the fetch, started immediately so it overlaps document parsing.
-    var inline = inlineData();
-    var ready;
+    const inline = inlineData();
+    let ready;
     if (inline !== null) {
         ready = Promise.resolve(setState(inline));
     } else {

--- a/static/style.css
+++ b/static/style.css
@@ -758,6 +758,20 @@ html.dark-mode button:not(.btn):disabled {
     overflow-wrap: break-word;
 }
 
+.app-version .app-version-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.app-version .app-version-link:hover {
+    text-decoration: underline;
+}
+
+.app-version .github-icon {
+    vertical-align: text-bottom;
+    margin-right: 0.35rem;
+}
+
 /* --- Utility --- */
 .hidden {
     display: none !important;

--- a/static/style.css
+++ b/static/style.css
@@ -777,6 +777,19 @@ html.dark-mode button:not(.btn):disabled {
     display: none !important;
 }
 
+/* Visually hidden but still read by screen readers (labels for compact controls). */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 /* --- Styles for Chat & Similarity Pages --- */
 
 /* General page header for chat/similarity */

--- a/templates/includes/layout.html
+++ b/templates/includes/layout.html
@@ -32,7 +32,9 @@
 
     <!-- Loaded in <head> so the server-selector fetch wrapper is installed before
          any page script can issue an /api request (every call must be scoped to the
-         selected server). -->
+         selected server). The JSON above it hands the script the server list with
+         the page itself, so no /api/servers round trip is needed after load. -->
+    {% if nav_music_servers %}<script type="application/json" id="server-selector-data">{{ nav_music_servers|tojson }}</script>{% endif %}
     <script src="{{ url_for('static', filename='server_selector.js') }}"></script>
 
     {% block headAdditions %}
@@ -49,6 +51,8 @@
                     {% endwith %}
                 </ul>
             </nav>
+            <a class="donate-button" href="https://liberapay.com/NeptuneHub/donate" target="_blank" rel="noopener noreferrer" aria-label="Donate to AudioMuse-AI"><svg class="donate-heart" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg><span>Donate</span></a>
+            {% if app_version %}<div class="app-version"><a class="app-version-link" href="https://github.com/NeptuneHub/AudioMuse-AI/releases/tag/{{ app_version if app_version.startswith('v') else 'v' ~ app_version }}" target="_blank" rel="noopener noreferrer"><svg class="github-icon" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true"><path fill="currentColor" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.06-1.86 3.75-3.64 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>AudioMuse-AI - {{ app_version }}</a></div>{% endif %}
         </aside>
 
         <div class="main-content" id="main-content">

--- a/templates/sidebar_navi.html
+++ b/templates/sidebar_navi.html
@@ -56,5 +56,14 @@
 </li>
 {% endif %}
 {% if setup_saved %}
-<li id="server-selector-nav" class="server-selector-nav" aria-live="polite"></li>
+{% set nav_pickable = nav_music_servers and nav_music_servers.multi_server_enabled and nav_music_servers.servers|length >= 2 %}
+<li id="server-selector-nav" class="server-selector-nav{% if nav_pickable %} active{% endif %}" aria-live="polite">
+    {%- if nav_pickable -%}
+    <select id="server-selector" class="server-selector" aria-label="Music server">
+        {%- for s in nav_music_servers.servers -%}
+        <option value="{{ s.server_id }}"{% if s.is_default %} selected{% endif %}>{{ s.name }}{% if s.is_default %} (default){% endif %}</option>
+        {%- endfor -%}
+    </select>
+    {%- endif -%}
+</li>
 {% endif %}

--- a/templates/sidebar_navi.html
+++ b/templates/sidebar_navi.html
@@ -59,7 +59,8 @@
 {% set nav_pickable = nav_music_servers and nav_music_servers.multi_server_enabled and nav_music_servers.servers|length >= 2 %}
 <li id="server-selector-nav" class="server-selector-nav{% if nav_pickable %} active{% endif %}" aria-live="polite">
     {%- if nav_pickable -%}
-    <select id="server-selector" class="server-selector" aria-label="Music server">
+    <label for="server-selector" class="sr-only">Music server</label>
+    <select id="server-selector" class="server-selector">
         {%- for s in nav_music_servers.servers -%}
         <option value="{{ s.server_id }}"{% if s.is_default %} selected{% endif %}>{{ s.name }}{% if s.is_default %} (default){% endif %}</option>
         {%- endfor -%}


### PR DESCRIPTION
What: The sidebar version now links to its GitHub release page, with a small GitHub icon (underline-only hover).

Fix 1: Donate button and version line were created by JavaScript after every page script finished loading, so they appeared ~1s after the menu links. They're now plain HTML rendered by the server - they paint instantly.

Fix 2: The server picker was hidden until JavaScript activated it, then pushed donate/version down - looking like the whole block "reloaded". Flask now renders the picker directly into the page with its data embedded, so nothing waits, jumps, and the per-page /api/servers call is gone.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30350734422/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30306669888/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30306669888/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30306669888/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30306669888/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30350734478/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-816`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-816-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-816-noavx2`
<!-- pr-test-build:end -->