### PR TITLE
Analysis improvement

### DIFF
--- a/tasks/analysis/__init__.py
+++ b/tasks/analysis/__init__.py
@@ -40,6 +40,8 @@ _HOMES = {
     'sigmoid': 'song',
     'analyze_track': 'song',
     'robust_load_audio_with_fallback': 'song',
+    'resample_audio': 'song',
+    'decode_audio_once': 'song',
     'make_task_reporter': 'helper',
     '_bind_server_context': 'helper',
 }

--- a/tasks/analysis/album.py
+++ b/tasks/analysis/album.py
@@ -88,6 +88,7 @@ from .song import (
     AudioNotDecodableError,
     cleanup_musicnn_sessions,
     cleanup_optional_models,
+    decode_audio_once,
     robust_load_audio_with_fallback,
 )
 
@@ -136,7 +137,7 @@ def _stage_collect_chromaprint(item, path, track_name_full):
 
 
 def _stage_musicnn(path, track_name_full, plan, model_paths, session_recycler,
-                   onnx_sessions, album_name):
+                   onnx_sessions, album_name, native_audio=None, native_sr=None):
     onnx_sessions = _ah.ensure_musicnn_sessions(
         onnx_sessions, model_paths, session_recycler, album_name
     )
@@ -145,10 +146,12 @@ def _stage_musicnn(path, track_name_full, plan, model_paths, session_recycler,
             analysis, embedding, track_audio, track_sr = analyze_track(
                 path, MOOD_LABELS, model_paths,
                 onnx_sessions=onnx_sessions, return_audio=True,
+                native_audio=native_audio, native_sr=native_sr,
             )
         else:
             analysis, embedding = analyze_track(
-                path, MOOD_LABELS, model_paths, onnx_sessions=onnx_sessions
+                path, MOOD_LABELS, model_paths, onnx_sessions=onnx_sessions,
+                native_audio=native_audio, native_sr=native_sr,
             )
             track_audio = track_sr = None
     except AudioNotDecodableError as exc:
@@ -212,8 +215,11 @@ def _stage_persist_musicnn(item, track_name_full, track_id_str, musicnn_analysis
     )
 
 
-def _stage_clap(path, track_id_str, track_name_full, clap_label_embeddings):
-    embedding = _ah.run_clap_for_track(path, track_name_full)
+def _stage_clap(path, track_id_str, track_name_full, clap_label_embeddings,
+                native_audio=None, native_sr=None):
+    embedding = _ah.run_clap_for_track(
+        path, track_name_full, native_audio=native_audio, native_sr=native_sr
+    )
     if embedding is None:
         logger.warning(
             "  - CLAP produced no embedding for '%s'; its other stages still run "
@@ -252,6 +258,7 @@ def _analyze_single_track(
     track_id_str = _ah.catalog_item_id(item)
     path = None
     track_audio = track_sr = None
+    native_audio = native_sr = None
     musicnn_analysis = musicnn_embedding = None
     clap_embedding = None
     top_moods = None
@@ -262,6 +269,9 @@ def _analyze_single_track(
 
         if plan.musicnn:
             _stage_collect_chromaprint(item, path, track_name_full)
+
+        if path and (plan.musicnn or plan.clap):
+            native_audio, native_sr = decode_audio_once(path)
 
         def ensure_download():
             nonlocal path
@@ -274,6 +284,7 @@ def _analyze_single_track(
                 _stage_musicnn(
                     path, track_name_full, plan, model_paths, session_recycler,
                     onnx_sessions, album_name,
+                    native_audio=native_audio, native_sr=native_sr,
                 )
             )
             top_moods = _ah.top_moods_from(musicnn_analysis, top_n_moods)
@@ -303,7 +314,8 @@ def _analyze_single_track(
 
         if plan.clap:
             clap_embedding, clap_saved = _stage_clap(
-                path, track_id_str, track_name_full, clap_label_embeddings
+                path, track_id_str, track_name_full, clap_label_embeddings,
+                native_audio=native_audio, native_sr=native_sr,
             )
             produced = produced or clap_saved
 

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -426,15 +426,20 @@ def _decode_audio_with_pyav(file_path, target_sr):
     import av
 
     resampler = av.audio.resampler.AudioResampler(format="flt", layout="mono", rate=target_sr)
-    max_samples = int(AUDIO_LOAD_TIMEOUT * target_sr) if AUDIO_LOAD_TIMEOUT else None
+    max_samples = int(AUDIO_LOAD_TIMEOUT * target_sr) if (AUDIO_LOAD_TIMEOUT and target_sr) else None
     chunks = []
     total = 0
+    actual_sr = target_sr
     with av.open(file_path) as container:
         if not container.streams.audio:
-            return np.array([], dtype=np.float32)
+            return np.array([], dtype=np.float32), actual_sr
         stream = container.streams.audio[0]
         for frame in container.decode(stream):
             for rframe in resampler.resample(frame):
+                if actual_sr is None:
+                    actual_sr = rframe.sample_rate
+                    if AUDIO_LOAD_TIMEOUT:
+                        max_samples = int(AUDIO_LOAD_TIMEOUT * actual_sr)
                 arr = rframe.to_ndarray().reshape(-1)
                 if arr.size:
                     chunks.append(arr)
@@ -442,15 +447,19 @@ def _decode_audio_with_pyav(file_path, target_sr):
             if max_samples and total >= max_samples:
                 break
         for rframe in resampler.resample(None):
+            if actual_sr is None:
+                actual_sr = rframe.sample_rate
+                if AUDIO_LOAD_TIMEOUT:
+                    max_samples = int(AUDIO_LOAD_TIMEOUT * actual_sr)
             arr = rframe.to_ndarray().reshape(-1)
             if arr.size:
                 chunks.append(arr)
     if not chunks:
-        return np.array([], dtype=np.float32)
+        return np.array([], dtype=np.float32), actual_sr
     audio = np.concatenate(chunks).astype(np.float32, copy=False)
     if max_samples:
         audio = audio[:max_samples]
-    return audio
+    return audio, actual_sr
 
 
 def robust_load_audio_with_fallback(file_path, target_sr=16000):
@@ -464,14 +473,24 @@ def robust_load_audio_with_fallback(file_path, target_sr=16000):
         logger.warning(f"Direct librosa load failed for {name}: {e}. Attempting PyAV fallback.")
 
     try:
-        audio = _decode_audio_with_pyav(file_path, target_sr)
+        audio, sr = _decode_audio_with_pyav(file_path, target_sr)
         if audio is None or audio.size == 0 or not np.any(audio):
             logger.error(f"PyAV fallback resulted in empty/silent audio for {name}.")
             return None, None
-        return audio, target_sr
+        return audio, sr
     except Exception:
         logger.exception(f"PyAV fallback loading also failed for {name}")
         return None, None
+
+
+def resample_audio(audio, orig_sr, target_sr):
+    if orig_sr == target_sr:
+        return audio
+    return librosa.resample(audio, orig_sr=orig_sr, target_sr=target_sr, res_type='soxr_hq')
+
+
+def decode_audio_once(file_path):
+    return robust_load_audio_with_fallback(file_path, target_sr=None)
 
 
 def _patches_for_track(audio, sr, name):
@@ -561,12 +580,16 @@ class AudioNotDecodableError(RuntimeError):
 
 
 def _analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None,
-                   return_audio=False, raise_on_unreadable=False):
+                   return_audio=False, raise_on_unreadable=False,
+                   native_audio=None, native_sr=None):
     name = os.path.basename(file_path)
     logger.info(f"Starting analysis for: {name}")
     nothing = (None, None, None, None) if return_audio else (None, None)
 
-    audio, sr = robust_load_audio_with_fallback(file_path, target_sr=16000)
+    if native_audio is not None and native_sr is not None:
+        audio, sr = resample_audio(native_audio, native_sr, 16000), 16000
+    else:
+        audio, sr = robust_load_audio_with_fallback(file_path, target_sr=16000)
     if audio is None or not np.any(audio) or audio.size == 0:
         logger.warning(
             f"Could not load a valid audio signal for {name} after all attempts. Skipping track."
@@ -605,18 +628,21 @@ def _analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None,
     return return_values
 
 
-def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None, return_audio=False):
+def analyze_track(file_path, mood_labels_list, model_paths, onnx_sessions=None,
+                  return_audio=False, native_audio=None, native_sr=None):
     return _analyze_track(
         file_path, mood_labels_list, model_paths, onnx_sessions=onnx_sessions,
-        return_audio=return_audio,
+        return_audio=return_audio, native_audio=native_audio, native_sr=native_sr,
     )
 
 
 def analyze_track_for_album(file_path, mood_labels_list, model_paths,
-                            onnx_sessions=None, return_audio=False):
+                            onnx_sessions=None, return_audio=False,
+                            native_audio=None, native_sr=None):
     return _analyze_track(
         file_path, mood_labels_list, model_paths, onnx_sessions=onnx_sessions,
         return_audio=return_audio, raise_on_unreadable=True,
+        native_audio=native_audio, native_sr=native_sr,
     )
 
 
@@ -645,12 +671,12 @@ def ensure_musicnn_sessions(onnx_sessions, model_paths, session_recycler, album_
     return load_musicnn_sessions(model_paths)
 
 
-def run_clap_for_track(path, track_name_full):
+def run_clap_for_track(path, track_name_full, native_audio=None, native_sr=None):
     logger.info(f"  - Starting CLAP analysis for {track_name_full}...")
     try:
         from ..clap_analyzer import analyze_audio_file
 
-        emb, _, _ = analyze_audio_file(path)
+        emb, _, _ = analyze_audio_file(path, native_audio=native_audio, native_sr=native_sr)
         if PER_SONG_MODEL_RELOAD:
             try:
                 from ..clap_analyzer import unload_clap_audio_only

--- a/tasks/clap_analyzer.py
+++ b/tasks/clap_analyzer.py
@@ -429,7 +429,7 @@ def compute_mel_spectrogram(audio_data: np.ndarray, sr: int = 48000) -> np.ndarr
     return mel.astype(np.float32)
 
 
-def analyze_audio_file(audio_path: str) -> Tuple[Optional[np.ndarray], float, int]:
+def analyze_audio_file(audio_path: str, native_audio=None, native_sr=None) -> Tuple[Optional[np.ndarray], float, int]:
     if not config.CLAP_ENABLED:
         return None, 0, 0
 
@@ -440,9 +440,12 @@ def analyze_audio_file(audio_path: str) -> Tuple[Optional[np.ndarray], float, in
         SEGMENT_LENGTH = _SEGMENT_LENGTH_SAMPLES
         HOP_LENGTH = 240000
 
-        from tasks.analysis import robust_load_audio_with_fallback
+        from tasks.analysis import resample_audio, robust_load_audio_with_fallback
 
-        audio_data, sr = robust_load_audio_with_fallback(audio_path, target_sr=SAMPLE_RATE)
+        if native_audio is not None and native_sr is not None:
+            audio_data = resample_audio(native_audio, native_sr, SAMPLE_RATE)
+        else:
+            audio_data, sr = robust_load_audio_with_fallback(audio_path, target_sr=SAMPLE_RATE)
 
         if audio_data is None or audio_data.size == 0:
             logger.warning(f"Could not load audio for CLAP analysis: {audio_path}")

--- a/test/unit/test_analysis.py
+++ b/test/unit/test_analysis.py
@@ -1380,7 +1380,7 @@ class TestRobustLoadAudioWithFallback:
     @patch('tasks.analysis.song._decode_audio_with_pyav')
     def test_fallback_on_librosa_failure(self, mock_pyav_decode, mock_librosa_load):
         mock_librosa_load.side_effect = Exception("Librosa failed")
-        mock_pyav_decode.return_value = np.random.rand(16000).astype(np.float32)
+        mock_pyav_decode.return_value = (np.random.rand(16000).astype(np.float32), 16000)
 
         audio, sr = robust_load_audio_with_fallback('corrupted.mp3')
 
@@ -1410,7 +1410,7 @@ class TestRobustLoadAudioWithFallback:
     @patch('tasks.analysis.song._decode_audio_with_pyav')
     def test_fallback_handles_silent_audio(self, mock_pyav_decode, mock_librosa_load):
         mock_librosa_load.side_effect = Exception("Librosa failed")
-        mock_pyav_decode.return_value = np.zeros(16000, dtype=np.float32)
+        mock_pyav_decode.return_value = (np.zeros(16000, dtype=np.float32), 16000)
 
         audio, sr = robust_load_audio_with_fallback('silent.mp3')
 


### PR DESCRIPTION
This PR include different analysis improvement:
- One audio load and then resample for Musicnn and DCLAP to avoid double load

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573883/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573868/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573868/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573868/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573868/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/31898573862/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-861`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-861-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-861-noavx2`
<!-- pr-test-build:end -->