### PR TITLE
Analysis: skip song in error from previous run

### DIFF
--- a/app_dashboard.py
+++ b/app_dashboard.py
@@ -73,7 +73,7 @@ def dashboard_page():
 # so there is nothing to leak. Deep pages are clamped by DASHBOARD_BROWSE_MAX_OFFSET
 # so a 1M-row table can never be walked end to end.
 
-_BROWSE_KINDS = ('songs', 'artists', 'albums')
+_BROWSE_KINDS = ('songs', 'artists', 'albums', 'unanalyzable')
 _BROWSE_FILTERS = ('all', 'unique', 'duplicates', 'orphan')
 _BROWSE_MIN_QUERY = 2
 
@@ -180,6 +180,26 @@ def _browse_albums_sql(server_id, q):
     return sql, params
 
 
+def _browse_unanalyzable_sql(server_id, q):
+    params = []
+    sql = (
+        "SELECT e.title, e.artist, e.duration_seconds, e.reason_code, "
+        "e.created_at, e.updated_at, ms.name "
+        "FROM analysis_exclusions e JOIN music_servers ms ON ms.server_id = e.server_id"
+    )
+    where = []
+    if server_id:
+        where.append("e.server_id = %s")
+        params.append(server_id)
+    if q:
+        where.append("(COALESCE(e.title, '') ILIKE %s OR COALESCE(e.artist, '') ILIKE %s)")
+        params.extend((_browse_like(q), _browse_like(q)))
+    if where:
+        sql += " WHERE " + " AND ".join(where)
+    sql += " ORDER BY e.updated_at DESC NULLS LAST, e.title ASC, e.artist ASC"
+    return sql, params
+
+
 def _browse_serialize(kind, rows):
     out = []
     if kind == 'artists':
@@ -188,6 +208,17 @@ def _browse_serialize(kind, rows):
     elif kind == 'albums':
         for r in rows:
             out.append({'album_artist': r[0], 'album': r[1]})
+    elif kind == 'unanalyzable':
+        for r in rows:
+            out.append({
+                'title': r[0],
+                'artist': r[1],
+                'duration_seconds': float(r[2]) if r[2] is not None else None,
+                'reason_code': int(r[3]) if r[3] is not None else None,
+                'created_at': to_local_str(r[4]),
+                'updated_at': to_local_str(r[5]),
+                'server': r[6],
+            })
     else:
         for r in rows:
             item = {
@@ -233,6 +264,8 @@ def _browse_total(content, kind, server_id, server_name, filt, has_q):
         return content.get('distinct_artists')
     if kind == 'albums' and server_id is None:
         return content.get('distinct_albums')
+    if kind == 'unanalyzable' and server_id is None:
+        return content.get('unanalyzable_tracks')
     return None
 
 
@@ -285,6 +318,8 @@ def browse_api():
         sql, params = _browse_artists_sql(server_id, q)
     elif kind == 'albums':
         sql, params = _browse_albums_sql(server_id, q)
+    elif kind == 'unanalyzable':
+        sql, params = _browse_unanalyzable_sql(server_id, q)
     else:
         sql, params = _browse_songs_sql(server_id, filt, q)
 
@@ -527,6 +562,9 @@ def _collect_fast_metrics(cur):
         # A genuine subset of the catalogue: CLAP is a separate pass that runs
         # after analysis, so its percentage can really be < 100.
         'clap_indexed': _counted_or_none(cur, "SELECT COUNT(*) FROM clap_embedding"),
+        'unanalyzable_tracks': _counted_or_none(
+            cur, "SELECT COUNT(*) FROM analysis_exclusions"
+        ),
     }
     metrics['music_servers'] = _collect_music_server_metrics(
         cur, total_songs=metrics['total_songs']
@@ -550,7 +588,7 @@ def _collect_fast_metrics(cur):
         metrics[k] is None
         for k in (
             'total_songs', 'distinct_artists', 'distinct_albums',
-            'clap_indexed',
+            'clap_indexed', 'unanalyzable_tracks',
         )
     )
     return metrics

--- a/database.py
+++ b/database.py
@@ -917,6 +917,109 @@ def get_chromaprint(server_id, provider_track_id):
         cur.close()
 
 
+def record_analysis_exclusion(server_id, provider_item_id, duration_seconds=None,
+                              title=None, artist=None, reason_code=2007, conn=None):
+    if not server_id or not provider_item_id:
+        return False
+    db = conn or get_db()
+    cur = db.cursor()
+    try:
+        duration = None
+        if duration_seconds is not None:
+            try:
+                duration = float(duration_seconds)
+            except (TypeError, ValueError):
+                duration = None
+        cur.execute(
+            """
+            INSERT INTO analysis_exclusions
+                (server_id, provider_item_id, duration_seconds, title, artist,
+                 reason_code, created_at, updated_at)
+            VALUES (%s, %s, %s, %s, %s, %s, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ON CONFLICT (server_id, provider_item_id) DO UPDATE SET
+                duration_seconds = EXCLUDED.duration_seconds,
+                title = EXCLUDED.title,
+                artist = EXCLUDED.artist,
+                reason_code = EXCLUDED.reason_code,
+                updated_at = CURRENT_TIMESTAMP
+            """,
+            (
+                sanitize_string_for_db(str(server_id)),
+                sanitize_string_for_db(str(provider_item_id)),
+                duration,
+                sanitize_db_field(title, field_name="analysis exclusion title"),
+                sanitize_db_field(artist, field_name="analysis exclusion artist"),
+                int(reason_code),
+            ),
+        )
+        db.commit()
+        return True
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            logger.debug("Analysis-exclusion rollback failed", exc_info=True)
+        logger.exception(
+            "Could not persist analysis exclusion for %s/%s",
+            server_id, provider_item_id,
+        )
+        return False
+    finally:
+        cur.close()
+
+
+def get_analysis_exclusions(server_id, provider_item_ids):
+    if not server_id or not provider_item_ids:
+        return {}
+    ids = [sanitize_string_for_db(str(item_id)) for item_id in provider_item_ids]
+    with get_db() as conn, conn.cursor(cursor_factory=DictCursor) as cur:
+        cur.execute(
+            "SELECT server_id, provider_item_id, duration_seconds, title, artist, "
+            "reason_code, created_at, updated_at "
+            "FROM analysis_exclusions WHERE server_id = %s AND provider_item_id = ANY(%s)",
+            (sanitize_string_for_db(str(server_id)), ids),
+        )
+        return {
+            row['provider_item_id']: {
+                'server_id': row['server_id'],
+                'provider_item_id': row['provider_item_id'],
+                'duration_seconds': row['duration_seconds'],
+                'title': row['title'],
+                'artist': row['artist'],
+                'reason_code': row['reason_code'],
+                'created_at': row['created_at'],
+                'updated_at': row['updated_at'],
+            }
+            for row in cur.fetchall()
+        }
+
+
+def delete_stale_analysis_exclusions(server_id, present_provider_item_ids, conn=None):
+    if not server_id or not present_provider_item_ids:
+        return 0
+    ids = [sanitize_string_for_db(str(item_id)) for item_id in present_provider_item_ids]
+    db = conn or get_db()
+    cur = db.cursor()
+    try:
+        cur.execute(
+            "DELETE FROM analysis_exclusions "
+            "WHERE server_id = %s AND NOT (provider_item_id = ANY(%s))",
+            (sanitize_string_for_db(str(server_id)), ids),
+        )
+        deleted = cur.rowcount
+        db.commit()
+        return int(deleted if deleted is not None and deleted >= 0 else 0)
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            logger.debug("Stale analysis-exclusion rollback failed", exc_info=True)
+        logger.exception("Could not remove stale analysis exclusions for %s", server_id)
+        return 0
+    finally:
+        cur.close()
+
+
 def get_lyrics_axis_vectors(item_ids):
     if not item_ids:
         return {}
@@ -1603,6 +1706,23 @@ def init_db():
             except Exception:
                 logger.warning("music_servers has duplicate names; unique-name index skipped")
                 cur.execute("ROLLBACK TO SAVEPOINT ms_unique_name")
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS analysis_exclusions (
+                    server_id TEXT NOT NULL REFERENCES music_servers (server_id) ON DELETE CASCADE,
+                    provider_item_id TEXT NOT NULL,
+                    duration_seconds DOUBLE PRECISION,
+                    title TEXT,
+                    artist TEXT,
+                    reason_code INTEGER NOT NULL,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    PRIMARY KEY (server_id, provider_item_id)
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_analysis_exclusions_updated_at "
+                "ON analysis_exclusions (updated_at DESC)"
+            )
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS track_server_map (
                     item_id TEXT NOT NULL REFERENCES score (item_id) ON UPDATE CASCADE ON DELETE CASCADE,

--- a/tasks/analysis/album.py
+++ b/tasks/analysis/album.py
@@ -76,11 +76,16 @@ from ..memory_utils import (
     comprehensive_memory_cleanup,
 )
 from .. import chromaprint
-from database import persist_chromaprint, get_chromaprint
+from database import (
+    persist_chromaprint,
+    get_chromaprint,
+    record_analysis_exclusion,
+)
 from . import helper as _ah
 from .helper import make_task_reporter, _bind_server_context
 from .song import (
-    analyze_track,
+    analyze_track_for_album,
+    AudioNotDecodableError,
     cleanup_musicnn_sessions,
     cleanup_optional_models,
     robust_load_audio_with_fallback,
@@ -89,9 +94,13 @@ from .song import (
 
 logger = logging.getLogger(__name__)
 
+analyze_track = analyze_track_for_album
+
 
 class TrackNotAnalyzable(Exception):
-    pass
+    def __init__(self, message, cacheable=False):
+        super().__init__(message)
+        self.cacheable = bool(cacheable)
 
 
 class TrackSourceUnavailable(Exception):
@@ -131,17 +140,23 @@ def _stage_musicnn(path, track_name_full, plan, model_paths, session_recycler,
     onnx_sessions = _ah.ensure_musicnn_sessions(
         onnx_sessions, model_paths, session_recycler, album_name
     )
-    if plan.lyrics:
-        analysis, embedding, track_audio, track_sr = analyze_track(
-            path, MOOD_LABELS, model_paths, onnx_sessions=onnx_sessions, return_audio=True
-        )
-    else:
-        analysis, embedding = analyze_track(
-            path, MOOD_LABELS, model_paths, onnx_sessions=onnx_sessions
-        )
-        track_audio = track_sr = None
+    try:
+        if plan.lyrics:
+            analysis, embedding, track_audio, track_sr = analyze_track(
+                path, MOOD_LABELS, model_paths,
+                onnx_sessions=onnx_sessions, return_audio=True,
+            )
+        else:
+            analysis, embedding = analyze_track(
+                path, MOOD_LABELS, model_paths, onnx_sessions=onnx_sessions
+            )
+            track_audio = track_sr = None
+    except AudioNotDecodableError as exc:
+        raise TrackNotAnalyzable(str(exc), cacheable=True) from exc
     if analysis is None:
-        raise TrackNotAnalyzable(f"no decodable audio for {track_name_full}")
+        raise TrackNotAnalyzable(
+            f"analysis produced no result for {track_name_full}", cacheable=False
+        )
     session_recycler.increment()
     cleanup_cuda_memory(force=False)
     return onnx_sessions, analysis, embedding, track_audio, track_sr
@@ -431,6 +446,7 @@ def _analyze_album_task_impl(album_id, album_name, top_n_moods, parent_task_id):
                 clap_label_embeddings,
                 existing_top_moods_by_id,
             ) = _ah.build_album_plan(album_name, tracks, top_n_moods, LYRICS_ENABLED)
+            analysis_exclusions = _ah.load_album_analysis_exclusions(tracks)
 
             _ah.upsert_artist_mappings_for_tracks(tracks, album_name=album_name)
 
@@ -468,6 +484,20 @@ def _analyze_album_task_impl(album_id, album_name, top_n_moods, parent_task_id):
                     return {"status": "REVOKED"}
 
                 track_name_full = f"{item['Name']} by {item.get('AlbumArtist', 'Unknown')}"
+                provider_id = _ah.provider_item_id(item)
+                exclusion = analysis_exclusions.get(provider_id)
+                if exclusion and _ah.analysis_exclusion_matches(item, exclusion):
+                    tracks_not_analyzable_count += 1
+                    logger.info(
+                        "Skipping '%s' - previously marked as not analyzable "
+                        "for this music server.", track_name_full
+                    )
+                    continue
+                if exclusion:
+                    logger.info(
+                        "Retrying '%s' because its provider metadata changed "
+                        "since the not-analyzable marker was written.", track_name_full
+                    )
                 plan = _ah.plan_track_stages(
                     _ah.catalog_item_id(item),
                     existing_track_ids_set,
@@ -506,6 +536,22 @@ def _analyze_album_task_impl(album_id, album_name, top_n_moods, parent_task_id):
                     error_manager.record(
                         ERR_TRACK_NOT_ANALYZABLE, str(e), logger=logger, level=logging.WARNING
                     )
+                    if e.cacheable:
+                        from ..mediaserver import context as server_context
+
+                        server_id = (
+                            server_context.active_server_id()
+                            or registry.get_default_server_id()
+                        )
+                        metadata = _ah.analysis_exclusion_metadata(item)
+                        record_analysis_exclusion(
+                            server_id,
+                            provider_id,
+                            duration_seconds=metadata['duration_seconds'],
+                            title=metadata['title'],
+                            artist=metadata['artist'],
+                            reason_code=ERR_TRACK_NOT_ANALYZABLE,
+                        )
                     tracks_not_analyzable_count += 1
                 except TrackSourceUnavailable:
                     logger.warning(

--- a/tasks/analysis/helper.py
+++ b/tasks/analysis/helper.py
@@ -40,7 +40,12 @@ from config import (
     TASK_STATUS_SUCCESS,
     TASK_STATUS_FAIL,
 )
-from database import get_db, save_task_status, MAX_LOG_ENTRIES_STORED
+from database import (
+    get_db,
+    save_task_status,
+    MAX_LOG_ENTRIES_STORED,
+    get_analysis_exclusions,
+)
 from psycopg2 import OperationalError
 from psycopg2 import sql as pgsql
 from sanitization import sanitize_string_for_db
@@ -158,6 +163,46 @@ def attach_catalog_item_ids(tracks, server_id=None):
     for item, provider_id in zip(tracks, provider_ids):
         item['_catalog_item_id'] = str(mapped.get(provider_id, provider_id))
     return tracks
+
+
+def track_duration_seconds(item):
+    value = item.get('DurationSeconds')
+    if value is None:
+        ticks = item.get('RunTimeTicks')
+        if ticks is not None:
+            try:
+                value = float(ticks) / 10_000_000.0
+            except (TypeError, ValueError):
+                value = None
+        else:
+            value = item.get('duration')
+    if value is None:
+        return None
+    try:
+        value = float(value)
+    except (TypeError, ValueError):
+        return None
+    return value if value > 0 else None
+
+
+def analysis_exclusion_metadata(item):
+    return {
+        'title': item['Name'],
+        'artist': item.get('AlbumArtist', 'Unknown'),
+        'duration_seconds': track_duration_seconds(item),
+    }
+
+
+def analysis_exclusion_matches(item, exclusion):
+    current = analysis_exclusion_metadata(item)
+    for field in ('title', 'artist'):
+        old_value = exclusion.get(field)
+        new_value = current.get(field)
+        old_normalized = str(old_value).strip().casefold() if old_value is not None else ''
+        new_normalized = str(new_value).strip().casefold() if new_value is not None else ''
+        if old_normalized != new_normalized:
+            return False
+    return True
 
 
 def get_existing_track_ids(track_ids):
@@ -379,6 +424,18 @@ def build_album_plan(album_name, tracks, top_n_moods, lyrics_enabled):
         track_ids, existing_ids, missing_lyrics_ids, top_n_moods, lyrics_enabled, album_name
     )
     return existing_ids, missing_clap_ids, missing_lyrics_ids, clap_label_embeddings, prior_moods
+
+
+def load_album_analysis_exclusions(tracks):
+    if not tracks:
+        return {}
+    from .song import provider_item_id
+    from tasks.mediaserver import context as server_context, registry
+
+    server_id = server_context.active_server_id() or registry.get_default_server_id()
+    return get_analysis_exclusions(
+        server_id, [provider_item_id(track) for track in tracks]
+    )
 
 
 def flush_pending_track_maps(pending_track_maps, map_flush_errors, album_name):

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -547,7 +547,12 @@ def _run_musicnn_models(final_patches, mood_labels_list, model_paths, onnx_sessi
                 logger.warning(f"Error during cleanup: {cleanup_error}")
 
 
-def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, return_audio=False):
+class AudioNotDecodableError(RuntimeError):
+    pass
+
+
+def _analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None,
+                   return_audio=False, raise_on_unreadable=False):
     name = os.path.basename(file_path)
     logger.info(f"Starting analysis for: {name}")
     nothing = (None, None, None, None) if return_audio else (None, None)
@@ -557,6 +562,8 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, 
         logger.warning(
             f"Could not load a valid audio signal for {name} after all attempts. Skipping track."
         )
+        if raise_on_unreadable:
+            raise AudioNotDecodableError(f"no decodable audio for {name}")
         return nothing
 
     tempo, average_energy, musical_key, scale = extract_basic_features(audio, sr)
@@ -587,6 +594,21 @@ def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, 
     gc.collect()
     comprehensive_memory_cleanup(force_cuda=False, reset_onnx_pool=False)
     return return_values
+
+
+def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, return_audio=False):
+    return _analyze_track(
+        file_path, mood_labels_list, model_paths, onnx_sessions=onnx_sessions,
+        return_audio=return_audio,
+    )
+
+
+def analyze_track_for_album(file_path, mood_labels_list, model_paths,
+                            onnx_sessions=None, return_audio=False):
+    return _analyze_track(
+        file_path, mood_labels_list, model_paths, onnx_sessions=onnx_sessions,
+        return_audio=return_audio, raise_on_unreadable=True,
+    )
 
 
 def catalog_item_id(item):

--- a/tasks/cleaning.py
+++ b/tasks/cleaning.py
@@ -53,7 +53,7 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
 
     from flask_app import app
     from app_helper import get_db, get_task_info_from_db, save_task_status
-    from database import MAX_LOG_ENTRIES_STORED
+    from database import MAX_LOG_ENTRIES_STORED, delete_stale_analysis_exclusions
     from config import (
         TASK_STATUS_RUNNING,
         TASK_STATUS_SUCCESS,
@@ -135,6 +135,7 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
             unbound_total = 0
             unbound_by_server = {}
             total_tracks_on_servers = 0
+            deleted_analysis_exclusions = 0
 
             for server_idx, server in enumerate(servers):
                 cancel()
@@ -165,9 +166,9 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
                     window_start + int(35 / len(servers)),
                 )
 
+                refused = []
                 if server_id:
                     _store_server_track_count(get_db(), server_id, len(provider_ids))
-                    refused = []
                     unbound = prune_stale_mappings(
                         get_db(), server_id, sorted(provider_ids), refused=refused
                     )
@@ -181,6 +182,11 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
                             "(kept in the shared catalogue).",
                             window_start + int(70 / len(servers)),
                         )
+                marker_server_id = server_id or registry.get_default_server_id()
+                if marker_server_id and not refused:
+                    deleted_analysis_exclusions += delete_stale_analysis_exclusions(
+                        marker_server_id, provider_ids, conn=get_db()
+                    )
                 provider_list = sorted(provider_ids)
                 for start in range(0, len(provider_list), 5000):
                     cancel()
@@ -289,6 +295,7 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
                 "failed_servers": failed_servers,
                 "prune_refused_servers": refused_servers,
                 "deleted_count": deleted_count,
+                "deleted_analysis_exclusions": deleted_analysis_exclusions,
                 "catalogue_deletion": clean_catalogue,
                 "chromaprint_splits": chromaprint_splits,
             }
@@ -298,7 +305,8 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
                 message = (
                     f"Cleanup finished with problems: server(s) {', '.join(failed_servers)} "
                     f"could not be fully read and were skipped; {unbound_total} stale "
-                    "mappings unbound elsewhere. The catalogue was not modified."
+                    "mappings unbound elsewhere. Stale not-analyzable markers were "
+                    "removed only for complete server reads. The catalogue was not modified."
                 )
             elif refused_servers:
                 message = (
@@ -311,13 +319,15 @@ def identify_and_clean_orphaned_albums_task(clean_catalogue=None):
                 message = (
                     f"Cleanup complete: {unbound_total} stale server mappings unbound; "
                     f"{deleted_count} of {len(fully_unbound)} orphaned catalogue tracks "
-                    "(on no server) deleted."
+                    f"(on no server) deleted; {deleted_analysis_exclusions} stale "
+                    "not-analyzable marker(s) removed."
                 )
             else:
                 message = (
                     f"Cleanup complete: {unbound_total} stale server mappings unbound; "
                     f"{len(fully_unbound)} catalogue tracks are on no server and were "
-                    "kept (catalogue cleaning is off - enable it to delete them)."
+                    f"kept (catalogue cleaning is off - enable it to delete them); "
+                    f"{deleted_analysis_exclusions} stale not-analyzable marker(s) removed."
                 )
             log_and_update_main(message, 100, task_state=state, final_summary_details=summary)
             return {"status": TASK_STATUS_SUCCESS if not failed_servers else TASK_STATUS_FAILURE,

--- a/templates/browse.html
+++ b/templates/browse.html
@@ -69,6 +69,11 @@
     background: #FEF3C7;
     color: #92400E;
   }
+  .browse-reason {
+    cursor: help;
+    border-bottom: 1px dotted currentColor;
+    white-space: nowrap;
+  }
   body.dark-mode .browse-copies, html.dark-mode body .browse-copies { background: #78350F; color: #FDE68A; }
   /* A duplicates row is clickable; a caret shows it expands to its file paths. */
   .browse-dup-row { cursor: pointer; }
@@ -122,6 +127,7 @@
         <button type="button" class="btn btn-ghost btn-sm" data-kind="songs">Songs</button>
         <button type="button" class="btn btn-ghost btn-sm" data-kind="artists">Artists</button>
         <button type="button" class="btn btn-ghost btn-sm" data-kind="albums">Albums</button>
+        <button type="button" class="btn btn-ghost btn-sm" data-kind="unanalyzable">Unanalyzable</button>
       </div>
     </div>
     <div class="browse-field">
@@ -168,13 +174,23 @@
 <script>
 (() => {
   const API = "{{ url_for('dashboard_bp.browse_api') }}";
-  const KINDS = ['songs', 'artists', 'albums'];
+  const KINDS = ['songs', 'artists', 'albums', 'unanalyzable'];
   const FILTERS = ['all', 'unique', 'duplicates', 'orphan'];
   const $ = id => document.getElementById(id);
   const esc = s => String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
     '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
   }[c]));
   const fmt = n => (n == null ? '' : Number(n).toLocaleString());
+  const fmtDuration = secs => {
+    if (secs == null) return '–';
+    const n = Number(secs);
+    if (!Number.isFinite(n)) return '–';
+    if (n < 60) return n.toFixed(1) + ' s';
+    return Math.floor(n / 60) + ' min ' + Math.round(n % 60) + ' s';
+  };
+  const reasonText = code => ({
+    2007: 'No decodable audio was found after all decoder attempts; the track was skipped.'
+  }[Number(code)] || 'The track was skipped as not analyzable. Check the task log for details.');
 
   const state = { kind: 'songs', filter: 'all', server: 'all', q: '', page: 1 };
   let hasMore = false, total = null, pageSize = {{ page_size }}, searchTimer = null, reqToken = 0;
@@ -248,6 +264,7 @@
   function colCount() {
     if (state.kind === 'artists') return 2;
     if (state.kind === 'albums') return 3;
+    if (state.kind === 'unanalyzable') return 8;
     return 5;  // songs (incl. duplicates): #, Copies/Year, Title, Artist, Album
   }
 
@@ -257,6 +274,7 @@
     let cols;
     if (state.kind === 'artists') cols = ['#', 'Artist'];
     else if (state.kind === 'albums') cols = ['#', 'Album Artist', 'Album'];
+    else if (state.kind === 'unanalyzable') cols = ['#', 'Title', 'Artist', 'Duration', 'Error', 'Server', 'First seen', 'Last seen'];
     else if (isDup()) cols = ['#', 'Copies', 'Title', 'Artist', 'Album'];
     else cols = ['#', 'Title', 'Artist', 'Album', 'Year'];
     $('browse-thead').innerHTML = '<tr>' + cols.map(c => '<th>' + esc(c) + '</th>').join('') + '</tr>';
@@ -277,6 +295,17 @@
       } else if (state.kind === 'albums') {
         html += '<tr><td class="browse-idx">' + n + '</td><td>' + esc(r.album_artist)
               + '</td><td>' + esc(r.album) + '</td></tr>';
+      } else if (state.kind === 'unanalyzable') {
+        const reason = r.reason_code == null ? null : 'ERR-' + r.reason_code;
+        const reasonCell = reason
+          ? '<span class="browse-reason" tabindex="0" title="' + esc(reasonText(r.reason_code))
+            + '" aria-label="' + esc(reasonText(r.reason_code)) + '">' + esc(reason) + '</span>'
+          : '–';
+        html += '<tr><td class="browse-idx">' + n + '</td><td class="browse-title-cell">'
+              + esc(r.title) + '</td><td>' + esc(r.artist) + '</td><td>'
+              + esc(fmtDuration(r.duration_seconds)) + '</td><td>' + reasonCell
+              + '</td><td>' + esc(r.server) + '</td><td>' + esc(r.created_at)
+              + '</td><td>' + esc(r.updated_at) + '</td></tr>';
       } else if (isDup()) {
         // The row stays narrow (fits any screen); its duplicate FILE paths live in
         // a hidden detail row revealed by clicking the row.
@@ -310,6 +339,7 @@
     if (total != null) {
       let noun = state.kind;
       if (state.kind === 'songs' && state.filter === 'orphan') noun = 'orphan songs';
+      if (state.kind === 'unanalyzable') noun = 'unanalyzable songs';
       st.textContent = fmt(total) + ' ' + noun;
     } else {
       st.textContent = count ? ('Showing ' + fmt(count) + ' result' + (count === 1 ? '' : 's')) : '';

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -547,6 +547,7 @@
             { title: 'Songs (unique)', value: totalSongs.toLocaleString(), kind: 'songs' },
             { title: 'Artists (unique)', value: totalArtists.toLocaleString(), kind: 'artists' },
             { title: 'Albums (unique)', value: (c.distinct_albums || 0).toLocaleString(), kind: 'albums' },
+            { title: 'Unanalyzable songs', value: (c.unanalyzable_tracks || 0).toLocaleString(), kind: 'unanalyzable' },
         ];
 
         cards.forEach(card => {

--- a/test/unit/test_app_dashboard_browse.py
+++ b/test/unit/test_app_dashboard_browse.py
@@ -103,6 +103,26 @@ class TestBrowseArtistsAlbumsSql:
         assert params == ['%x%', '%x%']
 
 
+class TestBrowseUnanalyzable:
+    def test_sql_is_server_scoped_and_searchable_without_internal_ids(self):
+        sql, params = dash._browse_unanalyzable_sql('srv1', 'bad')
+        assert 'analysis_exclusions' in sql
+        assert 'e.server_id = %s' in sql
+        assert 'provider_item_id' not in sql.split(' FROM ')[0]
+        assert params == ['srv1', '%bad%', '%bad%']
+
+    def test_serialization_contains_error_details(self):
+        out = dash._browse_serialize(
+            'unanalyzable',
+            [('Song', 'Artist', 123.5, 2007, 'created', 'updated', 'Jellyfin')],
+        )
+        assert out == [{
+            'title': 'Song', 'artist': 'Artist', 'duration_seconds': 123.5,
+            'reason_code': 2007, 'created_at': 'created', 'updated_at': 'updated',
+            'server': 'Jellyfin',
+        }]
+
+
 class TestBrowseSerialize:
     def test_songs_carry_no_id_and_no_fp_value(self):
         out = dash._browse_serialize('songs', [('Title', 'Artist', 'Album', 'AA', 2020, None)])


### PR DESCRIPTION
This PR improve the analysis by tracking the song that give error and directly skip in the future analysis.

In the dashboard is also added the number of song in error that you can click and check the details.

Cleaning functionality will also update this talbe, just in case the error song get cancelled from the music server.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401366098/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401365393/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401365393/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401365393/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401365393/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31401365180/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-850`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-850-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-850-noavx2`
<!-- pr-test-build:end -->