### PR TITLE
cudnn_conv_algo_search TO HEURISTIC - #798 #783

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ More information can be found in the [docs folder](docs): [ARCHITECTURE](docs/AR
   > * [AudioMuse-AI MusicServer](https://github.com/NeptuneHub/AudioMuse-AI-MusicServer): Open Subosnic like Music Sever with integrated sonic functionality.
 
 And now just some **NEWS:**
-> * **ghcr.io/neptunehub/audiomuse-ai:devel-nvidia-arm** is the new **experimental** image that support GPU on ARM, created for **DGX Spark**.
+> * **Version 3.3.0** introduce the `-nvidia-arm` image in order to support the DGX Spark and other machine based on the GB10 GPU. This new image is **experimental**
 > * **Version 3.2.0** implemented queue on postgresql, this means that Redis is not needed anymore. Just check the new deployment/docker-compose example.
 > * **Version 3.0.0** added multiple music server support on a single deployment, with duplicate detection so a song shared by more servers is analyzed only once.
 > * **Version 2.6.0** added support for third party plugin. Give a look to the [plugin documentation](docs/PLUGIN.md) to know how to develop one and to the [official 3rd party catalog](https://github.com/NeptuneHub/AudioMuse-AI-plugins). The plugin system requires a persistent volume mounted on both the Flask and worker containers, otherwise installed plugins are lost whenever the containers restart; the deployment example has been updated accordingly.
@@ -212,8 +212,8 @@ Our GitHub Actions workflow automatically builds and publishes Docker images wit
   Images that support the use of GPU for both Analysis and Clustering.
   **Not recommended** for old GPU.
   
-* **`-devel-nvidia-arm`** variants
-  Images that support the use of GPU on ARM processor for both Analysis and Clustering **EXPERIMENTAL FOR DGX SPARK**.
+* **`-nvidia-arm`** variants
+  Images that support the use of GPU of DGX SPARK on ARM processor for both Analysis and Clustering **EXPERIMENTAL**.
 
 > Versioning is Major.Minor.Patch release. Eventually (rare) model change that could require a new analysis could happen in Major and Minor release.
 > Read the [release note](https://github.com/NeptuneHub/AudioMuse-AI/releases) before any update especially for Major and Minor release.

--- a/config.py
+++ b/config.py
@@ -226,7 +226,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 }
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v3.2.0"
+APP_VERSION = "v3.3.0"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/docs/GPU.md
+++ b/docs/GPU.md
@@ -1,6 +1,8 @@
 # GPU deployment
 
-NVidia GPU **EXPERIMENTAL** support is available for analysis task in the worker process. This can significantly speed up processing of tracks.
+Nvidia GPU support is available for analysis task in the worker process. This can significantly speed up processing of tracks.
+
+**ARM (DGX Spark / GB10) support:** the `-nvidia-arm` image adds support for NVIDIA GPUs on ARM64 hosts, such as the DGX Spark and other GB10-based machines, for both analysis and clustering. This image is **EXPERIMENTAL**. Use it the same way as the regular `-nvidia` image, just pick the `-nvidia-arm` tag.
 
 We suggest **8GB VRAM** on GPU, with less you can experience the NON BLOCKING OutOFMemory error (that are handled by switching to CPU). The `PER_SONG_MODEL_RELOAD` env variable, that by default is TRUE, help cleaning the memory by entirely reloading the model each time, on the other side it slow the analysis process.
 

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -167,7 +167,7 @@ def resolve_providers(allow_coreml=False, cuda_options=None, label=None,
                 or {
                     'device_id': 0,
                     'arena_extend_strategy': 'kSameAsRequested',
-                    'cudnn_conv_algo_search': 'EXHAUSTIVE',
+                    'cudnn_conv_algo_search': 'HEURISTIC',
                     'do_copy_in_default_stream': True,
                 },
             )

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -127,15 +127,7 @@ def _load_audio_model():
 
     from tasks.analysis.song import resolve_providers
 
-    provider_options = resolve_providers(
-        allow_coreml=True,
-        cuda_options={
-            'device_id': 0,
-            'arena_extend_strategy': 'kSameAsRequested',
-            'cudnn_conv_algo_search': 'DEFAULT',
-        },
-        label='clap',
-    )
+    provider_options = resolve_providers(allow_coreml=True, label='clap')
 
     def _create_session(model_input, providers, provider_opts):
         return ort.InferenceSession(
@@ -220,14 +212,7 @@ def _load_text_model():
     else:
         from tasks.analysis.song import resolve_providers
 
-        provider_options = resolve_providers(
-            cuda_options={
-                'device_id': 0,
-                'arena_extend_strategy': 'kSameAsRequested',
-                'cudnn_conv_algo_search': 'DEFAULT',
-            },
-            label='clap_text',
-        )
+        provider_options = resolve_providers(label='clap_text')
 
     try:
         session = ort.InferenceSession(


### PR DESCRIPTION
This PR set cudnn_conv_algo_search TO HEURISTIC as suggested in #798 #783

This should improve the speed of the analysis on nvidia images.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31690111188/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31633489067/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31633489067/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31633489067/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31633489067/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31690111156/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-855`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-855-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-855-noavx2`
<!-- pr-test-build:end -->