### PR TITLE
Add ARM64 (DGX Spark) NVIDIA image build workflow

### DIFF
--- a/.github/workflows/build-nvidia-arm.yml
+++ b/.github/workflows/build-nvidia-arm.yml
@@ -110,8 +110,12 @@ jobs:
           push: true
           platforms: linux/arm64
           tags: ${{ steps.docker_tags.outputs.docker_tags }}
+          # DGX Spark / GB10 is compute capability sm_121, only targetable by CUDA
+          # 13+ (CUDA 12.8 cannot generate code for it). BASE_IMAGE must stay on
+          # CUDA 13.x to match the onnxruntime-gpu wheel below, which is linked
+          # against libcudart.so.13 / libcudnn.so.9 (built for CUDA 13.1.1).
           build-args: |
-            BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
+            BASE_IMAGE=nvidia/cuda:13.1.1-cudnn-runtime-ubuntu24.04
             ONNXRUNTIME_WHEEL_URL=https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v5.0.0-model/onnxruntime_gpu-1.25.0-cp312-cp312-linux_aarch64.whl
           cache-from: type=gha,scope=nvidia-arm
           cache-to: type=gha,scope=nvidia-arm,mode=max

--- a/.github/workflows/build-nvidia-arm.yml
+++ b/.github/workflows/build-nvidia-arm.yml
@@ -1,0 +1,117 @@
+name: Build and Push AudioMuse AI Docker Image with NVIDIA support (ARM64 / DGX Spark)
+
+on:
+  push:
+    branches:
+      - main      # Trigger on merge/push to main -> 'devel-nvidia-arm' tag
+    # Trigger on version tags for stable releases
+    tags:
+      - 'v*.*.*'  # Trigger for version tags like v1.0.0
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  # Allow manual runs from the Actions UI
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Version tag (e.g., v0.7.12-beta)'
+        required: true
+        type: string
+
+jobs:
+  build-and-push:
+    # Run on non-PR events; for PR events skip drafts and fork PRs (the
+    # latter only get a read-only GITHUB_TOKEN and cannot push to ghcr.io).
+    # Maintainers can build a fork PR manually via workflow_dispatch.
+    if: >-
+      github.event_name != 'pull_request' ||
+      (github.event.pull_request.draft == false &&
+       github.event.pull_request.head.repo.full_name == github.repository)
+    # Native arm64 runner: builds linux/arm64 without QEMU emulation, so pip
+    # resolves aarch64 wheels natively (fast and reliable).
+    runs-on: ubuntu-24.04-arm
+
+    permissions:
+      contents: read # Allow checkout to read repository contents
+      packages: write # Allow pushing to GitHub Container Registry
+
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          swap-storage: false
+          large-packages: true  # Remove large packages (saves ~8-10 GB)
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          docker-images: true
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine Docker image tags
+        id: docker_tags
+        run: |
+          REPO_NAME_LOWER=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          ALL_TAGS=""
+
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            # When compiling from a version tag, create both the versioned tag and latest-nvidia-arm
+            VERSION_TAG=$(echo "${GITHUB_REF}" | sed -e 's|refs/tags/v||g')
+            VERSIONED_TAG="ghcr.io/$REPO_NAME_LOWER:${VERSION_TAG}-nvidia-arm"
+            LATEST_TAG="ghcr.io/$REPO_NAME_LOWER:latest-nvidia-arm"
+            ALL_TAGS="${VERSIONED_TAG},${LATEST_TAG}"
+            echo "Building versioned tag: $VERSIONED_TAG"
+            echo "Also tagging as latest: $LATEST_TAG"
+          elif [[ "${GITHUB_REF}" == refs/heads/main ]]; then
+            # When compiling from main (merged PR), create devel-nvidia-arm tag
+            DEVEL_TAG="ghcr.io/$REPO_NAME_LOWER:devel-nvidia-arm"
+            ALL_TAGS="${DEVEL_TAG}"
+            echo "Building devel tag: $DEVEL_TAG"
+          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.pull_request.draft }}" == "false" ]]; then
+            PR_NUM="${{ github.event.pull_request.number }}"
+            PR_TAG="ghcr.io/$REPO_NAME_LOWER:pr-${PR_NUM}-nvidia-arm"
+            ALL_TAGS="${PR_TAG}"
+            echo "Building PR tag: $PR_TAG"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            # Manual run with version input
+            VERSION_TAG=$(echo "${{ inputs.version_tag }}" | sed -e 's|^v||g')
+            VERSIONED_TAG="ghcr.io/$REPO_NAME_LOWER:${VERSION_TAG}-nvidia-arm"
+            LATEST_TAG="ghcr.io/$REPO_NAME_LOWER:latest-nvidia-arm"
+            ALL_TAGS="${VERSIONED_TAG},${LATEST_TAG}"
+            echo "Building manual version tag: $VERSIONED_TAG"
+            echo "Also tagging as latest: $LATEST_TAG"
+          else
+            echo "This workflow is intended to run on tag pushes (refs/tags/v*), devel branch, non-draft pull requests, or manual dispatch. Exiting."
+            exit 1
+          fi
+
+          # Export the tags for subsequent steps (comma-separated)
+          echo "docker_tags=$ALL_TAGS" >> "$GITHUB_OUTPUT"
+
+      - name: Build and Push AudioMuse AI Image (ARM64)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: ${{ steps.docker_tags.outputs.docker_tags }}
+          build-args: |
+            BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04
+            ONNXRUNTIME_WHEEL_URL=https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v5.0.0-model/onnxruntime_gpu-1.25.0-cp312-cp312-linux_aarch64.whl
+          cache-from: type=gha,scope=nvidia-arm
+          cache-to: type=gha,scope=nvidia-arm,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ testing_suite/
 analysis.md
 .claude/
 lyrics_model_gte_vnni.tar.gz
+.reasonix/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,13 @@
 
 ARG BASE_IMAGE=ubuntu:24.04
 # Optional: URL of a prebuilt aarch64 onnxruntime-gpu wheel. There is no official
-# linux/aarch64 wheel for onnxruntime-gpu on PyPI, so ARM64 (DGX Spark / GB10) GPU
-# builds install this URL instead of the onnxruntime-gpu pin in gpu.txt.
+# linux/aarch64 wheel for onnxruntime-gpu on PyPI or pypi.nvidia.com, so ARM64
+# (DGX Spark / GB10, compute capability sm_121) GPU builds install this URL
+# instead of the onnxruntime-gpu pin in gpu.txt. sm_121 is only targetable by
+# CUDA 13+, so this wheel is linked against CUDA 13/cuDNN 9 - when this arg is
+# set, BASE_IMAGE must be a CUDA 13.x image and requirements/gpu-arm64.txt
+# (cupy-cuda13x, cuml-cu13) is installed instead of gpu.txt (cupy-cuda12x,
+# cuml-cu12), which target CUDA 12.x and would fail to load.
 # Example: https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v5.0.0-model/onnxruntime_gpu-1.25.0-cp312-cp312-linux_aarch64.whl
 ARG ONNXRUNTIME_WHEEL_URL=""
 
@@ -438,9 +443,8 @@ RUN rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED; \
     export UV_BREAK_SYSTEM_PACKAGES=1; \
     if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then \
         if [[ -n "$ONNXRUNTIME_WHEEL_URL" ]]; then \
-            echo "NVIDIA (arm64) base: installing GPU packages with prebuilt aarch64 onnxruntime-gpu wheel"; \
-            grep -v '^onnxruntime-gpu' /app/requirements/gpu.txt > /tmp/gpu-no-ort.txt; \
-            uv pip install --system --no-cache --index-strategy unsafe-best-match -r /tmp/gpu-no-ort.txt -r /app/requirements/common.txt "$ONNXRUNTIME_WHEEL_URL" || exit 1; \
+            echo "NVIDIA (arm64/CUDA 13) base: installing GPU packages (cupy-cuda13x, cuml-cu13) with prebuilt aarch64 onnxruntime-gpu wheel"; \
+            uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu-arm64.txt -r /app/requirements/common.txt "$ONNXRUNTIME_WHEEL_URL" || exit 1; \
         else \
             echo "NVIDIA base image detected: installing GPU packages (cupy, cuml, onnxruntime-gpu, torch+cuda)"; \
             uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu.txt -r /app/requirements/common.txt || exit 1; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@
 #   GPU:  docker build --build-arg BASE_IMAGE=nvidia/cuda:12.8.1-cudnn-runtime-ubuntu24.04 -t audiomuse-ai-gpu .
 
 ARG BASE_IMAGE=ubuntu:24.04
+# Optional: URL of a prebuilt aarch64 onnxruntime-gpu wheel. There is no official
+# linux/aarch64 wheel for onnxruntime-gpu on PyPI, so ARM64 (DGX Spark / GB10) GPU
+# builds install this URL instead of the onnxruntime-gpu pin in gpu.txt.
+# Example: https://github.com/NeptuneHub/AudioMuse-AI/releases/download/v5.0.0-model/onnxruntime_gpu-1.25.0-cp312-cp312-linux_aarch64.whl
+ARG ONNXRUNTIME_WHEEL_URL=""
 
 # ============================================================================
 # Stage 1: Download ML models (cached separately for faster rebuilds)
@@ -418,6 +423,7 @@ RUN set -ux; \
 FROM base AS libraries
 
 ARG BASE_IMAGE
+ARG ONNXRUNTIME_WHEEL_URL
 
 WORKDIR /app
 
@@ -431,8 +437,14 @@ COPY requirements/ /app/requirements/
 RUN rm -f /usr/lib/python3.*/EXTERNALLY-MANAGED; \
     export UV_BREAK_SYSTEM_PACKAGES=1; \
     if [[ "$BASE_IMAGE" =~ ^nvidia/cuda: ]]; then \
-        echo "NVIDIA base image detected: installing GPU packages (cupy, cuml, onnxruntime-gpu, torch+cuda)"; \
-        uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu.txt -r /app/requirements/common.txt || exit 1; \
+        if [[ -n "$ONNXRUNTIME_WHEEL_URL" ]]; then \
+            echo "NVIDIA (arm64) base: installing GPU packages with prebuilt aarch64 onnxruntime-gpu wheel"; \
+            grep -v '^onnxruntime-gpu' /app/requirements/gpu.txt > /tmp/gpu-no-ort.txt; \
+            uv pip install --system --no-cache --index-strategy unsafe-best-match -r /tmp/gpu-no-ort.txt -r /app/requirements/common.txt "$ONNXRUNTIME_WHEEL_URL" || exit 1; \
+        else \
+            echo "NVIDIA base image detected: installing GPU packages (cupy, cuml, onnxruntime-gpu, torch+cuda)"; \
+            uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/gpu.txt -r /app/requirements/common.txt || exit 1; \
+        fi \
     else \
         echo "CPU base image: installing all packages together for dependency resolution"; \
         uv pip install --system --no-cache --index-strategy unsafe-best-match -r /app/requirements/cpu.txt -r /app/requirements/common.txt || exit 1; \

--- a/requirements/gpu-arm64.txt
+++ b/requirements/gpu-arm64.txt
@@ -1,3 +1,3 @@
 --extra-index-url https://pypi.nvidia.com
 cupy-cuda13x==13.6.0
-cuml-cu13==26.8.0
+cuml-cu13==26.6.0

--- a/requirements/gpu-arm64.txt
+++ b/requirements/gpu-arm64.txt
@@ -1,0 +1,3 @@
+--extra-index-url https://pypi.nvidia.com
+cupy-cuda13x==13.6.0
+cuml-cu13==26.8.0


### PR DESCRIPTION
## Summary
- New `build-nvidia-arm.yml` workflow mirrors `build-nvidia.yml` but runs on a native `ubuntu-24.04-arm` runner, building `linux/arm64` images tagged `-nvidia-arm` (for the NVIDIA DGX Spark / GB10 platform).
- Dockerfile: adds an `ONNXRUNTIME_WHEEL_URL` build-arg; when set, the GPU install step installs a prebuilt aarch64 `onnxruntime-gpu` wheel instead of the PyPI pin, since `onnxruntime-gpu` has no official linux/aarch64 wheel on PyPI.

## Test plan
- [ ] Confirm `build-nvidia-arm.yml` runs successfully on push/PR and produces a `devel-nvidia-arm` / `pr-<N>-nvidia-arm` image
- [ ] Pull the built image on a DGX Spark (or other arm64 NVIDIA host) and verify the GPU packages (cupy, cuml, onnxruntime-gpu) import correctly
- [ ] Confirm the existing `build-nvidia.yml` (amd64) build is unaffected

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31620994178/AudioMuse-AI-arm64-macos.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31620994218/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-854`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-854-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-854-noavx2`
<!-- pr-test-build:end -->