### PR TITLE
DB Write sanitizer

### DIFF
--- a/database.py
+++ b/database.py
@@ -1554,6 +1554,7 @@ def init_db():
             _seed_registry_from_legacy_config(cur)
             _drop_unconfigured_servers(cur)
             _migrate_artist_mapping_to_server_map(cur)
+            _scrub_control_chars_from_map_ids(cur)
             _migrate_playlist_server_column(cur)
             removed_media_keys = purge_media_keys_from_app_config(cur)
             if removed_media_keys:
@@ -1629,6 +1630,57 @@ def _migrate_file_path_to_track_server_map(cur):
             "Moved %d file path(s) onto the default server's map rows and cleared "
             "%d shared score.file_path value(s).", moved, cleared,
         )
+
+
+_MAP_ID_SCRUB_MARKER = 'map_id_c0_scrub_v1'
+
+
+def _scrub_control_chars_from_map_ids(cur):
+    cur.execute("SELECT 1 FROM app_config WHERE key = %s", (_MAP_ID_SCRUB_MARKER,))
+    if cur.fetchone():
+        return
+    controls = ''.join(
+        chr(c) for c in (*range(0x01, 0x09), 0x0B, 0x0C, *range(0x0E, 0x20))
+    )
+    klass = '[' + controls + ']'
+    cur.execute(
+        "DELETE FROM track_server_map t WHERE t.provider_track_id ~ %s AND ("
+        "regexp_replace(t.provider_track_id, %s, '', 'g') = '' "
+        "OR EXISTS (SELECT 1 FROM track_server_map c WHERE c.server_id = t.server_id "
+        "AND c.provider_track_id = regexp_replace(t.provider_track_id, %s, '', 'g')) "
+        "OR t.provider_track_id > (SELECT MIN(d.provider_track_id) FROM track_server_map d "
+        "WHERE d.server_id = t.server_id AND d.provider_track_id ~ %s "
+        "AND regexp_replace(d.provider_track_id, %s, '', 'g') = "
+        "regexp_replace(t.provider_track_id, %s, '', 'g')))",
+        (klass, klass, klass, klass, klass, klass),
+    )
+    dropped = cur.rowcount
+    cur.execute(
+        "UPDATE track_server_map SET provider_track_id = "
+        "regexp_replace(provider_track_id, %s, '', 'g'), updated_at = now() "
+        "WHERE provider_track_id ~ %s",
+        (klass, klass),
+    )
+    rewritten = cur.rowcount
+    cur.execute(
+        "DELETE FROM artist_server_map WHERE artist_name ~ %s OR provider_artist_id ~ %s",
+        (klass, klass),
+    )
+    artist_rows = cur.rowcount
+    cur.execute("DELETE FROM chromaprint WHERE provider_track_id ~ %s", (klass,))
+    chroma_rows = cur.rowcount
+    if dropped or rewritten or artist_rows or chroma_rows:
+        logger.warning(
+            "Scrubbed control characters from legacy map rows: %d track map ids "
+            "rewritten, %d colliding/empty track rows dropped, %d artist rows and "
+            "%d chromaprint rows removed (they re-populate on the next sweep/analysis)",
+            rewritten, dropped, artist_rows, chroma_rows,
+        )
+    cur.execute(
+        "INSERT INTO app_config (key, value) VALUES (%s, %s) "
+        "ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value",
+        (_MAP_ID_SCRUB_MARKER, 'done'),
+    )
 
 
 def _ensure_track_server_map_key(cur):

--- a/database.py
+++ b/database.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 
 from tz_helper import UTC_NOW_SQL
 
-from sanitization import sanitize_db_field
+from sanitization import sanitize_db_field, sanitize_string_for_db
 
 from config import (
     TASK_STATUS_PENDING,
@@ -761,7 +761,7 @@ def persist_chromaprint(server_id, provider_track_id, fingerprint):
             "VALUES (%s, %s, %s, now()) "
             "ON CONFLICT (server_id, provider_track_id) DO UPDATE SET "
             "fingerprint = EXCLUDED.fingerprint, updated_at = now()",
-            (str(server_id), str(provider_track_id), blob),
+            (str(server_id), sanitize_string_for_db(str(provider_track_id)), blob),
         )
         conn.commit()
     except Exception:
@@ -787,7 +787,7 @@ def get_chromaprint(server_id, provider_track_id):
         cur.execute(
             "SELECT fingerprint FROM chromaprint "
             "WHERE server_id = %s AND provider_track_id = %s",
-            (str(server_id), str(provider_track_id)),
+            (str(server_id), sanitize_string_for_db(str(provider_track_id))),
         )
         row = cur.fetchone()
         return bytes(row[0]) if row and row[0] is not None else None

--- a/sanitization.py
+++ b/sanitization.py
@@ -15,6 +15,7 @@ used across the data-access layer and API responses.
 Main Features:
 * ``sanitize_db_field`` removes non-printable characters and truncates to a max length.
 * ``sanitize_string_for_db`` / ``sanitize_json_for_db`` strip NUL and control chars from text and nested JSON.
+* ``sanitize_string_for_db_loud`` is the same transform with a per-value warning when it changed something.
 * ``sanitize_for_json`` converts numpy int/float/bool/array types to native Python.
 """
 
@@ -26,6 +27,8 @@ import numpy as np
 
 logger = logging.getLogger(__name__)
 
+_DB_CONTROL_CHARS = re.compile(r'[\x00-\x08\x0B-\x0C\x0E-\x1F]')
+
 
 def sanitize_string_for_db(value: Optional[str]) -> Optional[str]:
     if value is None:
@@ -34,11 +37,18 @@ def sanitize_string_for_db(value: Optional[str]) -> Optional[str]:
     if not isinstance(value, str):
         value = str(value)
 
-    value = value.replace('\x00', '')
+    return _DB_CONTROL_CHARS.sub('', value)
 
-    value = re.sub(r'[\x01-\x08\x0B-\x0C\x0E-\x1F]', '', value)
 
-    return value
+def sanitize_string_for_db_loud(value, field):
+    text = value if isinstance(value, str) else str(value)
+    cleaned = _DB_CONTROL_CHARS.sub('', text)
+    if cleaned != text:
+        logger.warning(
+            "Sanitized control characters out of %s %r before database write",
+            field, text,
+        )
+    return cleaned
 
 
 def sanitize_db_field(s, max_length=1000, field_name="field"):

--- a/tasks/analysis/helper.py
+++ b/tasks/analysis/helper.py
@@ -44,6 +44,7 @@ from config import (
 from database import get_db, save_task_status
 from psycopg2 import OperationalError
 from psycopg2 import sql as pgsql
+from sanitization import sanitize_string_for_db
 
 from error import error_manager
 from error.error_dictionary import ERR_DB_CONNECTION
@@ -144,7 +145,7 @@ def make_task_reporter(task_id, task_type, job, initial_message,
 
 
 def _str_ids(ids):
-    return [str(i) for i in ids]
+    return [sanitize_string_for_db(str(i)) for i in ids]
 
 
 def attach_catalog_item_ids(tracks, server_id=None):
@@ -152,7 +153,9 @@ def attach_catalog_item_ids(tracks, server_id=None):
         return tracks
     from tasks.mediaserver import context, registry
 
-    provider_ids = [str(t.get('Id') or t.get('id')) for t in tracks]
+    provider_ids = [
+        sanitize_string_for_db(str(t.get('Id') or t.get('id'))) for t in tracks
+    ]
     active_server_id = server_id or context.active_server_id()
     mapped = registry.reverse_translate_ids(provider_ids, active_server_id)
     for item, provider_id in zip(tracks, provider_ids):

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -48,6 +48,8 @@ from database import (
 )
 from psycopg2 import OperationalError
 
+from sanitization import sanitize_string_for_db
+
 from error import error_manager
 from error.error_dictionary import (
     ERR_DB_QUERY,
@@ -588,11 +590,13 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, 
 
 
 def catalog_item_id(item):
-    return str(item.get('_catalog_item_id') or item.get('Id') or item.get('id'))
+    return sanitize_string_for_db(
+        str(item.get('_catalog_item_id') or item.get('Id') or item.get('id'))
+    )
 
 
 def provider_item_id(item):
-    return str(item.get('Id') or item.get('id'))
+    return sanitize_string_for_db(str(item.get('Id') or item.get('id')))
 
 
 def ensure_musicnn_sessions(onnx_sessions, model_paths, session_recycler, album_name):

--- a/tasks/duplicate_repair.py
+++ b/tasks/duplicate_repair.py
@@ -74,6 +74,7 @@ from psycopg2.extras import execute_values
 
 import config
 from database import connect_raw
+from sanitization import sanitize_string_for_db
 from tasks import provider_probe
 from tasks import simhash
 from tasks.chromaprint import chromaprints_agree
@@ -169,7 +170,7 @@ def _server_durations(server):
             server['server_type'], server['creds'], apply_filter=True
         )
     return {
-        str(track['id']): track['duration']
+        sanitize_string_for_db(str(track['id'])): track['duration']
         for track in tracks
         if track.get('id') is not None and track.get('duration') is not None
     }
@@ -182,7 +183,10 @@ def _group_duration(provider_ids, durations):
     DURATION_TOLERANCE_SECONDS; the stamped value is the smallest, deterministic
     and within tolerance of the survivor's true length.
     """
-    values = [durations.get(provider_id) for provider_id in provider_ids]
+    values = [
+        durations.get(sanitize_string_for_db(provider_id))
+        for provider_id in provider_ids
+    ]
     if any(value is None for value in values):
         return None
     if (max(values) - min(values)) > config.DURATION_TOLERANCE_SECONDS:

--- a/tasks/fingerprint_canonicalize.py
+++ b/tasks/fingerprint_canonicalize.py
@@ -72,6 +72,7 @@ import numpy as np
 
 import config
 from database import connect_raw
+from sanitization import sanitize_string_for_db
 from tasks import simhash
 from tasks.mediaserver import registry
 from tasks.provider_migration_tasks import (
@@ -175,7 +176,7 @@ def _fetch_provider_durations(source_id, conn):
                 server['server_type'], server['creds'], apply_filter=False
             )
         durations = {
-            str(track['id']): track['duration']
+            sanitize_string_for_db(str(track['id'])): track['duration']
             for track in tracks
             if track.get('id') is not None and track.get('duration') is not None
         }
@@ -206,9 +207,10 @@ def _durations_for_rows(cur, ids, rows, provider_durations, source_id):
         for item_id, duration in cur.fetchall():
             durations[str(item_id)] = float(duration)
     unresolved = [i for i in wanted if i not in durations]
-    direct = [i for i in unresolved if i in provider_durations]
-    for item_id in direct:
-        durations[item_id] = provider_durations[item_id]
+    for item_id in unresolved:
+        value = provider_durations.get(sanitize_string_for_db(item_id))
+        if value is not None:
+            durations[item_id] = value
     unresolved = [i for i in unresolved if i not in durations]
     if unresolved and provider_durations:
         for begin in range(0, len(unresolved), _CHUNK_ROWS):
@@ -219,7 +221,7 @@ def _durations_for_rows(cur, ids, rows, provider_durations, source_id):
                 (source_id, chunk),
             )
             for item_id, provider_id in cur.fetchall():
-                value = provider_durations.get(str(provider_id))
+                value = provider_durations.get(sanitize_string_for_db(str(provider_id)))
                 if value is not None:
                     durations.setdefault(str(item_id), value)
     return durations

--- a/tasks/mediaserver/emby.py
+++ b/tasks/mediaserver/emby.py
@@ -549,8 +549,8 @@ def download_track(temp_dir, item):
                     f.write(chunk)
         logger.info(f"Downloaded '{item.get('Name', track_id)}' to '{local_filename}'")
         return local_filename
-    except Exception:
-        logger.exception(f"Failed to download track {item.get('Name', 'Unknown')}")
+    except Exception as exc:
+        logger.warning(f"Failed to download track {item.get('Name', 'Unknown')}: {exc}")
         return None
 
 

--- a/tasks/mediaserver/jellyfin.py
+++ b/tasks/mediaserver/jellyfin.py
@@ -302,8 +302,8 @@ def download_track(temp_dir, item):
                     f.write(chunk)
         logger.info(f"Downloaded '{item.get('Name', track_id)}' to '{local_filename}'")
         return local_filename
-    except Exception:
-        logger.exception(f"Failed to download track {item.get('Name', 'Unknown')}")
+    except Exception as exc:
+        logger.warning(f"Failed to download track {item.get('Name', 'Unknown')}: {exc}")
         return None
 
 

--- a/tasks/mediaserver/lyrion.py
+++ b/tasks/mediaserver/lyrion.py
@@ -400,8 +400,8 @@ def download_track(temp_dir, item):
                         f.write(chunk)
         logger.info(f"Downloaded '{item.get('title', 'Unknown')}' to '{local_filename}'")
         return local_filename
-    except Exception:
-        logger.exception(f"Failed to download Lyrion track {item.get('title', 'Unknown')}")
+    except Exception as exc:
+        logger.warning(f"Failed to download Lyrion track {item.get('title', 'Unknown')}: {exc}")
     return None
 
 

--- a/tasks/mediaserver/plex.py
+++ b/tasks/mediaserver/plex.py
@@ -293,8 +293,8 @@ def download_track(temp_dir, item):
                     f.write(chunk)
         logger.info(f"Downloaded '{item.get('Name', 'Unknown')}' to '{local_filename}'")
         return local_filename
-    except Exception:
-        logger.exception(f"Failed to download track {item.get('Name', 'Unknown')}")
+    except Exception as exc:
+        logger.warning(f"Failed to download track {item.get('Name', 'Unknown')}: {exc}")
         return None
 
 

--- a/tasks/mediaserver/registry.py
+++ b/tasks/mediaserver/registry.py
@@ -48,7 +48,7 @@ from psycopg2.extras import DictCursor, Json, execute_values
 
 import config
 from database import get_db, missing_required_creds
-from sanitization import sanitize_string_for_db
+from sanitization import sanitize_string_for_db, sanitize_string_for_db_loud
 
 logger = logging.getLogger(__name__)
 
@@ -567,19 +567,23 @@ def reverse_translate_ids(provider_ids, server_id=None, conn=None):
     target = server_id or default_id
     if target is None:
         return {i: i for i in ids}
-    cur = db.cursor()
-    try:
-        cur.execute(
-            "SELECT provider_track_id, item_id FROM track_server_map "
-            "WHERE server_id = %s AND provider_track_id = ANY(%s)",
-            (target, ids),
-        )
-        mapped = {r[0]: r[1] for r in cur.fetchall()}
-    finally:
-        cur.close()
+    clean_of = {i: sanitize_string_for_db(i) for i in ids}
+    lookup = [c for c in dict.fromkeys(clean_of.values()) if c]
+    by_clean = {}
+    if lookup:
+        cur = db.cursor()
+        try:
+            cur.execute(
+                "SELECT provider_track_id, item_id FROM track_server_map "
+                "WHERE server_id = %s AND provider_track_id = ANY(%s)",
+                (target, lookup),
+            )
+            by_clean = {r[0]: r[1] for r in cur.fetchall()}
+        finally:
+            cur.close()
     if is_default:
-        return {i: mapped.get(i, i) for i in ids}
-    return mapped
+        return {i: by_clean.get(clean_of[i], i) for i in ids}
+    return {i: by_clean[clean_of[i]] for i in ids if clean_of[i] in by_clean}
 
 
 def canonical_input_ids(item_ids, server_id=None, conn=None):
@@ -626,28 +630,21 @@ def _staged_map_upsert(db, rows, stage_ddl, stage_insert, conflict_delete,
         cur.close()
 
 
-def _clean_map_text(value, field):
-    text = str(value)
-    cleaned = sanitize_string_for_db(text)
-    if cleaned != text:
-        logger.warning(
-            "Sanitized control characters out of %s %r before map upsert",
-            field, text,
-        )
-    return cleaned
-
-
 def upsert_artist_maps(server_id, mapping, conn=None):
     """Bulk-upsert ``{artist_name: provider_artist_id}`` for one server."""
     cleaned = {}
     for name, provider_id in (mapping or {}).items():
         if name and provider_id and server_id:
-            clean_name = _clean_map_text(name, 'artist_name')
-            clean_id = _clean_map_text(provider_id, 'provider_artist_id')
-            if clean_name and clean_id:
-                cleaned[clean_name] = clean_id
+            clean_name = sanitize_string_for_db_loud(name, 'artist_name')
+            clean_id = sanitize_string_for_db_loud(provider_id, 'provider_artist_id')
+            if not clean_name or not clean_id:
+                continue
+            rank = (0 if clean_name == str(name) else 1, clean_id)
+            prev = cleaned.get(clean_name)
+            if prev is None or rank < prev:
+                cleaned[clean_name] = rank
     rows_by_provider = {}
-    for clean_name, clean_id in cleaned.items():
+    for clean_name, (_dirty, clean_id) in cleaned.items():
         rows_by_provider[clean_id] = (clean_name, str(server_id), clean_id)
     rows = list(rows_by_provider.values())
     if not rows:
@@ -682,8 +679,12 @@ def _artist_lookup(values, server_id, conn, map_columns):
     (source, result) column pair, never caller input. The default server's ids now
     live in artist_server_map like every other server's (the legacy artist_mapping
     table was folded in and dropped at startup), so there is no fallback."""
-    wanted = [str(value) for value in values if value]
+    wanted = [str(value) for value in dict.fromkeys(values) if value]
     if not wanted:
+        return {}
+    clean_of = {value: sanitize_string_for_db(value) for value in wanted}
+    lookup = [c for c in dict.fromkeys(clean_of.values()) if c]
+    if not lookup:
         return {}
     db = conn or get_db()
     target = server_id or get_default_server_id(db)
@@ -695,11 +696,16 @@ def _artist_lookup(values, server_id, conn, map_columns):
         cur.execute(
             f"SELECT {src}, {dst} FROM artist_server_map "
             f"WHERE server_id = %s AND {src} = ANY(%s)",
-            (target, wanted),
+            (target, lookup),
         )
-        return {str(row[0]): str(row[1]) for row in cur.fetchall()}
+        by_clean = {str(row[0]): str(row[1]) for row in cur.fetchall()}
     finally:
         cur.close()
+    return {
+        value: by_clean[clean_of[value]]
+        for value in wanted
+        if clean_of[value] in by_clean
+    }
 
 
 def artist_names_for_ids(provider_artist_ids, server_id=None, conn=None):
@@ -766,14 +772,17 @@ def upsert_track_maps(server_id, mapping, conn=None):
             continue
         if item_id is None or item_id == '':
             continue
-        provider_track_id = _clean_map_text(provider_track_id, 'provider_track_id')
-        item_id = _clean_map_text(item_id, 'item_id')
-        if not provider_track_id or not item_id:
+        provider_track_id = sanitize_string_for_db_loud(
+            provider_track_id, 'provider_track_id'
+        )
+        if not provider_track_id:
             continue
-        file_path = _clean_map_text(file_path, 'file_path') if file_path else None
+        file_path = (
+            (sanitize_string_for_db_loud(file_path, 'file_path') or None)
+            if file_path else None
+        )
         rows_by_provider[provider_track_id] = (
-            item_id, server_id, provider_track_id, match_tier,
-            file_path or None,
+            str(item_id), server_id, provider_track_id, match_tier, file_path,
         )
     rows = list(rows_by_provider.values())
     if not rows:

--- a/tasks/mediaserver/registry.py
+++ b/tasks/mediaserver/registry.py
@@ -48,6 +48,7 @@ from psycopg2.extras import DictCursor, Json, execute_values
 
 import config
 from database import get_db, missing_required_creds
+from sanitization import sanitize_string_for_db
 
 logger = logging.getLogger(__name__)
 
@@ -625,14 +626,29 @@ def _staged_map_upsert(db, rows, stage_ddl, stage_insert, conflict_delete,
         cur.close()
 
 
+def _clean_map_text(value, field):
+    text = str(value)
+    cleaned = sanitize_string_for_db(text)
+    if cleaned != text:
+        logger.warning(
+            "Sanitized control characters out of %s %r before map upsert",
+            field, text,
+        )
+    return cleaned
+
+
 def upsert_artist_maps(server_id, mapping, conn=None):
     """Bulk-upsert ``{artist_name: provider_artist_id}`` for one server."""
-    rows_by_provider = {}
+    cleaned = {}
     for name, provider_id in (mapping or {}).items():
         if name and provider_id and server_id:
-            rows_by_provider[str(provider_id)] = (
-                str(name), str(server_id), str(provider_id)
-            )
+            clean_name = _clean_map_text(name, 'artist_name')
+            clean_id = _clean_map_text(provider_id, 'provider_artist_id')
+            if clean_name and clean_id:
+                cleaned[clean_name] = clean_id
+    rows_by_provider = {}
+    for clean_name, clean_id in cleaned.items():
+        rows_by_provider[clean_id] = (clean_name, str(server_id), clean_id)
     rows = list(rows_by_provider.values())
     if not rows:
         return 0
@@ -750,10 +766,14 @@ def upsert_track_maps(server_id, mapping, conn=None):
             continue
         if item_id is None or item_id == '':
             continue
-        provider_track_id = str(provider_track_id)
+        provider_track_id = _clean_map_text(provider_track_id, 'provider_track_id')
+        item_id = _clean_map_text(item_id, 'item_id')
+        if not provider_track_id or not item_id:
+            continue
+        file_path = _clean_map_text(file_path, 'file_path') if file_path else None
         rows_by_provider[provider_track_id] = (
-            str(item_id), server_id, provider_track_id, match_tier,
-            str(file_path) if file_path else None,
+            item_id, server_id, provider_track_id, match_tier,
+            file_path or None,
         )
     rows = list(rows_by_provider.values())
     if not rows:

--- a/tasks/multiserver_sync.py
+++ b/tasks/multiserver_sync.py
@@ -637,17 +637,9 @@ def _write_matches(db, server_id, result, path_by_id=None):
 
 
 def prune_stale_mappings(db, server_id, present_ids, refused=None):
-    """Remove map rows whose provider track is no longer on (or is filtered out
-    of) the server. Only track_server_map shrinks; the catalogue never does.
-
-    Skipped entirely when the fetch produced nothing or looks partial (fewer than
-    SWEEP_PRUNE_MIN_FETCH_RATIO of the existing mappings), so a fetch problem can
-    never wipe a server's mappings. ``refused`` is an optional list this appends
-    ``(fetched, mapped)`` to when it takes that escape hatch: a refusal returned 0,
-    which is indistinguishable from "nothing to prune", so a library that really
-    had shrunk by more than half kept its stale mappings and said nothing.
-    """
-    present = [(_strip_nul(str(pid)),) for pid in present_ids if pid is not None]
+    present_set = {_strip_nul(str(pid)) for pid in present_ids if pid is not None}
+    present_set.discard('')
+    present = [(pid,) for pid in present_set]
     if not present:
         return 0
     cur = db.cursor()
@@ -724,11 +716,6 @@ def _store_server_track_count(db, server_id, track_count):
 
 
 def _strip_nul(value):
-    """Postgres text cannot hold a NUL (0x00) byte, but provider tags and file
-    paths occasionally carry one; execute_values/mogrify raises on it. Delegates
-    to the shared sanitizer so every sweep bind site applies the exact transform
-    the registry map upserts apply - a divergence would make the prune anti-join
-    and metadata-refresh join miss rows the registry stored sanitized."""
     if isinstance(value, str):
         return sanitize_string_for_db(value)
     return value
@@ -933,7 +920,7 @@ def _sweep_one(server, db, report, base, span, cancel, full_refresh=False):
     def _drain_candidates(tracks):
         while tracks:
             track = tracks.pop()
-            if track.get('id') and str(track.get('id')) not in already_mapped:
+            if track.get('id') and _strip_nul(str(track.get('id'))) not in already_mapped:
                 yield track
 
     index = CandidateIndex(_drain_candidates(target_tracks))

--- a/tasks/multiserver_sync.py
+++ b/tasks/multiserver_sync.py
@@ -72,6 +72,7 @@ from psycopg2.extras import execute_values
 import rq_job_state
 from config import SWEEP_PRUNE_MIN_FETCH_RATIO
 from database import connect_raw, INLINE_FLASK_TASK_TYPES
+from sanitization import sanitize_string_for_db
 from tasks import provider_probe
 from tasks.mediaserver import context as ms_context, registry
 from tasks.provider_migration_matcher import CandidateIndex
@@ -646,7 +647,7 @@ def prune_stale_mappings(db, server_id, present_ids, refused=None):
     which is indistinguishable from "nothing to prune", so a library that really
     had shrunk by more than half kept its stale mappings and said nothing.
     """
-    present = [(pid,) for pid in present_ids]
+    present = [(_strip_nul(str(pid)),) for pid in present_ids if pid is not None]
     if not present:
         return 0
     cur = db.cursor()
@@ -724,10 +725,12 @@ def _store_server_track_count(db, server_id, track_count):
 
 def _strip_nul(value):
     """Postgres text cannot hold a NUL (0x00) byte, but provider tags and file
-    paths occasionally carry one; execute_values/mogrify raises on it. Strip it
-    from strings so a single bad tag cannot fail the whole sweep write."""
-    if isinstance(value, str) and '\x00' in value:
-        return value.replace('\x00', '')
+    paths occasionally carry one; execute_values/mogrify raises on it. Delegates
+    to the shared sanitizer so every sweep bind site applies the exact transform
+    the registry map upserts apply - a divergence would make the prune anti-join
+    and metadata-refresh join miss rows the registry stored sanitized."""
+    if isinstance(value, str):
+        return sanitize_string_for_db(value)
     return value
 
 
@@ -765,8 +768,11 @@ def _stage_track_metadata(db, tracks):
         provider_id = t.get('id')
         if not provider_id:
             continue
-        rows[str(provider_id)] = (
-            _strip_nul(str(provider_id)), _strip_nul(t.get('album')),
+        clean_id = _strip_nul(str(provider_id))
+        if not clean_id:
+            continue
+        rows[clean_id] = (
+            clean_id, _strip_nul(t.get('album')),
             _strip_nul(t.get('album_artist')),
             t.get('year'), t.get('rating'), _strip_nul(t.get('path')),
         )

--- a/tasks/provider_migration_tasks.py
+++ b/tasks/provider_migration_tasks.py
@@ -378,7 +378,10 @@ def _populate_migration_map_table(cur, mapping):
     for i in range(0, len(_rows), 1000):
         chunk = _rows[i : i + 1000]
         placeholders = ",".join(["(%s,%s)"] * len(chunk))
-        flat = [_sanitize_text(v) if isinstance(v, str) else v for pair in chunk for v in pair]
+        flat = []
+        for old_id, new_id in chunk:
+            flat.append(old_id)
+            flat.append(_sanitize_text(new_id) if isinstance(new_id, str) else new_id)
         cur.execute(
             "INSERT INTO item_id_migration_map (old_id, new_id) VALUES " + placeholders,  # nosec B608 - %s-placeholder string only; values are bound params
             flat,

--- a/tasks/provider_migration_tasks.py
+++ b/tasks/provider_migration_tasks.py
@@ -378,7 +378,7 @@ def _populate_migration_map_table(cur, mapping):
     for i in range(0, len(_rows), 1000):
         chunk = _rows[i : i + 1000]
         placeholders = ",".join(["(%s,%s)"] * len(chunk))
-        flat = [v for pair in chunk for v in pair]
+        flat = [_sanitize_text(v) if isinstance(v, str) else v for pair in chunk for v in pair]
         cur.execute(
             "INSERT INTO item_id_migration_map (old_id, new_id) VALUES " + placeholders,  # nosec B608 - %s-placeholder string only; values are bound params
             flat,
@@ -564,8 +564,8 @@ def _run_migration_transaction(
 
 
 def _cleaned_libraries_value(selected_libraries):
-    cleaned = [str(name).strip() for name in (selected_libraries or []) if str(name).strip()]
-    cleaned = [name for name in cleaned if ',' not in name]
+    cleaned = [_sanitize_text(str(name)).strip() for name in (selected_libraries or [])]
+    cleaned = [name for name in cleaned if name and ',' not in name]
     return ','.join(cleaned)
 
 

--- a/test/unit/test_nul_sanitization_maps.py
+++ b/test/unit/test_nul_sanitization_maps.py
@@ -1,0 +1,206 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""NUL and control-character hardening on the server-map and provider-id write paths.
+
+Verifies every Postgres bind site that carries media-server tag text applies the
+shared ``sanitize_string_for_db`` transform before the value reaches psycopg2,
+so one dirty tag can neither crash mogrify nor desync the sweep's staged ids
+from the ids the registry stored sanitized.
+
+Main Features:
+* Artist map upserts strip NUL from names/ids and re-dedup names that collide after sanitizing
+* Track map upserts sanitize ids and paths before the provider-id dedup key is built
+* The sweep prune stages present ids with the identical transform the registry applies
+* Sweep metadata staging keys rows by the sanitized id so collisions cannot violate the temp PK
+* Migration id maps and chromaprint reads/writes sanitize provider ids the same way
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sanitization import sanitize_string_for_db
+
+
+def _mock_db():
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestUpsertArtistMapsSanitization:
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_artist_maps_strips_nul_from_name_and_id(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_artist_maps(
+            'srv1', {'Artist\x00Name': 'id\x00123'}, conn=conn
+        )
+
+        assert written == 1
+        rows = mock_ev.call_args_list[0][0][2]
+        assert rows == [('ArtistName', 'srv1', 'id123')]
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_artist_maps_strips_control_chars_like_score_author(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        registry.upsert_artist_maps('srv1', {'Art\x01ist\x1f': 'id1'}, conn=conn)
+
+        rows = mock_ev.call_args_list[0][0][2]
+        assert rows[0][0] == 'Artist'
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_artist_maps_dedups_names_that_collide_after_sanitize(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_artist_maps(
+            'srv1', {'AB': 'id1', 'A\x00B': 'id2'}, conn=conn
+        )
+
+        assert written == 1
+        rows = mock_ev.call_args_list[0][0][2]
+        assert [r[0] for r in rows] == ['AB']
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_artist_maps_drops_entries_empty_after_sanitize(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_artist_maps('srv1', {'\x00': 'id1'}, conn=conn)
+
+        assert written == 0
+        assert not mock_ev.called
+
+
+class TestUpsertTrackMapsSanitization:
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_track_maps_sanitizes_ids_and_paths(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_track_maps(
+            'srv1',
+            {'prov\x00id': ('fp_item\x00', 'tier1', '/music/a\x00.flac')},
+            conn=conn,
+        )
+
+        assert written == 1
+        rows = mock_ev.call_args_list[0][0][2]
+        assert rows == [('fp_item', 'srv1', 'provid', 'tier1', '/music/a.flac')]
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_track_maps_dedups_ids_that_collide_after_sanitize(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_track_maps(
+            'srv1',
+            {'id1': ('fp_a', None, None), 'id\x001': ('fp_b', None, None)},
+            conn=conn,
+        )
+
+        assert written == 1
+        rows = mock_ev.call_args_list[0][0][2]
+        assert [r[2] for r in rows] == ['id1']
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_track_maps_drops_rows_whose_id_is_empty_after_sanitize(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        written = registry.upsert_track_maps(
+            'srv1', {'\x00': ('fp_a', None, None)}, conn=conn
+        )
+
+        assert written == 0
+        assert not mock_ev.called
+
+
+class TestSweepUsesSameTransformAsRegistry:
+    def test_strip_nul_delegates_to_shared_sanitizer(self):
+        from tasks import multiserver_sync
+
+        dirty = 'a\x00b\x01c'
+        assert multiserver_sync._strip_nul(dirty) == sanitize_string_for_db(dirty)
+        assert multiserver_sync._strip_nul(dirty) == 'abc'
+        assert multiserver_sync._strip_nul(7) == 7
+        assert multiserver_sync._strip_nul(None) is None
+
+    @patch('tasks.multiserver_sync.execute_values')
+    def test_prune_present_ids_use_same_transform_as_upsert(self, mock_ev):
+        from tasks import multiserver_sync
+
+        conn, cur = _mock_db()
+        cur.fetchone.return_value = (0,)
+        cur.rowcount = 0
+        dirty = 'prov\x00id\x01x'
+        multiserver_sync.prune_stale_mappings(conn, 'srv1', [dirty, 'clean'])
+
+        staged = mock_ev.call_args_list[0][0][2]
+        assert staged == [(sanitize_string_for_db(dirty),), ('clean',)]
+
+    @patch('tasks.multiserver_sync.execute_values')
+    def test_stage_track_metadata_dedups_ids_that_collide_after_sanitize(self, mock_ev):
+        from tasks import multiserver_sync
+
+        conn, _ = _mock_db()
+        tracks = [
+            {'id': 'id1', 'album': 'Album\x00One', 'album_artist': 'AA',
+             'year': 2020, 'rating': 5, 'path': '/p\x001'},
+            {'id': 'id\x001', 'album': 'Album Two', 'album_artist': 'BB',
+             'year': 2021, 'rating': 4, 'path': '/p2'},
+        ]
+        multiserver_sync._stage_track_metadata(conn, tracks)
+
+        staged = mock_ev.call_args_list[0][0][2]
+        assert staged == [('id1', 'Album Two', 'BB', 2021, 4, '/p2')]
+
+
+class TestMigrationMapSanitization:
+    def test_migration_map_sanitizes_ids_like_new_meta(self):
+        from tasks.provider_migration_tasks import _populate_migration_map_table
+
+        cur = MagicMock()
+        _populate_migration_map_table(cur, {'old\x00id': 'new\x00id'})
+
+        insert_call = cur.execute.call_args_list[1]
+        assert insert_call[0][1] == ['oldid', 'newid']
+
+    def test_cleaned_libraries_drops_names_empty_after_sanitize(self):
+        from tasks.provider_migration_tasks import _cleaned_libraries_value
+
+        assert _cleaned_libraries_value(['Mus\x00ic', '\x00', 'a,b']) == 'Music'
+
+
+class TestChromaprintIdSanitization:
+    @patch('database.get_db')
+    def test_persist_chromaprint_strips_nul_from_provider_track_id(self, mock_get_db):
+        from database import persist_chromaprint
+
+        conn, cur = _mock_db()
+        mock_get_db.return_value = conn
+        persist_chromaprint('srv1', 'prov\x00id', b'\x01\x02')
+
+        params = cur.execute.call_args_list[0][0][1]
+        assert params[1] == 'provid'
+
+    @patch('database.get_db')
+    def test_get_chromaprint_looks_up_with_sanitized_id(self, mock_get_db):
+        from database import get_chromaprint
+
+        conn, cur = _mock_db()
+        cur.fetchone.return_value = None
+        mock_get_db.return_value = conn
+        get_chromaprint('srv1', 'prov\x00id')
+
+        params = cur.execute.call_args_list[0][0][1]
+        assert params[1] == 'provid'

--- a/test/unit/test_nul_sanitization_maps.py
+++ b/test/unit/test_nul_sanitization_maps.py
@@ -6,31 +6,55 @@
 # the terms of the GNU Affero General Public License v3.0. See the LICENSE file
 # in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
 
-"""NUL and control-character hardening on the server-map and provider-id write paths.
+"""NUL and control-character hardening across the provider-id write AND read domains.
 
-Verifies every Postgres bind site that carries media-server tag text applies the
-shared ``sanitize_string_for_db`` transform before the value reaches psycopg2,
-so one dirty tag can neither crash mogrify nor desync the sweep's staged ids
-from the ids the registry stored sanitized.
+Verifies that every Postgres bind site carrying media-server tag text applies the
+shared ``sanitize_string_for_db`` transform, and that every compare/read site that
+probes those columns (translation, work map, duration dicts) sanitizes its probe
+the same way, so stored and fetched ids always live in one domain. DB-sourced
+keys (score item_id, migration old_id) stay raw: they were stored sanitized or
+predate the transform, and mutating them would break FK joins.
 
 Main Features:
-* Artist map upserts strip NUL from names/ids and re-dedup names that collide after sanitizing
-* Track map upserts sanitize ids and paths before the provider-id dedup key is built
-* The sweep prune stages present ids with the identical transform the registry applies
-* Sweep metadata staging keys rows by the sanitized id so collisions cannot violate the temp PK
-* Migration id maps and chromaprint reads/writes sanitize provider ids the same way
+* Artist map upserts strip NUL/C0 from names and ids with a deterministic collision tiebreak
+* Track map upserts sanitize provider ids and paths but keep the DB-sourced item_id raw
+* reverse_translate_ids and artist lookups bind sanitized ids and key results by caller input
+* The sweep prune stages a deduped post-sanitize present set; metadata staging keys clean ids
+* Analysis id seams, migration id maps, duration dicts and chromaprint use the same transform
+* The one-time init_db scrub targets exactly the C0 class and is gated by an app_config marker
 """
 
+import os
+import re
+import sys
 from unittest.mock import MagicMock, patch
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from conftest import make_mock_connection
 from sanitization import sanitize_string_for_db
 
 
 def _mock_db():
-    conn = MagicMock()
     cur = MagicMock()
-    conn.cursor.return_value = cur
-    return conn, cur
+    return make_mock_connection(cur), cur
+
+
+class TestSanitizeStringForDb:
+    def test_single_pass_matches_two_pass_reference(self):
+        probe = ''.join(chr(c) for c in range(0x00, 0x20)) + '\x7f caf\xe9 \r\n\t'
+        reference = re.sub(
+            r'[\x01-\x08\x0B-\x0C\x0E-\x1F]', '', probe.replace('\x00', '')
+        )
+        assert sanitize_string_for_db(probe) == reference
+
+    def test_loud_variant_warns_only_when_value_changed(self):
+        import sanitization
+
+        with patch.object(sanitization.logger, 'warning') as warn:
+            assert sanitization.sanitize_string_for_db_loud('a\x01b', 'field') == 'ab'
+            assert warn.call_count == 1
+            assert sanitization.sanitize_string_for_db_loud('clean', 'field') == 'clean'
+            assert warn.call_count == 1
 
 
 class TestUpsertArtistMapsSanitization:
@@ -48,27 +72,41 @@ class TestUpsertArtistMapsSanitization:
         assert rows == [('ArtistName', 'srv1', 'id123')]
 
     @patch('tasks.mediaserver.registry.execute_values')
-    def test_upsert_artist_maps_strips_control_chars_like_score_author(self, mock_ev):
+    def test_upsert_artist_maps_strips_c0_controls_but_keeps_del_and_cr(self, mock_ev):
         from tasks.mediaserver import registry
 
         conn, _ = _mock_db()
-        registry.upsert_artist_maps('srv1', {'Art\x01ist\x1f': 'id1'}, conn=conn)
+        registry.upsert_artist_maps(
+            'srv1', {'Art\x01ist\x1f': 'id1', 'Keep\x7f\rMe': 'id2'}, conn=conn
+        )
 
-        rows = mock_ev.call_args_list[0][0][2]
-        assert rows[0][0] == 'Artist'
+        names = {r[0] for r in mock_ev.call_args_list[0][0][2]}
+        assert names == {'Artist', 'Keep\x7f\rMe'}
 
     @patch('tasks.mediaserver.registry.execute_values')
-    def test_upsert_artist_maps_dedups_names_that_collide_after_sanitize(self, mock_ev):
+    def test_upsert_artist_maps_collision_prefers_already_clean_name(self, mock_ev):
         from tasks.mediaserver import registry
 
         conn, _ = _mock_db()
         written = registry.upsert_artist_maps(
-            'srv1', {'AB': 'id1', 'A\x00B': 'id2'}, conn=conn
+            'srv1', {'A\x00B': 'id_dirty', 'AB': 'id_clean'}, conn=conn
         )
 
         assert written == 1
         rows = mock_ev.call_args_list[0][0][2]
-        assert [r[0] for r in rows] == ['AB']
+        assert rows == [('AB', 'srv1', 'id_clean')]
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_artist_maps_collision_tiebreak_is_input_order_independent(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        registry.upsert_artist_maps(
+            'srv1', {'AB': 'id_clean', 'A\x00B': 'id_dirty'}, conn=conn
+        )
+
+        rows = mock_ev.call_args_list[0][0][2]
+        assert rows == [('AB', 'srv1', 'id_clean')]
 
     @patch('tasks.mediaserver.registry.execute_values')
     def test_upsert_artist_maps_drops_entries_empty_after_sanitize(self, mock_ev):
@@ -83,19 +121,31 @@ class TestUpsertArtistMapsSanitization:
 
 class TestUpsertTrackMapsSanitization:
     @patch('tasks.mediaserver.registry.execute_values')
-    def test_upsert_track_maps_sanitizes_ids_and_paths(self, mock_ev):
+    def test_upsert_track_maps_sanitizes_provider_id_and_path(self, mock_ev):
         from tasks.mediaserver import registry
 
         conn, _ = _mock_db()
         written = registry.upsert_track_maps(
             'srv1',
-            {'prov\x00id': ('fp_item\x00', 'tier1', '/music/a\x00.flac')},
+            {'prov\x00id': ('fp_item', 'tier1', '/music/a\x00.flac')},
             conn=conn,
         )
 
         assert written == 1
         rows = mock_ev.call_args_list[0][0][2]
         assert rows == [('fp_item', 'srv1', 'provid', 'tier1', '/music/a.flac')]
+
+    @patch('tasks.mediaserver.registry.execute_values')
+    def test_upsert_track_maps_keeps_db_sourced_item_id_raw(self, mock_ev):
+        from tasks.mediaserver import registry
+
+        conn, _ = _mock_db()
+        registry.upsert_track_maps(
+            'srv1', {'provid': ('fp_leg\x01acy', None, None)}, conn=conn
+        )
+
+        rows = mock_ev.call_args_list[0][0][2]
+        assert rows[0][0] == 'fp_leg\x01acy'
 
     @patch('tasks.mediaserver.registry.execute_values')
     def test_upsert_track_maps_dedups_ids_that_collide_after_sanitize(self, mock_ev):
@@ -125,6 +175,38 @@ class TestUpsertTrackMapsSanitization:
         assert not mock_ev.called
 
 
+class TestTranslationReadSitesSanitize:
+    @patch('tasks.mediaserver.registry.get_default_server')
+    def test_reverse_translate_ids_binds_sanitized_ids_and_keys_by_input(self, mock_default):
+        from tasks.mediaserver import registry
+
+        mock_default.return_value = {'server_id': 'srv1'}
+        conn, cur = _mock_db()
+        cur.fetchall.return_value = [('provid', 'fp_1')]
+
+        result = registry.reverse_translate_ids(
+            ['prov\x01id', 'unknown'], server_id='srv1', conn=conn
+        )
+
+        bound = cur.execute.call_args_list[0][0][1]
+        assert bound == ('srv1', ['provid', 'unknown'])
+        assert result == {'prov\x01id': 'fp_1', 'unknown': 'unknown'}
+
+    @patch('tasks.mediaserver.registry.get_default_server_id')
+    def test_artist_lookup_matches_sanitized_rows_keyed_by_caller_input(self, mock_default_id):
+        from tasks.mediaserver import registry
+
+        mock_default_id.return_value = 'srv1'
+        conn, cur = _mock_db()
+        cur.fetchall.return_value = [('artid1', 'AC/DC')]
+
+        result = registry.artist_names_for_ids(['art\x01id1'], conn=conn)
+
+        bound = cur.execute.call_args_list[0][0][1]
+        assert bound == ('srv1', ['artid1'])
+        assert result == {'art\x01id1': 'AC/DC'}
+
+
 class TestSweepUsesSameTransformAsRegistry:
     def test_strip_nul_delegates_to_shared_sanitizer(self):
         from tasks import multiserver_sync
@@ -136,17 +218,18 @@ class TestSweepUsesSameTransformAsRegistry:
         assert multiserver_sync._strip_nul(None) is None
 
     @patch('tasks.multiserver_sync.execute_values')
-    def test_prune_present_ids_use_same_transform_as_upsert(self, mock_ev):
+    def test_prune_present_ids_dedup_post_sanitize_and_drop_empty(self, mock_ev):
         from tasks import multiserver_sync
 
         conn, cur = _mock_db()
         cur.fetchone.return_value = (0,)
         cur.rowcount = 0
-        dirty = 'prov\x00id\x01x'
-        multiserver_sync.prune_stale_mappings(conn, 'srv1', [dirty, 'clean'])
+        multiserver_sync.prune_stale_mappings(
+            conn, 'srv1', ['prov\x00id', 'provid', '\x01', 'clean']
+        )
 
         staged = mock_ev.call_args_list[0][0][2]
-        assert staged == [(sanitize_string_for_db(dirty),), ('clean',)]
+        assert sorted(staged) == [('clean',), ('provid',)]
 
     @patch('tasks.multiserver_sync.execute_values')
     def test_stage_track_metadata_dedups_ids_that_collide_after_sanitize(self, mock_ev):
@@ -165,15 +248,60 @@ class TestSweepUsesSameTransformAsRegistry:
         assert staged == [('id1', 'Album Two', 'BB', 2021, 4, '/p2')]
 
 
+class TestAnalysisIdSeamsSanitize:
+    def test_provider_item_id_sanitizes_control_chars(self):
+        from tasks.analysis.song import provider_item_id
+
+        assert provider_item_id({'Id': 'prov\x01id'}) == 'provid'
+        assert provider_item_id({'id': 'prov\x00id'}) == 'provid'
+
+    def test_catalog_item_id_sanitizes_fallback_provider_id(self):
+        from tasks.analysis.song import catalog_item_id
+
+        assert catalog_item_id({'_catalog_item_id': 'fp_1'}) == 'fp_1'
+        assert catalog_item_id({'Id': 'prov\x01id'}) == 'provid'
+
+    def test_str_ids_sanitizes_before_db_bind(self):
+        from tasks.analysis.helper import _str_ids
+
+        assert _str_ids(['a\x00b', 'c\x1fd', 'clean']) == ['ab', 'cd', 'clean']
+
+
+class TestDurationDictsShareTheIdDomain:
+    @patch('tasks.duplicate_repair.provider_probe')
+    @patch('tasks.duplicate_repair.ms_context')
+    def test_server_durations_keys_are_sanitized(self, _ctx, probe):
+        from tasks.duplicate_repair import _server_durations
+
+        probe.fetch_all_tracks.return_value = [{'id': 'prov\x01id', 'duration': 100.0}]
+        result = _server_durations({'server_type': 'jellyfin', 'creds': {}})
+
+        assert result == {'provid': 100.0}
+
+    def test_group_duration_probes_with_sanitized_provider_ids(self):
+        from tasks.duplicate_repair import _group_duration
+
+        assert _group_duration(['prov\x01id'], {'provid': 42.0}) == 42.0
+
+    def test_migration_duration_lookup_matches_sanitized_ids(self):
+        from tasks.fingerprint_canonicalize import _durations_for_rows
+
+        cur = MagicMock()
+        cur.fetchall.side_effect = [[], [('fp_1', 'prov\x01id')]]
+        durations = _durations_for_rows(cur, ['fp_1'], [0], {'provid': 77.0}, 'srv1')
+
+        assert durations == {'fp_1': 77.0}
+
+
 class TestMigrationMapSanitization:
-    def test_migration_map_sanitizes_ids_like_new_meta(self):
+    def test_migration_map_keeps_db_sourced_old_id_raw_and_sanitizes_new_id(self):
         from tasks.provider_migration_tasks import _populate_migration_map_table
 
         cur = MagicMock()
-        _populate_migration_map_table(cur, {'old\x00id': 'new\x00id'})
+        _populate_migration_map_table(cur, {'old\x01id': 'new\x01id'})
 
         insert_call = cur.execute.call_args_list[1]
-        assert insert_call[0][1] == ['oldid', 'newid']
+        assert insert_call[0][1] == ['old\x01id', 'newid']
 
     def test_cleaned_libraries_drops_names_empty_after_sanitize(self):
         from tasks.provider_migration_tasks import _cleaned_libraries_value
@@ -204,3 +332,31 @@ class TestChromaprintIdSanitization:
 
         params = cur.execute.call_args_list[0][0][1]
         assert params[1] == 'provid'
+
+
+class TestLegacyMapIdScrub:
+    def test_scrub_skips_when_marker_present(self):
+        from database import _scrub_control_chars_from_map_ids
+
+        cur = MagicMock()
+        cur.fetchone.return_value = (1,)
+        _scrub_control_chars_from_map_ids(cur)
+
+        assert cur.execute.call_count == 1
+
+    def test_scrub_targets_exactly_the_c0_class_and_sets_marker(self):
+        from database import _scrub_control_chars_from_map_ids, _MAP_ID_SCRUB_MARKER
+
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        cur.rowcount = 0
+        _scrub_control_chars_from_map_ids(cur)
+
+        klass = cur.execute.call_args_list[1][0][1][0]
+        assert klass.startswith('[') and klass.endswith(']')
+        chars = set(klass[1:-1])
+        assert chars == {
+            chr(c) for c in (*range(0x01, 0x09), 0x0B, 0x0C, *range(0x0E, 0x20))
+        }
+        last = cur.execute.call_args_list[-1]
+        assert _MAP_ID_SCRUB_MARKER in last[0][1]


### PR DESCRIPTION
Strip NUL bytes from media-server metadata on all map and id write paths

Album analysis crashed with psycopg2 "A string literal cannot contain NUL (0x00) characters" when an artist tag carried a NUL byte, burning all RQ retries on the same album. The score table already sanitized tag text, but the registry map upserts bound it raw.

Route every such bind site through the existing sanitize_string_for_db:
- registry: upsert_artist_maps / upsert_track_maps clean names, ids and paths BEFORE the dedup keys are built (cleaning after dedup could turn the NUL crash into an ON CONFLICT cardinality error), drop entries than clean to empty, and log each sanitized value loudly
- sweep: _strip_nul now delegates to the shared sanitizer and the prune's present-id staging applies it too, so stored and staged ids always compare equal and pruning cannot churn; metadata staging keys rows by the sanitized id
- chromaprint persist/lookup and the migration id map sanitize provider ids the same way for join and lookup parity

Covered by test/unit/test_nul_sanitization_maps.py.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30550962005/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30543746998/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30543746998/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30543746998/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30543746998/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30550961931/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-822`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-822-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-822-noavx2`
<!-- pr-test-build:end -->