### PR TITLE
Postgress connection standardization

### DIFF
--- a/app_backup.py
+++ b/app_backup.py
@@ -35,6 +35,7 @@ import logging
 import tempfile
 import zipfile
 from datetime import datetime
+from functools import lru_cache
 from urllib.parse import unquote, urlsplit, urlunsplit
 from flask import Blueprint, render_template, jsonify, request, send_file
 from redis.exceptions import RedisError
@@ -96,14 +97,19 @@ def _restore_lock_held():
         return True
 
 
-def _pg_conninfo():
-    parts = urlsplit(config.DATABASE_URL)
+@lru_cache(maxsize=1)
+def _split_conninfo(database_url):
+    parts = urlsplit(database_url)
     userinfo, at, hostport = parts.netloc.rpartition('@')
     user, _, password = userinfo.partition(':')
     conninfo = urlunsplit(
         (parts.scheme, f"{user}{at}{hostport}", parts.path, parts.query, parts.fragment)
     )
     return conninfo, unquote(password)
+
+
+def _pg_conninfo():
+    return _split_conninfo(config.DATABASE_URL)
 
 
 def _pg_env():

--- a/app_backup.py
+++ b/app_backup.py
@@ -15,6 +15,9 @@ workers around a restore.
 Main Features:
 * Routes: `/backup` page, `/api/backup/create`, `/api/backup/download/<filename>`,
   `/api/backup/restore`.
+* Connects exactly like the rest of the app: `pg_dump`/`psql` are handed
+  `config.DATABASE_URL`, with the password moved into PGPASSWORD so it never
+  reaches argv or the restore log.
 * Serializes restores across containers with a self-releasing Redis lock and
   strips the PG17+ `SET transaction_timeout` prologue line that PG15/16 reject.
 * Backups are compressed to .zip; restore accepts .sql or .zip uploads
@@ -32,9 +35,10 @@ import logging
 import tempfile
 import zipfile
 from datetime import datetime
+from urllib.parse import unquote, urlsplit, urlunsplit
 from flask import Blueprint, render_template, jsonify, request, send_file
 from redis.exceptions import RedisError
-from config import POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_HOST, POSTGRES_PORT, POSTGRES_DB
+import config
 import restart_manager
 from taskqueue import new_redis_connection
 from error import error_manager
@@ -92,25 +96,28 @@ def _restore_lock_held():
         return True
 
 
+def _pg_conninfo():
+    parts = urlsplit(config.DATABASE_URL)
+    userinfo, at, hostport = parts.netloc.rpartition('@')
+    user, _, password = userinfo.partition(':')
+    conninfo = urlunsplit(
+        (parts.scheme, f"{user}{at}{hostport}", parts.path, parts.query, parts.fragment)
+    )
+    return conninfo, unquote(password)
+
+
 def _pg_env():
     """Return a copy of os.environ with PGPASSWORD set."""
+    _, password = _pg_conninfo()
     env = os.environ.copy()
-    env['PGPASSWORD'] = POSTGRES_PASSWORD
+    env['PGPASSWORD'] = password
     return env
 
 
 def _pg_cmd(tool, *extra_args):
-    """Build a pg command list with common connection args."""
-    return [
-        tool,
-        '-h',
-        POSTGRES_HOST,
-        '-p',
-        POSTGRES_PORT,
-        '-U',
-        POSTGRES_USER,
-        *extra_args,
-    ]
+    """Build a pg command list with the connection string."""
+    conninfo, _ = _pg_conninfo()
+    return [tool, '-d', conninfo, *extra_args]
 
 
 # Only files created by create_backup may be served by the download route.
@@ -178,11 +185,18 @@ def _extract_sql_if_zip(dump_file, log):
 def _run_restore_runner(dump_file, log_file):
     """Run the restore outside the Flask request in a detached process."""
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    env = _pg_env()
     with open(log_file, 'a', encoding='utf-8', errors='ignore') as log:
         log.write(f"Restore runner started at {datetime.now().isoformat()}\n")
         log.write(f"Dump file: {dump_file}\n")
         log.flush()
+
+        try:
+            env = _pg_env()
+        except ValueError as exc:
+            log.write(f"Restore FAILED: the configured database connection is unusable: {exc}\n")
+            log.flush()
+            _release_restore_lock()
+            return 1
 
         # Worker stop is published by the Flask restore endpoint before this
         # detached runner starts. The runner only waits briefly to allow
@@ -216,8 +230,6 @@ def _run_restore_runner(dump_file, log_file):
 
         restore_cmd = _pg_cmd(
             'psql',
-            '-d',
-            POSTGRES_DB,
             '-v',
             'ON_ERROR_STOP=1',
             '--single-transaction',
@@ -286,7 +298,7 @@ def _run_restore_runner(dump_file, log_file):
                 from database import USERS_PASSWORD_CHANGED_AT_DDL
 
                 ensure_cmd = _pg_cmd(
-                    'psql', '-d', POSTGRES_DB, '-v', 'ON_ERROR_STOP=1',
+                    'psql', '-v', 'ON_ERROR_STOP=1',
                     '-c', USERS_PASSWORD_CHANGED_AT_DDL,
                 )
                 ensure_ret = -1
@@ -423,7 +435,7 @@ def create_backup():
     filename = f"audiomuse_backup_{timestamp}.sql"
     filepath = os.path.join(BACKUP_DIR, filename)
 
-    cmd = _pg_cmd('pg_dump', '--clean', '--if-exists', '--no-owner', '--no-acl', '-d', POSTGRES_DB)
+    cmd = _pg_cmd('pg_dump', '--clean', '--if-exists', '--no-owner', '--no-acl')
 
     try:
         with open(filepath, 'w') as f:

--- a/config.py
+++ b/config.py
@@ -190,7 +190,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 }
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v3.1.1"
+APP_VERSION = "v3.1.2"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/config.py
+++ b/config.py
@@ -439,18 +439,26 @@ POSTGRES_HOST = os.environ.get("POSTGRES_HOST", "postgres-service.playlist") # D
 POSTGRES_PORT = os.environ.get("POSTGRES_PORT", "5432")
 POSTGRES_DB = os.environ.get("POSTGRES_DB", "audiomusedb")
 
-# Allow an explicit DATABASE_URL to override construction (useful for docker-compose or direct env override)
+# DATABASE_URL is derived, never configured. Every deployment sets the five
+# POSTGRES_* parts above and this is the single place that assembles them, so a
+# DATABASE_URL in the environment is deliberately ignored: two config sources
+# for one connection is what broke pg_dump when only one of them was set.
 from urllib.parse import quote
 
 # Percent-encode username and password to safely include special characters like '@' in the URI
 _pg_user_esc = quote(POSTGRES_USER, safe='')
 _pg_pass_esc = quote(POSTGRES_PASSWORD, safe='')
 
-# If DATABASE_URL is set in the environment, prefer it; otherwise build one using the escaped credentials
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL",
-    f"postgresql://{_pg_user_esc}:{_pg_pass_esc}@{POSTGRES_HOST}:{POSTGRES_PORT}/{POSTGRES_DB}"
-)
+# The host is escaped the same way: a normal name or IP passes through untouched,
+# while the Unix socket directory the standalone builds use gets its slashes
+# percent-encoded, which is how libpq expects a socket path inside a URI.
+_pg_host_esc = quote(POSTGRES_HOST, safe='[]:')
+
+# The database name is escaped too: an unescaped '?' or '#' would otherwise start
+# a query string or a fragment and silently point the connection somewhere else.
+_pg_db_esc = quote(POSTGRES_DB, safe='')
+
+DATABASE_URL = f"postgresql://{_pg_user_esc}:{_pg_pass_esc}@{_pg_host_esc}:{POSTGRES_PORT}/{_pg_db_esc}"
 
 DATABASE_TYPE = os.environ.get("DATABASE_TYPE", "postgres").lower()
 QUEUE_TYPE = os.environ.get("QUEUE_TYPE", "redis").lower()

--- a/config.py
+++ b/config.py
@@ -454,11 +454,15 @@ _pg_pass_esc = quote(POSTGRES_PASSWORD, safe='')
 # percent-encoded, which is how libpq expects a socket path inside a URI.
 _pg_host_esc = quote(POSTGRES_HOST, safe='[]:')
 
-# The database name is escaped too: an unescaped '?' or '#' would otherwise start
-# a query string or a fragment and silently point the connection somewhere else.
+# Database name and port are escaped too. Every part has to be, or a stray '/',
+# '?' or '#' in one of them re-splits the URI: a port of "5432/evil" silently
+# moves the connection to a database named "evil/<db>" instead of failing.
 _pg_db_esc = quote(POSTGRES_DB, safe='')
+_pg_port_esc = quote(POSTGRES_PORT, safe='')
 
-DATABASE_URL = f"postgresql://{_pg_user_esc}:{_pg_pass_esc}@{_pg_host_esc}:{POSTGRES_PORT}/{_pg_db_esc}"
+DATABASE_URL = (
+    f"postgresql://{_pg_user_esc}:{_pg_pass_esc}@{_pg_host_esc}:{_pg_port_esc}/{_pg_db_esc}"
+)
 
 DATABASE_TYPE = os.environ.get("DATABASE_TYPE", "postgres").lower()
 QUEUE_TYPE = os.environ.get("QUEUE_TYPE", "redis").lower()

--- a/native-build/linux/env.py
+++ b/native-build/linux/env.py
@@ -20,15 +20,28 @@ Main Features:
   ``native_lib_path_restored`` applies the same fix in-process (no-op when not frozen).
 * ``build_child_env`` points model/cache/temp/backup paths at ``linux.paths`` and
   forces offline HuggingFace/Transformers for supervised Flask/RQ children.
+* It derives POSTGRES_HOST/POSTGRES_PORT from the URL the embedded server
+  reported, so the children reach the socket it actually opened rather than a
+  guess: ``config.py`` builds every connection string from those two.
 """
 
 import contextlib
 import os
 import sys
+from urllib.parse import parse_qs, urlsplit
 
 from linux import paths
 
 _WORKER_ROLES = {"worker-high", "worker-default", "janitor", "restart-listener"}
+
+
+def _pg_conn_parts(database_url):
+    parts = urlsplit(database_url or "")
+    socket_dir = parse_qs(parts.query).get("host", [""])[0]
+    return (
+        socket_dir or parts.hostname or paths.pgdata_dir(),
+        str(parts.port or 5432),
+    )
 
 
 def restore_native_lib_path(env):
@@ -61,6 +74,7 @@ def native_lib_path_restored():
 def build_child_env(role, database_url, redis_url):
     env = dict(os.environ)
     model_dir = paths.model_dir()
+    pg_host, pg_port = _pg_conn_parts(database_url)
     env.update(
         {
             "AUDIOMUSE_PLATFORM": "linux",
@@ -86,8 +100,8 @@ def build_child_env(role, database_url, redis_url):
             "LYRICS_GTE_TOKENIZER_DIR": os.path.join(model_dir, "gte-multilingual-base"),
             "BACKUP_DIR": paths.backup_dir(),
             "RESTORE_LOG_DIR": paths.backup_dir(),
-            "POSTGRES_HOST": paths.pgdata_dir(),
-            "POSTGRES_PORT": "5432",
+            "POSTGRES_HOST": pg_host,
+            "POSTGRES_PORT": pg_port,
             "POSTGRES_USER": "postgres",
             "POSTGRES_PASSWORD": "",
             "POSTGRES_DB": "postgres",

--- a/native-build/macos/env.py
+++ b/native-build/macos/env.py
@@ -16,18 +16,32 @@ offline-model flags and the macOS fork-safety setting. The Windows/Linux
 Main Features:
 * Points model, cache, temp, backup and control-socket paths at ``macos.paths``.
 * Forces offline HuggingFace/Transformers and the OBJC fork-safety workaround.
+* Derives POSTGRES_HOST/POSTGRES_PORT from the URL the embedded server reported,
+  so the children reach the socket it actually opened rather than a guess:
+  ``config.py`` builds every connection string from those two.
 """
 
 import os
+from urllib.parse import parse_qs, urlsplit
 
 from macos import paths
 
 _WORKER_ROLES = {"worker-high", "worker-default", "janitor", "restart-listener"}
 
 
+def _pg_conn_parts(database_url):
+    parts = urlsplit(database_url or "")
+    socket_dir = parse_qs(parts.query).get("host", [""])[0]
+    return (
+        socket_dir or parts.hostname or paths.pgdata_dir(),
+        str(parts.port or 5432),
+    )
+
+
 def build_child_env(role, database_url, redis_url):
     env = dict(os.environ)
     model_dir = paths.model_dir()
+    pg_host, pg_port = _pg_conn_parts(database_url)
     env.update(
         {
             "AUDIOMUSE_PLATFORM": "macos",
@@ -55,8 +69,8 @@ def build_child_env(role, database_url, redis_url):
             "LYRICS_GTE_TOKENIZER_DIR": os.path.join(model_dir, "gte-multilingual-base"),
             "BACKUP_DIR": paths.backup_dir(),
             "RESTORE_LOG_DIR": paths.backup_dir(),
-            "POSTGRES_HOST": paths.pgdata_dir(),
-            "POSTGRES_PORT": "5432",
+            "POSTGRES_HOST": pg_host,
+            "POSTGRES_PORT": pg_port,
             "POSTGRES_USER": "postgres",
             "POSTGRES_PASSWORD": "",
             "POSTGRES_DB": "postgres",

--- a/tasks/mcp_helper.py
+++ b/tasks/mcp_helper.py
@@ -40,9 +40,11 @@ def _build_ai_chat_db_url():
     if not AI_CHAT_DB_USER_NAME:
         return DATABASE_URL
     parsed = urlparse(DATABASE_URL)
-    host = parsed.hostname or ''
-    if parsed.port:
-        host = f"{host}:{parsed.port}"
+    # Only the credentials are swapped: the host part is carried over verbatim.
+    # Rebuilding it from .hostname/.port would drop the brackets of an IPv6
+    # literal and mangle the percent-encoded socket directory of the standalone
+    # builds, leaving the AI chat as the one caller unable to reach the database.
+    host = parsed.netloc.rpartition('@')[2]
     return urlunparse(
         (
             parsed.scheme,

--- a/tasks/mcp_helper.py
+++ b/tasks/mcp_helper.py
@@ -19,6 +19,10 @@ Main Features:
 * get_db_connection with _ensure_ai_chat_db_user: connect as the configured
   AI_CHAT_DB_USER when set, auto-creating or resetting that role's password, and
   fall back to the primary DATABASE_URL otherwise.
+* Swapping in those credentials replaces only the userinfo and carries the host
+  part of DATABASE_URL over verbatim: rebuilding it from urlparse's .hostname
+  would drop the brackets of an IPv6 literal, lowercase the host, and mangle the
+  percent-encoded socket directory of the standalone builds.
 """
 
 import logging
@@ -40,10 +44,6 @@ def _build_ai_chat_db_url():
     if not AI_CHAT_DB_USER_NAME:
         return DATABASE_URL
     parsed = urlparse(DATABASE_URL)
-    # Only the credentials are swapped: the host part is carried over verbatim.
-    # Rebuilding it from .hostname/.port would drop the brackets of an IPv6
-    # literal and mangle the percent-encoded socket directory of the standalone
-    # builds, leaving the AI chat as the one caller unable to reach the database.
     host = parsed.netloc.rpartition('@')[2]
     return urlunparse(
         (

--- a/tasks/provider_migration_tasks.py
+++ b/tasks/provider_migration_tasks.py
@@ -137,13 +137,7 @@ def _get_dedicated_conn():
     import psycopg2
     import config  # noqa: F401  (lazy so tests don't need live env vars)
 
-    return psycopg2.connect(
-        host=config.POSTGRES_HOST,
-        port=config.POSTGRES_PORT,
-        user=config.POSTGRES_USER,
-        password=config.POSTGRES_PASSWORD,
-        dbname=config.POSTGRES_DB,
-    )
+    return psycopg2.connect(config.DATABASE_URL)
 
 
 def _get_redis():

--- a/tasks/setup_manager.py
+++ b/tasks/setup_manager.py
@@ -25,6 +25,11 @@ Main Features:
   parameters in config.py, without rewriting values that are still valid.
 * Hashes secrets with Argon2, skips re-hashing values already hashed, treats
   placeholder values as unset, and reports whether server/auth setup is complete.
+* The connection is always ``config.DATABASE_URL`` and is resolved on first use,
+  not at construction, so importing this module never pulls in config. In a
+  frozen build only a supervised child connects at all: the standalone launcher
+  imports config before its embedded Postgres exists and must dial nothing, and
+  ``build_child_env`` sets SERVICE_TYPE on exactly the children.
 """
 
 import os
@@ -102,9 +107,6 @@ class SetupManager:
     def _get_database_url(self):
         import sys
 
-        # The standalone launcher imports config before it has started its
-        # embedded server, and must not dial anything: SERVICE_TYPE is set by
-        # build_child_env, so only a supervised child gets a connection.
         if getattr(sys, "frozen", False) and not os.environ.get("SERVICE_TYPE"):
             return None
 

--- a/tasks/setup_manager.py
+++ b/tasks/setup_manager.py
@@ -34,7 +34,6 @@ import psycopg2
 from argon2 import PasswordHasher
 from argon2 import exceptions as argon2_exceptions
 from psycopg2.extras import RealDictCursor
-from urllib.parse import quote
 
 DEFAULT_CONFIG_TABLE = "app_config"
 BASIC_SERVER_FIELDS = {
@@ -83,30 +82,35 @@ def hydrate_worker_config():
 
 class SetupManager:
     def __init__(self, database_url=None):
-        self.database_url = database_url or self._get_database_url()
+        self._database_url = database_url or None
+        self._database_url_resolved = self._database_url is not None
         self.logger = logging.getLogger(__name__)
         self._password_hasher = PasswordHasher()
 
-    def _get_database_url(self):
-        env_url = os.environ.get("DATABASE_URL")
-        if env_url:
-            return env_url
+    @property
+    def database_url(self):
+        if not self._database_url_resolved:
+            self._database_url = self._get_database_url()
+            self._database_url_resolved = True
+        return self._database_url
 
+    @database_url.setter
+    def database_url(self, value):
+        self._database_url = value
+        self._database_url_resolved = True
+
+    def _get_database_url(self):
         import sys
 
-        if getattr(sys, "frozen", False):
+        # The standalone launcher imports config before it has started its
+        # embedded server, and must not dial anything: SERVICE_TYPE is set by
+        # build_child_env, so only a supervised child gets a connection.
+        if getattr(sys, "frozen", False) and not os.environ.get("SERVICE_TYPE"):
             return None
 
         import config
 
-        user = os.environ.get("POSTGRES_USER") or config.POSTGRES_USER
-        password = os.environ.get("POSTGRES_PASSWORD") or config.POSTGRES_PASSWORD
-        host = os.environ.get("POSTGRES_HOST") or config.POSTGRES_HOST
-        port = os.environ.get("POSTGRES_PORT") or config.POSTGRES_PORT
-        db = os.environ.get("POSTGRES_DB") or config.POSTGRES_DB
-        user_escaped = quote(user, safe='')
-        password_escaped = quote(password, safe='')
-        return f"postgresql://{user_escaped}:{password_escaped}@{host}:{port}/{db}"
+        return config.DATABASE_URL
 
     def get_connection(self):
         if not self.database_url:

--- a/test/unit/test_app_backup_restore.py
+++ b/test/unit/test_app_backup_restore.py
@@ -18,6 +18,8 @@ Main Features:
 * Create returning the zipped backup file name as JSON; download serving only
   filenames matching the backup pattern and 404ing everything else.
 * Zip-or-sql detection by magic bytes with in-zip .sql extraction for restore.
+* pg_dump/psql connection args come from config.DATABASE_URL, with the password
+  moved into PGPASSWORD so it never appears in argv.
 """
 
 import io
@@ -27,6 +29,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from flask import Flask
+from psycopg2.extensions import parse_dsn
 
 import app_backup
 
@@ -240,6 +243,71 @@ class TestFeedDumpStrip:
         assert result.get('ok') is not True
         assert 'error' in result
         assert fake.closed is True
+
+
+class TestPgConnectionArgs:
+    def test_pg_dump_targets_the_database_url(self, monkeypatch):
+        monkeypatch.setattr(
+            app_backup.config, 'DATABASE_URL', 'postgresql://audiomuse:pw@postgres:5432/audiomusedb'
+        )
+        cmd = app_backup._pg_cmd('pg_dump', '--clean')
+        assert cmd == [
+            'pg_dump', '-d', 'postgresql://audiomuse@postgres:5432/audiomusedb', '--clean',
+        ]
+
+    def test_password_goes_to_pgpassword_and_never_into_argv(self, monkeypatch):
+        monkeypatch.setattr(
+            app_backup.config, 'DATABASE_URL', 'postgresql://audiomuse:s3cr%40t@db:5432/audiomusedb'
+        )
+        assert 's3cr' not in ' '.join(app_backup._pg_cmd('pg_dump'))
+        assert app_backup._pg_env()['PGPASSWORD'] == 's3cr@t'
+
+    def test_unix_socket_url_still_resolves_to_the_socket_directory(self, monkeypatch):
+        monkeypatch.setattr(
+            app_backup.config,
+            'DATABASE_URL',
+            'postgresql://postgres:@%2Fvar%2Flib%2Fpgdata:5432/postgres',
+        )
+        cmd = app_backup._pg_cmd('psql', '-v', 'ON_ERROR_STOP=1')
+        assert cmd == [
+            'psql',
+            '-d',
+            'postgresql://postgres@%2Fvar%2Flib%2Fpgdata:5432/postgres',
+            '-v',
+            'ON_ERROR_STOP=1',
+        ]
+        assert parse_dsn(cmd[2])['host'] == '/var/lib/pgdata'
+        assert app_backup._pg_env()['PGPASSWORD'] == ''
+
+    def test_unusable_connection_releases_the_restore_lock_and_logs(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(app_backup.config, 'DATABASE_URL', 'postgresql://u:p@[::1:5432/db')
+        released = []
+        monkeypatch.setattr(app_backup, '_release_restore_lock', lambda: released.append(True))
+        log_file = tmp_path / 'restore.log'
+        assert app_backup._run_restore_runner(str(tmp_path / 'dump.sql'), str(log_file)) == 1
+        assert released == [True]
+        assert 'unusable' in log_file.read_text()
+
+    def test_create_backup_runs_pg_dump_against_the_database_url(
+        self, client, monkeypatch, tmp_path
+    ):
+        monkeypatch.setattr(app_backup, 'BACKUP_DIR', str(tmp_path))
+        monkeypatch.setattr(
+            app_backup.config, 'DATABASE_URL', 'postgresql://audiomuse:pw@postgres:5432/audiomusedb'
+        )
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen['cmd'] = cmd
+            seen['env'] = kwargs['env']
+            kwargs['stdout'].write('-- dump\n')
+            return MagicMock(returncode=0, stderr='')
+
+        monkeypatch.setattr(app_backup.subprocess, 'run', fake_run)
+        assert client.post('/api/backup/create').status_code == 200
+        assert 'postgresql://audiomuse@postgres:5432/audiomusedb' in seen['cmd']
+        assert '-h' not in seen['cmd']
+        assert seen['env']['PGPASSWORD'] == 'pw'
 
 
 class TestRestoreChunkProgress:

--- a/test/unit/test_config_centralization.py
+++ b/test/unit/test_config_centralization.py
@@ -17,7 +17,10 @@ default or use a getattr(config, ...) fallback default.
 Main Features:
 * config attributes exist with the documented default and coerce env overrides
 * DATABASE_URL is derived from the five POSTGRES_* parts only and a DATABASE_URL
-  env var is ignored; libpq resolves the result for TCP, IPv6 and socket hosts
+  env var is ignored; libpq resolves the result for TCP, IPv6 and socket hosts,
+  and every part is escaped so none of them can re-split the URI
+* No module outside test/ reads DATABASE_URL from the environment, by get/getenv
+  or by subscript
 * Importer modules still reference the config names they depend on
 * Importers have no local os.environ.get or getattr-fallback default for those names
 * Repo-wide: no runtime module re-reads a config-owned env var with a default
@@ -156,6 +159,17 @@ class TestDatabaseUrlIsDerivedFromThePostgresParts:
         assert reloaded.DATABASE_URL == 'postgresql://myuser:mypass@myhost:5433/db%3Fx%23y'
         assert parse_dsn(reloaded.DATABASE_URL)['dbname'] == 'db?x#y'
 
+    def test_a_malformed_port_cannot_repoint_the_database(self, monkeypatch):
+        env = dict(_PG_PARTS, POSTGRES_PORT='5432/evil')
+        reloaded = _reload_config_with(monkeypatch, env)
+        parsed = parse_dsn(reloaded.DATABASE_URL)
+        assert parsed['dbname'] == 'mydb'
+        assert parsed['port'] == '5432/evil'
+
+    def test_a_normal_port_is_left_alone(self, monkeypatch):
+        reloaded = _reload_config_with(monkeypatch, _PG_PARTS)
+        assert reloaded.DATABASE_URL.endswith('@myhost:5433/mydb')
+
 
 def _read_source(relative_path):
     repo_root = os.path.normpath(
@@ -270,20 +284,43 @@ def _config_reread_violation(rel, node, owned):
 _DERIVED_ONLY_ENV_NAMES = ('DATABASE_URL',)
 
 
+def _tracked_py_files_outside_tests():
+    out = subprocess.check_output(['git', 'ls-files', '*.py'], cwd=_REPO_ROOT).decode('utf-8')
+    return [rel for rel in out.splitlines() if rel and not rel.startswith('test/')]
+
+
+def _is_os_environ_subscript(node):
+    if not isinstance(node, ast.Subscript):
+        return False
+    target = node.value
+    return (
+        isinstance(target, ast.Attribute)
+        and target.attr == 'environ'
+        and isinstance(target.value, ast.Name)
+        and target.value.id == 'os'
+    )
+
+
+def _env_name_read(node):
+    if isinstance(node, ast.Call) and _is_os_environ_get(node):
+        if node.args and isinstance(node.args[0], ast.Constant):
+            return node.args[0].value
+    if _is_os_environ_subscript(node) and isinstance(node.slice, ast.Constant):
+        return node.slice.value
+    return None
+
+
 def test_no_module_reads_the_derived_database_url_from_env():
     violations = []
-    for rel in ['config.py'] + _tracked_runtime_py_files():
+    for rel in _tracked_py_files_outside_tests():
         for node in ast.walk(_parse(rel)):
-            if not (isinstance(node, ast.Call) and _is_os_environ_get(node)):
-                continue
-            if not (node.args and isinstance(node.args[0], ast.Constant)):
-                continue
-            if node.args[0].value in _DERIVED_ONLY_ENV_NAMES:
-                violations.append(f'{rel}:{node.lineno}: os.environ.get({node.args[0].value!r})')
+            name = _env_name_read(node)
+            if name in _DERIVED_ONLY_ENV_NAMES:
+                violations.append(f'{rel}:{node.lineno}: reads {name!r} from the environment')
     assert not violations, (
         'DATABASE_URL is derived by config.py from the POSTGRES_* parts and must never '
-        'be read from the environment, with or without a default (use config.DATABASE_URL):\n  '
-        + '\n  '.join(violations)
+        'be read from the environment, by get/getenv or subscript, with or without a '
+        'default (use config.DATABASE_URL):\n  ' + '\n  '.join(violations)
     )
 
 

--- a/test/unit/test_config_centralization.py
+++ b/test/unit/test_config_centralization.py
@@ -16,6 +16,8 @@ default or use a getattr(config, ...) fallback default.
 
 Main Features:
 * config attributes exist with the documented default and coerce env overrides
+* DATABASE_URL is derived from the five POSTGRES_* parts only and a DATABASE_URL
+  env var is ignored; libpq resolves the result for TCP, IPv6 and socket hosts
 * Importer modules still reference the config names they depend on
 * Importers have no local os.environ.get or getattr-fallback default for those names
 * Repo-wide: no runtime module re-reads a config-owned env var with a default
@@ -29,6 +31,7 @@ import re
 import subprocess
 
 import pytest
+from psycopg2.extensions import parse_dsn
 
 import config
 
@@ -70,6 +73,88 @@ def test_attribute_honors_env(attr, _default, env_var, env_value, expected, monk
     finally:
         monkeypatch.delenv(env_var, raising=False)
         importlib.reload(config)
+
+
+_PG_PARTS = {
+    'POSTGRES_USER': 'myuser',
+    'POSTGRES_PASSWORD': 'mypass',
+    'POSTGRES_HOST': 'myhost',
+    'POSTGRES_PORT': '5433',
+    'POSTGRES_DB': 'mydb',
+}
+
+
+def _reload_config_with(monkeypatch, env):
+    for key in list(_PG_PARTS) + ['DATABASE_URL']:
+        monkeypatch.delenv(key, raising=False)
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    return importlib.reload(config)
+
+
+def _refuse_connection(*_args, **_kwargs):
+    raise RuntimeError('unit test: config reload must not open a database connection')
+
+
+class TestDatabaseUrlIsDerivedFromThePostgresParts:
+    @pytest.fixture(autouse=True)
+    def _offline_config_reload(self, monkeypatch):
+        from tasks.setup_manager import SetupManager
+
+        monkeypatch.setattr(SetupManager, 'get_connection', _refuse_connection)
+        yield
+        for key in list(_PG_PARTS) + ['DATABASE_URL']:
+            monkeypatch.delenv(key, raising=False)
+        importlib.reload(config)
+
+    def test_url_is_built_from_the_five_parts(self, monkeypatch):
+        reloaded = _reload_config_with(monkeypatch, _PG_PARTS)
+        assert reloaded.DATABASE_URL == 'postgresql://myuser:mypass@myhost:5433/mydb'
+
+    def test_database_url_env_var_is_ignored(self, monkeypatch):
+        env = dict(_PG_PARTS, DATABASE_URL='postgresql://someone:else@elsewhere:1/other')
+        reloaded = _reload_config_with(monkeypatch, env)
+        assert reloaded.DATABASE_URL == 'postgresql://myuser:mypass@myhost:5433/mydb'
+
+    def test_credentials_are_percent_encoded(self, monkeypatch):
+        env = dict(_PG_PARTS, POSTGRES_USER='user@domain', POSTGRES_PASSWORD='p@ss:word')
+        reloaded = _reload_config_with(monkeypatch, env)
+        assert reloaded.DATABASE_URL == 'postgresql://user%40domain:p%40ss%3Aword@myhost:5433/mydb'
+
+    def test_unix_socket_directory_host_is_percent_encoded(self, monkeypatch):
+        env = dict(_PG_PARTS, POSTGRES_HOST='/var/lib/audiomuse/pgdata')
+        reloaded = _reload_config_with(monkeypatch, env)
+        assert reloaded.DATABASE_URL == (
+            'postgresql://myuser:mypass@%2Fvar%2Flib%2Faudiomuse%2Fpgdata:5433/mydb'
+        )
+        assert parse_dsn(reloaded.DATABASE_URL)['host'] == '/var/lib/audiomuse/pgdata'
+
+    def test_socket_directory_with_a_space_stays_resolvable(self, monkeypatch):
+        env = dict(
+            _PG_PARTS,
+            POSTGRES_HOST='/Users/me/Library/Application Support/AudioMuse-AI/pgdata',
+            POSTGRES_PASSWORD='',
+            POSTGRES_USER='postgres',
+            POSTGRES_DB='postgres',
+            POSTGRES_PORT='5432',
+        )
+        reloaded = _reload_config_with(monkeypatch, env)
+        parsed = parse_dsn(reloaded.DATABASE_URL)
+        assert parsed['host'] == '/Users/me/Library/Application Support/AudioMuse-AI/pgdata'
+        assert parsed['dbname'] == 'postgres'
+        assert parsed['port'] == '5432'
+
+    def test_ipv6_host_keeps_its_brackets(self, monkeypatch):
+        env = dict(_PG_PARTS, POSTGRES_HOST='[::1]')
+        reloaded = _reload_config_with(monkeypatch, env)
+        assert reloaded.DATABASE_URL == 'postgresql://myuser:mypass@[::1]:5433/mydb'
+        assert parse_dsn(reloaded.DATABASE_URL)['host'] == '::1'
+
+    def test_database_name_is_percent_encoded(self, monkeypatch):
+        env = dict(_PG_PARTS, POSTGRES_DB='db?x#y')
+        reloaded = _reload_config_with(monkeypatch, env)
+        assert reloaded.DATABASE_URL == 'postgresql://myuser:mypass@myhost:5433/db%3Fx%23y'
+        assert parse_dsn(reloaded.DATABASE_URL)['dbname'] == 'db?x#y'
 
 
 def _read_source(relative_path):
@@ -180,6 +265,26 @@ def _config_reread_violation(rel, node, owned):
     if name in owned:
         return f'{rel}:{node.lineno}: os.environ.get({name!r}, <default>)'
     return None
+
+
+_DERIVED_ONLY_ENV_NAMES = ('DATABASE_URL',)
+
+
+def test_no_module_reads_the_derived_database_url_from_env():
+    violations = []
+    for rel in ['config.py'] + _tracked_runtime_py_files():
+        for node in ast.walk(_parse(rel)):
+            if not (isinstance(node, ast.Call) and _is_os_environ_get(node)):
+                continue
+            if not (node.args and isinstance(node.args[0], ast.Constant)):
+                continue
+            if node.args[0].value in _DERIVED_ONLY_ENV_NAMES:
+                violations.append(f'{rel}:{node.lineno}: os.environ.get({node.args[0].value!r})')
+    assert not violations, (
+        'DATABASE_URL is derived by config.py from the POSTGRES_* parts and must never '
+        'be read from the environment, with or without a default (use config.DATABASE_URL):\n  '
+        + '\n  '.join(violations)
+    )
 
 
 def test_no_module_rereads_config_env_with_default():

--- a/test/unit/test_embedded_pg_env_parts.py
+++ b/test/unit/test_embedded_pg_env_parts.py
@@ -1,0 +1,86 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""POSTGRES_HOST/POSTGRES_PORT derivation in the Linux and macOS standalone builds.
+
+config.py assembles every connection string from the five POSTGRES_* parts, so
+in the standalone builds those parts must carry what the embedded server
+actually reported (pgserver picks the socket directory at runtime and falls back
+to a hashed runtime path when the pgdata path is too long for a Unix socket).
+
+Main Features:
+* A socket URL yields the reported socket directory, not the pgdata guess
+* A TCP URL yields its host and port
+* An empty or hostless URL falls back to the pgdata directory and 5432
+* The parts round-trip through config's URL assembly back to the same host
+"""
+
+import importlib.util
+import os
+import sys
+
+import pytest
+from psycopg2.extensions import parse_dsn
+from urllib.parse import quote
+
+REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..'))
+NATIVE_BUILD = os.path.join(REPO_ROOT, 'native-build')
+
+SOCKET_DIR = '/Users/me/Library/Application Support/AudioMuse-AI/pgdata'
+
+
+def _load_env_module(platform_name):
+    for entry in (REPO_ROOT, NATIVE_BUILD):
+        if entry not in sys.path:
+            sys.path.insert(0, entry)
+    mod_name = 'native_env_under_test_' + platform_name
+    if mod_name in sys.modules:
+        return sys.modules[mod_name]
+    path = os.path.join(NATIVE_BUILD, platform_name, 'env.py')
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except Exception as exc:
+        sys.modules.pop(mod_name, None)
+        pytest.skip(f"{platform_name} env does not import on this platform: {exc!r}")
+    return mod
+
+
+@pytest.fixture(params=['linux', 'macos'])
+def env_mod(request):
+    return _load_env_module(request.param)
+
+
+class TestPgConnParts:
+    def test_socket_url_yields_the_reported_socket_directory(self, env_mod):
+        url = f"postgresql://postgres:@/postgres?host={SOCKET_DIR}"
+        assert env_mod._pg_conn_parts(url) == (SOCKET_DIR, '5432')
+
+    def test_socket_directory_is_not_assumed_to_be_the_pgdata_directory(self, env_mod, monkeypatch):
+        monkeypatch.setattr(env_mod.paths, 'pgdata_dir', lambda: '/never/used')
+        url = "postgresql://postgres:@/postgres?host=/tmp/pgserver-3f2a1b/"
+        assert env_mod._pg_conn_parts(url)[0] == '/tmp/pgserver-3f2a1b/'
+
+    def test_tcp_url_yields_its_host_and_port(self, env_mod):
+        assert env_mod._pg_conn_parts('postgresql://postgres:pw@127.0.0.1:5544/postgres') == (
+            '127.0.0.1',
+            '5544',
+        )
+
+    @pytest.mark.parametrize('url', ['', None, 'postgresql://postgres@/postgres'])
+    def test_hostless_url_falls_back_to_the_pgdata_directory(self, env_mod, monkeypatch, url):
+        monkeypatch.setattr(env_mod.paths, 'pgdata_dir', lambda: '/fallback/pgdata')
+        assert env_mod._pg_conn_parts(url) == ('/fallback/pgdata', '5432')
+
+    def test_derived_parts_rebuild_a_url_libpq_resolves_to_the_same_socket(self, env_mod):
+        host, port = env_mod._pg_conn_parts(f"postgresql://postgres:@/postgres?host={SOCKET_DIR}")
+        rebuilt = f"postgresql://postgres:@{quote(host, safe='[]:')}:{port}/postgres"
+        assert parse_dsn(rebuilt)['host'] == SOCKET_DIR
+        assert parse_dsn(rebuilt)['port'] == '5432'

--- a/test/unit/test_mcp_server.py
+++ b/test/unit/test_mcp_server.py
@@ -1625,3 +1625,43 @@ class TestGenreVocabCoverage:
         from tasks.ai.vocab import GENRE_VOCAB
 
         assert set(config.STRATIFIED_GENRES) <= set(GENRE_VOCAB)
+
+
+class TestAiChatDbUrl:
+    @staticmethod
+    def _build(monkeypatch, database_url, user='ai_user', password='pw'):
+        import config
+        from tasks.mcp_helper import _build_ai_chat_db_url
+
+        monkeypatch.setattr(config, 'DATABASE_URL', database_url)
+        monkeypatch.setattr(config, 'AI_CHAT_DB_USER_NAME', user)
+        monkeypatch.setattr(config, 'AI_CHAT_DB_USER_PASSWORD', password)
+        return _build_ai_chat_db_url()
+
+    def test_only_the_credentials_are_swapped(self, monkeypatch):
+        url = self._build(monkeypatch, 'postgresql://audiomuse:secret@postgres:5432/audiomusedb')
+        assert url == 'postgresql://ai_user:pw@postgres:5432/audiomusedb'
+
+    def test_ipv6_host_keeps_its_brackets(self, monkeypatch):
+        from psycopg2.extensions import parse_dsn
+
+        url = self._build(monkeypatch, 'postgresql://audiomuse:secret@[::1]:5432/audiomusedb')
+        assert url == 'postgresql://ai_user:pw@[::1]:5432/audiomusedb'
+        assert parse_dsn(url)['host'] == '::1'
+
+    def test_unix_socket_host_survives_percent_encoded(self, monkeypatch):
+        from psycopg2.extensions import parse_dsn
+
+        url = self._build(
+            monkeypatch, 'postgresql://postgres:@%2Fvar%2Flib%2Fpgdata:5432/postgres'
+        )
+        assert parse_dsn(url)['host'] == '/var/lib/pgdata'
+        assert parse_dsn(url)['user'] == 'ai_user'
+
+    def test_uppercase_host_is_not_lowercased(self, monkeypatch):
+        url = self._build(monkeypatch, 'postgresql://audiomuse:secret@PGHost.local:5432/db')
+        assert url == 'postgresql://ai_user:pw@PGHost.local:5432/db'
+
+    def test_no_chat_user_returns_the_primary_url_untouched(self, monkeypatch):
+        url = self._build(monkeypatch, 'postgresql://audiomuse:secret@[::1]:5432/db', user='')
+        assert url == 'postgresql://audiomuse:secret@[::1]:5432/db'

--- a/test/unit/test_setup_manager.py
+++ b/test/unit/test_setup_manager.py
@@ -215,28 +215,40 @@ class TestCastFormatRoundTrip:
         assert recovered == original
 
 
+DERIVED = "postgresql://derived:pw@derived-host:5432/derived-db"
+FROM_ENV = "postgresql://fromenv:pw@fromenv-host:5432/fromenv-db"
+
+
 class TestGetDatabaseUrl:
-    def test_returns_the_config_database_url(self):
+    @pytest.fixture(autouse=True)
+    def _derived_url(self, monkeypatch):
         import config
 
-        assert _mgr(database_url=None)._get_database_url() == config.DATABASE_URL
+        monkeypatch.setattr(config, 'DATABASE_URL', DERIVED)
+
+    def test_returns_the_config_database_url(self):
+        assert _mgr(database_url=None)._get_database_url() == DERIVED
 
     def test_database_url_env_var_is_ignored(self):
-        with patch.dict("os.environ", {"DATABASE_URL": "postgresql://u:p@h:5/d"}, clear=False):
-            url = _mgr(database_url=None)._get_database_url()
-        assert url != "postgresql://u:p@h:5/d"
+        with patch.dict("os.environ", {"DATABASE_URL": FROM_ENV}, clear=False):
+            assert _mgr(database_url=None)._get_database_url() == DERIVED
+
+    def test_postgres_part_env_vars_are_ignored_too(self):
+        env = {"POSTGRES_HOST": "late-host", "POSTGRES_DB": "late-db", "POSTGRES_PORT": "5599"}
+        with patch.dict("os.environ", env, clear=False):
+            assert _mgr(database_url=None)._get_database_url() == DERIVED
 
     def test_empty_url_argument_falls_back_to_the_derived_url(self):
+        assert SetupManager(database_url="").database_url == DERIVED
+
+    def test_url_is_resolved_on_first_use_not_at_construction(self, monkeypatch):
         import config
 
-        assert SetupManager(database_url="").database_url == config.DATABASE_URL
-
-    def test_url_is_resolved_on_first_use_not_at_construction(self):
-        import config
-
+        monkeypatch.setattr(config, 'DATABASE_URL', 'postgresql://stale:pw@stale-host:5432/stale')
         mgr = SetupManager()
         assert mgr._database_url_resolved is False
-        assert mgr.database_url == config.DATABASE_URL
+        monkeypatch.setattr(config, 'DATABASE_URL', DERIVED)
+        assert mgr.database_url == DERIVED
         assert mgr._database_url_resolved is True
 
     def test_explicit_url_is_kept_and_never_resolved(self):

--- a/test/unit/test_setup_manager.py
+++ b/test/unit/test_setup_manager.py
@@ -15,7 +15,8 @@ Main Features:
 * Placeholder and empty/whitespace strings are detected while real values pass
 * Argon2id/argon2i hashes are recognized and bcrypt/plain are not
 * cast_value coerces bool/int/float/list/dict and falls back on invalid JSON
-* cast and format round-trip preserves the original value; DATABASE_URL env honored
+* cast and format round-trip preserves the original value; the connection always
+  comes from config.DATABASE_URL and a DATABASE_URL env var is ignored
 * Startup pruning deletes retired keys without touching valid config rows
 * Importing tasks.setup_manager before config keeps the DB-override init working
 """
@@ -215,51 +216,33 @@ class TestCastFormatRoundTrip:
 
 
 class TestGetDatabaseUrl:
-    def test_uses_database_url_env(self):
+    def test_returns_the_config_database_url(self):
+        import config
+
+        assert _mgr(database_url=None)._get_database_url() == config.DATABASE_URL
+
+    def test_database_url_env_var_is_ignored(self):
         with patch.dict("os.environ", {"DATABASE_URL": "postgresql://u:p@h:5/d"}, clear=False):
             url = _mgr(database_url=None)._get_database_url()
-            assert url == "postgresql://u:p@h:5/d"
+        assert url != "postgresql://u:p@h:5/d"
 
-    def test_builds_from_components(self):
-        env = {
-            "POSTGRES_USER": "myuser",
-            "POSTGRES_PASSWORD": "mypass",
-            "POSTGRES_HOST": "myhost",
-            "POSTGRES_PORT": "5433",
-            "POSTGRES_DB": "mydb",
-        }
-        old = os.environ.pop("DATABASE_URL", None)
-        try:
-            with patch.dict("os.environ", env, clear=False):
-                mgr = SetupManager.__new__(SetupManager)
-                url = mgr._get_database_url()
-                assert "myuser" in url
-                assert "mypass" in url
-                assert "myhost" in url
-                assert "5433" in url
-                assert "mydb" in url
-        finally:
-            if old is not None:
-                os.environ["DATABASE_URL"] = old
+    def test_empty_url_argument_falls_back_to_the_derived_url(self):
+        import config
 
-    def test_special_chars_escaped(self):
-        env = {
-            "POSTGRES_USER": "user@domain",
-            "POSTGRES_PASSWORD": "p@ss:word",
-            "POSTGRES_HOST": "host",
-            "POSTGRES_PORT": "5432",
-            "POSTGRES_DB": "db",
-        }
-        old = os.environ.pop("DATABASE_URL", None)
-        try:
-            with patch.dict("os.environ", env, clear=False):
-                mgr = SetupManager.__new__(SetupManager)
-                url = mgr._get_database_url()
-                assert "user%40domain" in url
-                assert "p%40ss%3Aword" in url
-        finally:
-            if old is not None:
-                os.environ["DATABASE_URL"] = old
+        assert SetupManager(database_url="").database_url == config.DATABASE_URL
+
+    def test_url_is_resolved_on_first_use_not_at_construction(self):
+        import config
+
+        mgr = SetupManager()
+        assert mgr._database_url_resolved is False
+        assert mgr.database_url == config.DATABASE_URL
+        assert mgr._database_url_resolved is True
+
+    def test_explicit_url_is_kept_and_never_resolved(self):
+        mgr = SetupManager(database_url="postgresql://explicit:pw@host:5432/db")
+        assert mgr._database_url_resolved is True
+        assert mgr.database_url == "postgresql://explicit:pw@host:5432/db"
 
 
 class TestIsValidServerConfig:


### PR DESCRIPTION
This PR standardize the way on which the connection is stabilish on the database:
- config.py now always builds DATABASE_URL from the five POSTGRES_* params and never reads it from the environment; user, password, host and database name are percent-encoded, so a socket path or IPv6 host survives.

- app_backup.py runs pg_dump/psql against that URL instead of -h POSTGRES_HOST, with the password in PGPASSWORD, and releases the restore lock if the URL is unusable.

- provider_migration_tasks.py and setup_manager.py connect through the same URL.

- mcp_helper.py copies the host verbatim rather than through .hostname, fixing IPv6 and letter case.

- native-build linux/macos take POSTGRES_HOST/PORT from the embedded server's reported URL.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466217/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466223/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466223/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466223/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466223/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/30747466233/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-833`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-833-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-833-noavx2`
<!-- pr-test-build:end -->