### PR TITLE
Ram cleaning improvement

### DIFF
--- a/app.py
+++ b/app.py
@@ -1330,6 +1330,55 @@ if not _is_worker:
 
     dashboard_stats_thread = threading.Thread(target=_dashboard_stats_refresher_loop, daemon=True)
     dashboard_stats_thread.start()
+
+    # Reclaim the dead rows autovacuum will never get to. Its threshold counts ROWS
+    # (50 + 20% of the live count), so a table holding a handful of huge blobs needs
+    # ~50 rebuilds to qualify and sits at several times its useful size until then.
+    #
+    # Hourly, not minutes: dead rows only appear when an index rebuild or analysis
+    # replaces a blob, and a swept table drops to zero dead rows and leaves the set
+    # until it dirties again. Sweeping more often would only re-read those tables
+    # into the page cache for nothing.
+    #
+    # This deliberately lives in the WEB process, not the worker: a restore stops
+    # Flask before psql replaces the database (see app_backup), so this thread is
+    # already dead by the time a restore takes its ACCESS EXCLUSIVE locks. It is a
+    # daemon thread, so a setup-wizard restart kills it the same way; the connection
+    # drops and Postgres rolls the VACUUM back, which is crash-safe by design.
+    #
+    # A dedicated connection, because VACUUM cannot run inside a transaction and the
+    # app-context connections are mid-transaction by definition.
+    def _blob_reclaim_loop():
+        try:
+            from time import sleep
+            from database import connect_raw
+            from taskqueue import sql as queue_sql
+            from taskqueue.maintenance import reclaim_blob_space
+
+            # Let the startup index loads finish before adding any VACUUM I/O.
+            sleep(120)
+            conn = None
+            while True:
+                try:
+                    if conn is None or conn.closed:
+                        conn = connect_raw(
+                            application_name=f"audiomuse-blob-reclaim-{os.getpid()}"
+                        )
+                    reclaim_blob_space(conn)
+                except Exception:
+                    app.logger.exception('blob space reclaim cycle failed')
+                    if conn is not None:
+                        try:
+                            conn.close()
+                        except Exception:
+                            app.logger.exception('closing the blob reclaim connection failed')
+                    conn = None
+                sleep(queue_sql.BLOB_RECLAIM_INTERVAL_SECONDS)
+        except Exception:
+            app.logger.exception('blob space reclaim main loop error')
+
+    blob_reclaim_thread = threading.Thread(target=_blob_reclaim_loop, daemon=True)
+    blob_reclaim_thread.start()
 else:
     logger.info('Running as a queue worker: skipping index loading, the event listener and the cron thread.')
 

--- a/app.py
+++ b/app.py
@@ -1022,6 +1022,17 @@ def listen_for_index_reloads():
                 )
             except Exception:
                 logger.exception("Error reloading indexes/maps from background listener")
+            finally:
+                # A reload replaces every index in place, so the whole previous
+                # generation plus each rebuild's scratch is garbage by now. Hand
+                # it back to the kernel instead of letting RSS ratchet up once
+                # per reload for the life of the process.
+                try:
+                    from tasks.memory_utils import release_memory_to_os
+
+                    release_memory_to_os()
+                except Exception:
+                    logger.exception("Index reload: heap release to the OS failed")
 
     listener = Listener(
         (CHANNEL_EVENT,),
@@ -1200,6 +1211,17 @@ if not _is_worker:
                 )
         except Exception as e:
             logger.debug(f"SemGrove cache not loaded at startup: {e}")
+
+        # Every load above streams a large directory blob out of Postgres and
+        # discards it once unpacked. Those frees land in the allocator's free
+        # lists, not back in the kernel, so without this the pod's RSS keeps the
+        # startup peak for the life of the process. One call, after all six.
+        try:
+            from tasks.memory_utils import release_memory_to_os
+
+            release_memory_to_os()
+        except Exception:
+            logger.exception("Startup index load: heap release to the OS failed")
 
         def _start_map_init_background():
             try:

--- a/app_map.py
+++ b/app_map.py
@@ -19,9 +19,9 @@ Main Features:
   are labelled by their top mood parsed from the stored mood_vector string.
 * Multi-server: responses are filtered per request to the selected server's
   catalogue; the shared cache always holds the full union.
-* build_map_cache streams the catalogue through a named server-side cursor and
-  loads the stored projection first, so a row it already covers drops its
-  embedding on read instead of every vector staying resident until projection.
+* build_map_cache reads the catalogue through a plain client-side cursor, so
+  Postgres streams the rows and holds nothing server-side; the transient peak
+  lands in the web process, which is the one this app can release.
 * The build is the web process's largest short-lived allocation, so it ends by
   handing the freed heap back to the kernel: gc alone only returns it to the
   allocator's free lists and the pod would keep the peak RSS for good.
@@ -192,49 +192,48 @@ def build_map_cache():
     has_canonical = False
 
     conn = get_db()
-    # A NAMED server-side cursor streams the join in itersize chunks. An unnamed
-    # cursor buffers every row - embedding bytea included, and psycopg2 receives
-    # bytea as hex, so twice its binary size - inside libpq AND again as Python
-    # objects before the first row is visible, which is this process's peak RSS.
-    with conn.cursor(name='map_cache_scan') as cur:
-        cur.itersize = 20000
+    # A plain client-side cursor delivers the whole join into this process.
+    # Postgres streams the rows and holds nothing server-side, so the transient
+    # peak lands here, where this app owns the release, instead of on the
+    # database container. The raw rows are dropped before the projection step so
+    # the heap release at the end returns real memory, not just free lists.
+    with conn.cursor() as cur:
         cur.execute("""
             SELECT s.item_id, s.title, s.author, s.mood_vector, e.embedding
             FROM score s
             JOIN embedding e ON s.item_id = e.item_id
         """)
-        for item_id, title, author, mood_vector, emb_blob in cur:
-            if emb_blob is None:
-                continue
-            iid = str(item_id)
-            if not has_canonical and is_fingerprint_id(iid):
-                has_canonical = True
-            coord = coords_by_id.get(iid)
-            if coord is None:
-                # Only an item the stored projection does not cover needs its
-                # vector kept. The copy is mandatory: np.frombuffer aliases the
-                # chunk buffer that the next itersize fetch overwrites.
+        rows = cur.fetchall()
+    for item_id, title, author, mood_vector, emb_blob in rows:
+        if emb_blob is None:
+            continue
+        iid = str(item_id)
+        if not has_canonical and is_fingerprint_id(iid):
+            has_canonical = True
+        coord = coords_by_id.get(iid)
+        if coord is None:
+            try:
+                emb = np.frombuffer(emb_blob, dtype=np.float32)
+            except Exception:
+                # fallback if already stored as list
                 try:
-                    emb = np.frombuffer(emb_blob, dtype=np.float32).copy()
+                    emb = np.array(emb_blob, dtype=np.float32)
                 except Exception:
-                    # fallback if already stored as list
-                    try:
-                        emb = np.array(emb_blob, dtype=np.float32)
-                    except Exception:
-                        continue
-                missing_slots.append((len(full_light), emb))
-                coord = (0.0, 0.0)
-            full_light.append(
-                {
-                    'artist': author or '',
-                    'embedding_2d': _round_coord(coord),
-                    'item_id': iid,
-                    'mood_vector': _pick_top_mood(mood_vector),
-                    'title': title or '',
-                }
-            )
+                    continue
+            missing_slots.append((len(full_light), emb))
+            coord = (0.0, 0.0)
+        full_light.append(
+            {
+                'artist': author or '',
+                'embedding_2d': _round_coord(coord),
+                'item_id': iid,
+                'mood_vector': _pick_top_mood(mood_vector),
+                'title': title or '',
+            }
+        )
+    rows = None
 
-    # Set the canonical-id memo from the ids just streamed - NO extra DB probe. The
+    # Set the canonical-id memo from the ids just loaded - NO extra DB probe. The
     # fast path may stream these cached bytes verbatim only when NONE is a canonical
     # fp_ id; a rebuild (e.g. after canonicalization) reflects the legacy->fp_ flip
     # exactly here, instead of a reset that re-triggered a score seq-scan on every

--- a/app_map.py
+++ b/app_map.py
@@ -19,6 +19,12 @@ Main Features:
   are labelled by their top mood parsed from the stored mood_vector string.
 * Multi-server: responses are filtered per request to the selected server's
   catalogue; the shared cache always holds the full union.
+* build_map_cache streams the catalogue through a named server-side cursor and
+  loads the stored projection first, so a row it already covers drops its
+  embedding on read instead of every vector staying resident until projection.
+* The build is the web process's largest short-lived allocation, so it ends by
+  handing the freed heap back to the kernel: gc alone only returns it to the
+  allocator's free lists and the pod would keep the peak RSS for good.
 """
 
 import gc
@@ -137,6 +143,16 @@ def _sample_items(items, fraction):
     return out
 
 
+def _release_map_build_memory():
+    gc.collect()
+    try:
+        from tasks.memory_utils import release_memory_to_os
+
+        release_memory_to_os()
+    except Exception:
+        logger.exception('Map cache build: heap release to the OS failed')
+
+
 def build_map_cache():
     """Load all tracks & embeddings from DB, compute 2D projection (prefer precomputed),
     and build cached JSON blobs for 100/75/50/25 percent samples. This should be called
@@ -146,62 +162,10 @@ def build_map_cache():
     logger = logging.getLogger(__name__)
     logger.info('Building map JSON cache (this reads the DB once).')
 
-    conn = get_db()
-    cur = conn.cursor()
-    try:
-        cur.execute("""
-            SELECT s.item_id, s.title, s.author, s.mood_vector, e.embedding
-            FROM score s
-            JOIN embedding e ON s.item_id = e.item_id
-        """)
-        rows = cur.fetchall()
-    finally:
-        cur.close()
-
-    items = []
-    for r in rows:
-        # r: item_id, title, author, mood_vector, embedding_blob
-        item_id = r[0]
-        title = r[1]
-        author = r[2]
-        mood_vector = r[3]
-        emb_blob = r[4]
-        if emb_blob is None:
-            continue
-        try:
-            emb = np.frombuffer(emb_blob, dtype=np.float32)
-        except Exception:
-            # fallback if already stored as list
-            try:
-                emb = np.array(r[4], dtype=np.float32)
-            except Exception:
-                continue
-        items.append(
-            {
-                'item_id': str(item_id),
-                'title': title,
-                'artist': author,
-                'mood_vector': mood_vector,
-                'embedding': emb,
-            }
-        )
-
-    # Set the canonical-id memo from the ids just loaded - NO extra DB probe. The
-    # fast path may stream these cached bytes verbatim only when NONE is a canonical
-    # fp_ id; a rebuild (e.g. after canonicalization) reflects the legacy->fp_ flip
-    # exactly here, instead of a reset that re-triggered a score seq-scan on every
-    # routine rebuild. Canonicalization is one-way, so this only ever flips to True.
-    from tasks.simhash import is_fingerprint_id
-    _HAS_CANONICAL_IDS = any(is_fingerprint_id(it['item_id']) for it in items)
-    _HAS_CANONICAL_CHECKED_AT = time.monotonic()
-
-    if not items:
-        # empty cache
-        MAP_JSON_CACHE = {}
-        logger.warning('No items found to build map cache.')
-        return
-
-    # Try to use precomputed projection if available
+    # The precomputed projection is loaded BEFORE the catalogue scan: a row whose
+    # coordinates are already known can then drop its embedding the moment it is
+    # read, instead of every embedding staying resident until the projection step.
+    # On a projected library that keeps ZERO embeddings in RAM for the whole build.
     id_map, proj = None, None
     try:
         id_map, proj = load_map_projection('main_map', force_reload=True)
@@ -218,13 +182,78 @@ def build_map_cache():
             used_projection = 'precomputed'
         except Exception:
             coords_by_id = {}
+    id_map = None
+    proj = None
+
+    from tasks.simhash import is_fingerprint_id
+
+    full_light = []
+    missing_slots = []
+    has_canonical = False
+
+    conn = get_db()
+    # A NAMED server-side cursor streams the join in itersize chunks. An unnamed
+    # cursor buffers every row - embedding bytea included, and psycopg2 receives
+    # bytea as hex, so twice its binary size - inside libpq AND again as Python
+    # objects before the first row is visible, which is this process's peak RSS.
+    with conn.cursor(name='map_cache_scan') as cur:
+        cur.itersize = 20000
+        cur.execute("""
+            SELECT s.item_id, s.title, s.author, s.mood_vector, e.embedding
+            FROM score s
+            JOIN embedding e ON s.item_id = e.item_id
+        """)
+        for item_id, title, author, mood_vector, emb_blob in cur:
+            if emb_blob is None:
+                continue
+            iid = str(item_id)
+            if not has_canonical and is_fingerprint_id(iid):
+                has_canonical = True
+            coord = coords_by_id.get(iid)
+            if coord is None:
+                # Only an item the stored projection does not cover needs its
+                # vector kept. The copy is mandatory: np.frombuffer aliases the
+                # chunk buffer that the next itersize fetch overwrites.
+                try:
+                    emb = np.frombuffer(emb_blob, dtype=np.float32).copy()
+                except Exception:
+                    # fallback if already stored as list
+                    try:
+                        emb = np.array(emb_blob, dtype=np.float32)
+                    except Exception:
+                        continue
+                missing_slots.append((len(full_light), emb))
+                coord = (0.0, 0.0)
+            full_light.append(
+                {
+                    'artist': author or '',
+                    'embedding_2d': _round_coord(coord),
+                    'item_id': iid,
+                    'mood_vector': _pick_top_mood(mood_vector),
+                    'title': title or '',
+                }
+            )
+
+    # Set the canonical-id memo from the ids just streamed - NO extra DB probe. The
+    # fast path may stream these cached bytes verbatim only when NONE is a canonical
+    # fp_ id; a rebuild (e.g. after canonicalization) reflects the legacy->fp_ flip
+    # exactly here, instead of a reset that re-triggered a score seq-scan on every
+    # routine rebuild. Canonicalization is one-way, so this only ever flips to True.
+    _HAS_CANONICAL_IDS = has_canonical
+    _HAS_CANONICAL_CHECKED_AT = time.monotonic()
+
+    if not full_light:
+        # empty cache
+        MAP_JSON_CACHE = {}
+        logger.warning('No items found to build map cache.')
+        _release_map_build_memory()
+        return
 
     # For items still missing coordinates, compute projection on-the-fly using available helpers
-    missing_indices = [i for i, it in enumerate(items) if str(it['item_id']) not in coords_by_id]
-    if missing_indices:
+    if missing_slots:
         try:
             # Build matrix of missing emb
-            mat = np.vstack([items[i]['embedding'] for i in missing_indices])
+            mat = np.vstack([emb for _, emb in missing_slots])
             projections = None
             used = 'none'
             # prefer UMAP helper if present
@@ -248,34 +277,22 @@ def build_map_cache():
                 except Exception as e:
                     logger.debug('PCA helper failed during cache build: %s', e)
             if projections is None:
-                projections = [(0.0, 0.0) for _ in missing_indices]
+                projections = [(0.0, 0.0) for _ in missing_slots]
                 used = 'none'
 
             del mat
 
-            for idx, coord in zip(missing_indices, projections):
-                coords_by_id[str(items[idx]['item_id'])] = (float(coord[0]), float(coord[1]))
+            for (slot, _emb), coord in zip(missing_slots, projections):
+                full_light[slot]['embedding_2d'] = _round_coord(
+                    (float(coord[0]), float(coord[1]))
+                )
             if used_projection == 'none':
                 used_projection = used
         except Exception:
             logger.exception('Failed to compute missing projections')
 
-    for it in items:
-        it.pop('embedding', None)
-
-    full_light = []
-    for it in items:
-        iid = str(it['item_id'])
-        coord = coords_by_id.get(iid, (0.0, 0.0))
-        light = {
-            'artist': it.get('artist') or '',
-            'embedding_2d': _round_coord(coord),
-            'item_id': iid,
-            'mood_vector': _pick_top_mood(it.get('mood_vector')),
-            'title': it.get('title') or '',
-        }
-        full_light.append(light)
-    del items
+    coords_by_id = {}
+    missing_slots = []
     gc.collect()
 
     n = len(full_light)
@@ -302,6 +319,9 @@ def build_map_cache():
         n,
         {k: v['count'] for k, v in MAP_JSON_CACHE.items()},
     )
+    del full_light
+    del new_cache
+    _release_map_build_memory()
 
 
 def _translated_bucket(entry, server_id):

--- a/taskqueue/maintenance.py
+++ b/taskqueue/maintenance.py
@@ -33,6 +33,12 @@ Main Features:
   that stopped, skipping any protected migration handshake task
 * run_cycle elects one maintenance winner per pass and runs reclaim plus the
   slower retention sweeps only when they are due
+* reclaim_blob_space VACUUMs what autovacuum cannot reach, because its threshold
+  counts ROWS and a table of a few huge blobs never gets near it. Plain VACUUM
+  only, so readers and writers are never blocked; it stands down while a task is
+  live or another session holds an old snapshot (a backup's pg_dump), and a
+  lock_timeout means it never queues behind anyone. run_cycle does NOT call it -
+  the web process schedules it, where a restore has already stopped Flask
 """
 
 import json
@@ -261,6 +267,80 @@ def clear_terminal_shared_payloads(conn):
             "Cleared the shared payload left on %d terminal task row(s).", cleared
         )
     return cleared
+
+
+def reclaim_blob_space(conn):
+    import psycopg2
+
+    previous = conn.autocommit
+    try:
+        conn.autocommit = True
+    except Exception:
+        logger.exception(
+            "Could not put the connection in autocommit; skipping this blob reclaim "
+            "(VACUUM cannot run inside a transaction block)"
+        )
+        return []
+    reclaimed = []
+    try:
+        with conn.cursor() as cur:
+            sql.begin_reclaim_session(cur)
+            if sql.any_live_task(cur):
+                logger.info("Blob reclaim skipped: a task is live")
+                return []
+            if sql.snapshot_holder_blocking_reclaim(cur):
+                logger.info(
+                    "Blob reclaim skipped: another session has held a snapshot for over "
+                    "%ss (a backup's pg_dump looks exactly like this). VACUUM could not "
+                    "remove anything newer than that snapshot anyway.",
+                    sql.BLOB_RECLAIM_SNAPSHOT_GRACE_SECONDS,
+                )
+                return []
+            targets = sql.blob_tables_autovacuum_cannot_reach(cur)
+            if not targets:
+                logger.info("Blob reclaim passed: found no tables with reclaimable dead rows.")
+                return []
+        for quoted_relname, dead, total in targets:
+            try:
+                with conn.cursor() as cur:
+                    sql.vacuum_table(cur, quoted_relname)
+            except (psycopg2.errors.LockNotAvailable, psycopg2.errors.QueryCanceled):
+                logger.info(
+                    "Blob reclaim left %s alone: it was busy, and this sweep never queues "
+                    "behind another lock. The next pass picks it up.",
+                    quoted_relname,
+                )
+                continue
+            except Exception:
+                logger.exception(
+                    "VACUUM %s failed; sweeping the remaining tables anyway", quoted_relname
+                )
+                continue
+            reclaimed.append(quoted_relname)
+            logger.info(
+                "VACUUM %s reclaimed %d dead row(s) in a %s table. Autovacuum fires on ROW "
+                "count, so a table of a few huge blobs needs ~50 rebuilds to qualify and "
+                "meanwhile every replaced blob stays on disk.",
+                quoted_relname, dead, total,
+            )
+        if reclaimed:
+            logger.info(
+                "Blob reclaim passed: vacuumed %d table(s): %s",
+                len(reclaimed), ", ".join(reclaimed),
+            )
+        else:
+            logger.info(
+                "Blob reclaim passed: %d candidate table(s) found but none were vacuumed.",
+                len(targets),
+            )
+    except Exception:
+        logger.exception("Blob-table space reclaim failed")
+    finally:
+        try:
+            conn.autocommit = previous
+        except Exception:
+            logger.exception("Restoring the connection autocommit mode failed")
+    return reclaimed
 
 
 def run_cycle(conn, with_retention=True):

--- a/taskqueue/sql.py
+++ b/taskqueue/sql.py
@@ -24,6 +24,10 @@ Main Features:
 * insert_job / claim / finish_child / requeue_or_fail move a row through its life
 * hold / try_hold / release are the advisory-lock liveness primitives
 * reap_children deletes finished children; notify_* publish to workers/Flask
+* blob_tables_autovacuum_cannot_reach / vacuum_table sweep the tables whose dead
+  rows autovacuum will not collect, because its threshold counts ROWS and these
+  hold a few enormous TOASTed blobs; begin_reclaim_session caps that sweep with
+  a lock_timeout so it can never queue behind a reader, writer or restore
 """
 
 import hashlib
@@ -462,6 +466,81 @@ def release_maintenance_lock(cur):
     cur.execute(
         "SELECT pg_advisory_unlock(%s, %s)", (MAINTENANCE_LOCK_CLASS, MAINTENANCE_LOCK_KEY)
     )
+
+
+BLOB_RECLAIM_MIN_BYTES = 1024 * 1024
+BLOB_RECLAIM_INTERVAL_SECONDS = 3600
+BLOB_RECLAIM_LOCK_TIMEOUT = '2s'
+BLOB_RECLAIM_STATEMENT_TIMEOUT = '10min'
+BLOB_RECLAIM_SNAPSHOT_GRACE_SECONDS = 30
+
+
+def begin_reclaim_session(cur):
+    cur.execute("SELECT set_config('lock_timeout', %s, false)", (BLOB_RECLAIM_LOCK_TIMEOUT,))
+    cur.execute(
+        "SELECT set_config('statement_timeout', %s, false)",
+        (BLOB_RECLAIM_STATEMENT_TIMEOUT,),
+    )
+
+
+_ANY_LIVE_TASK = f"SELECT 1 FROM task_status WHERE status IN ({_LIVE_IN_LIST}) LIMIT 1"
+
+
+def any_live_task(cur):
+    cur.execute(_ANY_LIVE_TASK)
+    return cur.fetchone() is not None
+
+
+_OLD_SNAPSHOT_HOLDER = """
+    SELECT 1 FROM pg_stat_activity
+    WHERE datname = current_database()
+      AND pid <> pg_backend_pid()
+      AND backend_xmin IS NOT NULL
+      AND xact_start < now() - make_interval(secs => %s)
+    LIMIT 1
+"""
+
+
+def snapshot_holder_blocking_reclaim(cur, grace_seconds=None):
+    grace = (
+        BLOB_RECLAIM_SNAPSHOT_GRACE_SECONDS if grace_seconds is None else float(grace_seconds)
+    )
+    cur.execute(_OLD_SNAPSHOT_HOLDER, (grace,))
+    return cur.fetchone() is not None
+
+
+_BLOB_TABLES_AUTOVACUUM_CANNOT_REACH = """
+    SELECT quote_ident(s.schemaname) || '.' || quote_ident(s.relname), s.n_dead_tup,
+           pg_size_pretty(pg_total_relation_size(s.relid))
+    FROM pg_stat_user_tables AS s
+    WHERE s.n_dead_tup > 0
+      AND s.n_dead_tup < current_setting('autovacuum_vacuum_threshold')::numeric
+                         + current_setting('autovacuum_vacuum_scale_factor')::numeric
+                           * greatest(s.n_live_tup, 0)
+      AND (
+          EXISTS (
+              SELECT 1 FROM pg_attribute AS a
+              WHERE a.attrelid = s.relid
+                AND a.attnum > 0 AND NOT a.attisdropped
+                AND a.atttypid = 'bytea'::regtype
+          )
+          OR pg_total_relation_size(s.relid) >= %s
+      )
+    ORDER BY pg_total_relation_size(s.relid) DESC
+"""
+
+
+def blob_tables_autovacuum_cannot_reach(cur, min_bytes=None):
+    floor_bytes = BLOB_RECLAIM_MIN_BYTES if min_bytes is None else int(min_bytes)
+    cur.execute(_BLOB_TABLES_AUTOVACUUM_CANNOT_REACH, (floor_bytes,))
+    return [
+        (quoted_relname, int(dead), str(total))
+        for quoted_relname, dead, total in (cur.fetchall() or ())
+    ]
+
+
+def vacuum_table(cur, quoted_relname):
+    cur.execute('VACUUM ' + quoted_relname)
 
 
 _RUNNING_TASKS = f"""

--- a/tasks/index_build_helpers.py
+++ b/tasks/index_build_helpers.py
@@ -19,6 +19,10 @@ Main Features:
 * build_and_store_index_streaming and the segmented-blob helpers: split large
   id maps and index payloads into row-sized fragments (SQL identifiers are
   regex-validated before interpolation), plus artist-metadata pack/unpack.
+* load_segmented_blob reads the part names first and then one part per round
+  trip, so a multi-hundred-MB index never has every segment resident at once;
+  segmented_blob_length answers an existence/size probe in SQL, leaving the
+  blob bytes on the server.
 """
 
 from __future__ import annotations
@@ -450,9 +454,7 @@ def load_segmented_blob(
     _validate_sql_identifier(name, "name")
 
     select_single_sql = f"SELECT blob_data FROM {target_table} WHERE name = %s"
-    select_segments_sql = (
-        f"SELECT name, blob_data FROM {target_table} WHERE name LIKE %s ESCAPE '\\'"
-    )
+    select_names_sql = f"SELECT name FROM {target_table} WHERE name LIKE %s ESCAPE '\\'"
     like_pattern = name.replace("_", r"\_") + r"\_%\_%"
     seg_pattern = re.compile(rf"^{re.escape(name)}_(\d+)_(\d+)$")
 
@@ -463,15 +465,15 @@ def load_segmented_blob(
             data = row[0]
             return bytes(data)
 
-        cur.execute(select_segments_sql, (like_pattern,))
-        rows = cur.fetchall()
+        cur.execute(select_names_sql, (like_pattern,))
+        seg_names = [r[0] for r in cur.fetchall()]
 
-    if not rows:
+    if not seg_names:
         return None
 
-    parts: List[Tuple[int, bytes]] = []
+    ordered: List[Tuple[int, str]] = []
     total_expected: Optional[int] = None
-    for row_name, row_blob in rows:
+    for row_name in seg_names:
         m = seg_pattern.match(row_name)
         if not m:
             continue
@@ -484,16 +486,61 @@ def load_segmented_blob(
                 f"Segment total mismatch for '{name}' in {target_table}: "
                 f"saw {total_expected} and {total}."
             )
-        parts.append((part_no, bytes(row_blob) if row_blob else b""))
+        ordered.append((part_no, row_name))
 
-    if total_expected is None or len(parts) != total_expected:
+    if total_expected is None or len(ordered) != total_expected:
         raise ValueError(
             f"Incomplete segmented blob for '{name}' in {target_table}: "
-            f"expected {total_expected}, found {len(parts)}."
+            f"expected {total_expected}, found {len(ordered)}."
         )
 
-    parts.sort(key=lambda p: p[0])
-    return b"".join(part_data for _, part_data in parts)
+    ordered.sort(key=lambda p: p[0])
+
+    buf = bytearray()
+    with db_conn.cursor() as cur:
+        for _part_no, part_name in ordered:
+            cur.execute(select_single_sql, (part_name,))
+            part_row = cur.fetchone()
+            if part_row is None:
+                raise ValueError(
+                    f"Segment '{part_name}' of '{name}' in {target_table} "
+                    f"disappeared between the name scan and the read."
+                )
+            if part_row[0]:
+                buf += part_row[0]
+            part_row = None
+    return bytes(buf)
+
+
+def segmented_blob_length(
+    db_conn,
+    target_table: str,
+    name: str,
+) -> Optional[int]:
+    _validate_sql_identifier(target_table, "table")
+    _validate_sql_identifier(name, "name")
+
+    like_pattern = name.replace("_", r"\_") + r"\_%\_%"
+
+    with db_conn.cursor() as cur:
+        cur.execute(
+            f"SELECT octet_length(blob_data) FROM {target_table} WHERE name = %s",
+            (name,),
+        )
+        row = cur.fetchone()
+        if row and row[0]:
+            return int(row[0])
+
+        cur.execute(
+            f"SELECT COALESCE(SUM(octet_length(blob_data)), 0) FROM {target_table} "
+            f"WHERE name LIKE %s ESCAPE '\\'",
+            (like_pattern,),
+        )
+        row = cur.fetchone()
+
+    if not row or not row[0]:
+        return None
+    return int(row[0])
 
 
 _ARTIST_META_MAGIC = b"ARMD"

--- a/tasks/paged_ivf.py
+++ b/tasks/paged_ivf.py
@@ -1531,11 +1531,11 @@ def build_and_store_paged_ivf(
 
 
 def has_paged_ivf(db_conn, index_name: str) -> bool:
-    from .index_build_helpers import load_segmented_blob
+    from .index_build_helpers import segmented_blob_length
 
     try:
-        blob = load_segmented_blob(db_conn, IVF_DIR_TABLE, f"{index_name}__ivf_dir")
-        return blob is not None and len(blob) >= _HEADER_SIZE
+        size = segmented_blob_length(db_conn, IVF_DIR_TABLE, f"{index_name}__ivf_dir")
+        return size is not None and size >= _HEADER_SIZE
     except Exception:
         return False
 

--- a/test/unit/test_app_map_helpers.py
+++ b/test/unit/test_app_map_helpers.py
@@ -17,7 +17,7 @@ Main Features:
 * _sample_items samples a deterministic fraction, returning a fresh list
 * _translated_bucket rewrites canonical ids to a server's provider ids, drops
   fp_/unmapped rows, and fails closed on a registry error (never leaks fp_)
-* build_map_cache streams the catalogue through a named server-side cursor and
+* build_map_cache reads the catalogue through a plain client-side cursor and
   keeps a vector only for rows the stored projection does not already cover
 """
 
@@ -138,7 +138,7 @@ class TestBuildMapCacheStreaming:
         cur = MagicMock()
         cur.__enter__ = MagicMock(return_value=cur)
         cur.__exit__ = MagicMock(return_value=False)
-        cur.__iter__ = MagicMock(return_value=iter(rows))
+        cur.fetchall = MagicMock(return_value=list(rows))
         conn = MagicMock()
         conn.cursor.return_value = cur
 
@@ -149,7 +149,7 @@ class TestBuildMapCacheStreaming:
         app_map.build_map_cache()
         return conn, cur
 
-    def test_catalogue_scan_uses_a_named_server_side_cursor(self, monkeypatch):
+    def test_catalogue_scan_uses_a_plain_client_side_cursor(self, monkeypatch):
         emb = np.array([0.1, 0.2], dtype=np.float32).tobytes()
         conn, cur = self._run(
             monkeypatch,
@@ -157,8 +157,8 @@ class TestBuildMapCacheStreaming:
             ['a'],
             np.array([[1.0, 2.0]], dtype=np.float32),
         )
-        assert conn.cursor.call_args.kwargs.get('name') == 'map_cache_scan'
-        assert cur.itersize == 20000
+        assert conn.cursor.call_args.kwargs.get('name') is None
+        cur.fetchall.assert_called_once()
 
     def test_row_already_in_the_projection_never_parses_its_embedding(self, monkeypatch):
         self._run(

--- a/test/unit/test_app_map_helpers.py
+++ b/test/unit/test_app_map_helpers.py
@@ -17,11 +17,17 @@ Main Features:
 * _sample_items samples a deterministic fraction, returning a fresh list
 * _translated_bucket rewrites canonical ids to a server's provider ids, drops
   fp_/unmapped rows, and fails closed on a registry error (never leaks fp_)
+* build_map_cache streams the catalogue through a named server-side cursor and
+  keeps a vector only for rows the stored projection does not already cover
 """
 
 import gzip
 import json
+from unittest.mock import MagicMock
 
+import numpy as np
+
+import app_map
 from app_map import (
     _pick_top_mood,
     _round_coord,
@@ -125,3 +131,70 @@ class TestTranslatedBucket:
 
     def test_empty_entry_returns_none(self):
         assert _translated_bucket({}, None) is None
+
+
+class TestBuildMapCacheStreaming:
+    def _run(self, monkeypatch, rows, id_map, proj):
+        cur = MagicMock()
+        cur.__enter__ = MagicMock(return_value=cur)
+        cur.__exit__ = MagicMock(return_value=False)
+        cur.__iter__ = MagicMock(return_value=iter(rows))
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+
+        monkeypatch.setattr(app_map, 'get_db', lambda: conn)
+        monkeypatch.setattr(app_map, 'load_map_projection', lambda *a, **k: (id_map, proj))
+        monkeypatch.setattr(app_map, '_warm_server_buckets', lambda: None)
+        monkeypatch.setattr(app_map, 'MAP_JSON_CACHE', {})
+        app_map.build_map_cache()
+        return conn, cur
+
+    def test_catalogue_scan_uses_a_named_server_side_cursor(self, monkeypatch):
+        emb = np.array([0.1, 0.2], dtype=np.float32).tobytes()
+        conn, cur = self._run(
+            monkeypatch,
+            [('a', 'T', 'A', 'happy:1', emb)],
+            ['a'],
+            np.array([[1.0, 2.0]], dtype=np.float32),
+        )
+        assert conn.cursor.call_args.kwargs.get('name') == 'map_cache_scan'
+        assert cur.itersize == 20000
+
+    def test_row_already_in_the_projection_never_parses_its_embedding(self, monkeypatch):
+        self._run(
+            monkeypatch,
+            [('a', 'Title', 'Artist', 'happy:1', b'not-a-float32-buffer')],
+            ['a'],
+            np.array([[1.0, 2.0]], dtype=np.float32),
+        )
+        payload = _items_from_bucket(app_map.MAP_JSON_CACHE['100'])
+        assert [it['item_id'] for it in payload['items']] == ['a']
+        assert payload['items'][0]['embedding_2d'] == [1.0, 2.0]
+
+    def test_only_rows_missing_from_the_projection_reach_the_projector(self, monkeypatch):
+        emb = np.array([0.1, 0.2], dtype=np.float32).tobytes()
+        seen = {}
+
+        def fake_project(mat):
+            seen['rows'] = mat.shape[0]
+            return [(9.0, 9.0)] * mat.shape[0]
+
+        monkeypatch.setattr(app_map, '_project_with_umap', None)
+        monkeypatch.setattr(app_map, '_project_to_2d', fake_project)
+        self._run(
+            monkeypatch,
+            [
+                ('a', 'T', 'A', 'happy:1', emb),
+                ('b', 'T', 'A', 'happy:1', emb),
+            ],
+            ['a'],
+            np.array([[1.0, 2.0]], dtype=np.float32),
+        )
+        assert seen['rows'] == 1
+        payload = _items_from_bucket(app_map.MAP_JSON_CACHE['100'])
+        coords = {it['item_id']: it['embedding_2d'] for it in payload['items']}
+        assert coords == {'a': [1.0, 2.0], 'b': [9.0, 9.0]}
+
+    def test_empty_catalogue_leaves_an_empty_cache(self, monkeypatch):
+        self._run(monkeypatch, [], [], np.zeros((0, 2), dtype=np.float32))
+        assert app_map.MAP_JSON_CACHE == {}

--- a/test/unit/test_artist_metadata_codec.py
+++ b/test/unit/test_artist_metadata_codec.py
@@ -275,16 +275,85 @@ class TestStoreLoadSegmentedBlob:
         result = _helpers.load_segmented_blob(mock_conn, "artist_metadata_data", "artist_metadata")
         assert result == b"hello-world"
 
+    def _segmented_conn(self, segments):
+        mock_conn, mock_cur, captured = self._captured_conn()
+        mock_cur.fetchall.return_value = [(n,) for n in segments]
+
+        def fetchone_side():
+            _sql, params = captured[-1]
+            return (segments[params[0]],) if params[0] in segments else None
+
+        mock_cur.fetchone.side_effect = fetchone_side
+        return mock_conn, mock_cur, captured
+
     def test_load_reassembles_segments_in_order(self):
-        mock_conn, mock_cur, _ = self._captured_conn()
-        mock_cur.fetchone.return_value = None
-        mock_cur.fetchall.return_value = [
-            ("artist_metadata_3_3", b"-third"),
-            ("artist_metadata_1_3", b"first"),
-            ("artist_metadata_2_3", b"-second"),
-        ]
+        mock_conn, _, _ = self._segmented_conn(
+            {
+                "artist_metadata_3_3": b"-third",
+                "artist_metadata_1_3": b"first",
+                "artist_metadata_2_3": b"-second",
+            }
+        )
         result = _helpers.load_segmented_blob(mock_conn, "artist_metadata_data", "artist_metadata")
         assert result == b"first-second-third"
+
+    def test_load_never_selects_every_segment_blob_in_one_result_set(self):
+        mock_conn, _, captured = self._segmented_conn(
+            {
+                "artist_metadata_1_2": b"first",
+                "artist_metadata_2_2": b"-second",
+            }
+        )
+        _helpers.load_segmented_blob(mock_conn, "artist_metadata_data", "artist_metadata")
+        multi_row_reads = [
+            sql for sql, _params in captured
+            if "LIKE" in sql and "blob_data" in sql
+        ]
+        assert multi_row_reads == []
+
+    def test_load_reads_one_segment_blob_per_round_trip(self):
+        mock_conn, _, captured = self._segmented_conn(
+            {
+                "artist_metadata_1_2": b"first",
+                "artist_metadata_2_2": b"-second",
+            }
+        )
+        _helpers.load_segmented_blob(mock_conn, "artist_metadata_data", "artist_metadata")
+        blob_reads = [params[0] for sql, params in captured if "blob_data" in sql and "LIKE" not in sql]
+        assert blob_reads == ["artist_metadata", "artist_metadata_1_2", "artist_metadata_2_2"]
+
+    def test_load_raises_when_a_segment_vanishes_between_name_scan_and_read(self):
+        mock_conn, mock_cur, _ = self._captured_conn()
+        mock_cur.fetchone.return_value = None
+        mock_cur.fetchall.return_value = [("artist_metadata_1_1",)]
+        with pytest.raises(ValueError, match="disappeared"):
+            _helpers.load_segmented_blob(mock_conn, "artist_metadata_data", "artist_metadata")
+
+    def test_segmented_blob_length_returns_single_row_length(self):
+        mock_conn, mock_cur, _ = self._captured_conn()
+        mock_cur.fetchone.return_value = (4096,)
+        size = _helpers.segmented_blob_length(
+            mock_conn, "artist_metadata_data", "artist_metadata"
+        )
+        assert size == 4096
+
+    def test_segmented_blob_length_sums_segments_without_selecting_blob_data(self):
+        mock_conn, mock_cur, captured = self._captured_conn()
+        mock_cur.fetchone.side_effect = [None, (900,)]
+        size = _helpers.segmented_blob_length(
+            mock_conn, "artist_metadata_data", "artist_metadata"
+        )
+        assert size == 900
+        assert all("SELECT blob_data" not in sql for sql, _params in captured)
+        assert all("octet_length" in sql for sql, _params in captured)
+
+    def test_segmented_blob_length_returns_none_when_absent(self):
+        mock_conn, mock_cur, _ = self._captured_conn()
+        mock_cur.fetchone.side_effect = [None, (0,)]
+        size = _helpers.segmented_blob_length(
+            mock_conn, "artist_metadata_data", "artist_metadata"
+        )
+        assert size is None
 
     def test_load_raises_on_incomplete_segments(self):
         mock_conn, mock_cur, _ = self._captured_conn()

--- a/test/unit/test_taskqueue_blob_reclaim.py
+++ b/test/unit/test_taskqueue_blob_reclaim.py
@@ -1,0 +1,313 @@
+# AudioMuse-AI - https://github.com/NeptuneHub/AudioMuse-AI
+# Copyright (C) 2025 NeptuneHub
+# SPDX-License-Identifier: AGPL-3.0-only
+#
+# This program is free software: you can redistribute it and/or modify it under
+# the terms of the GNU Affero General Public License v3.0. See the LICENSE file
+# in the project root or <https://github.com/NeptuneHub/AudioMuse-AI/blob/main/LICENSE>
+
+"""Autovacuum counts ROWS, so a table of a few huge blobs never qualifies.
+
+Its threshold is 50 + 20% of the LIVE row count. ivf_dir carries eight rows,
+150-odd MB and the hyperbolic tree, so it needs ~50 dead rows - about seven full
+index rebuilds - before autovacuum touches it, and sits at several times its
+useful size until then. This sweep keeps that plateau low.
+
+It must never collide with anything. Plain VACUUM only, which takes SHARE UPDATE
+EXCLUSIVE and so blocks no reader and no writer. It stands down while a task is
+live, and while any other session holds an old snapshot - which is exactly what a
+backup's pg_dump looks like, and during which VACUUM could reclaim nothing
+anyway. A lock_timeout means it can never queue behind another lock. It runs in
+the WEB process, which a restore stops before psql replaces the database, and as
+a daemon thread a setup-wizard restart kills it mid-VACUUM harmlessly.
+
+It sweeps hourly, not every few minutes: dead rows only appear when a rebuild or
+analysis replaces a blob, and a swept table drops to zero dead rows and leaves
+the set until it dirties again. The session caps are re-applied every pass rather
+than once, because the loop rebuilds its connection after any error and a fresh
+session would otherwise run uncapped.
+
+Main Features:
+* Plain VACUUM only - never FULL, so readers and writers are never blocked
+* Stands down for a live task, and for a backup's long-lived snapshot
+* lock_timeout keeps it from queueing; statement_timeout is generous enough to
+  finish the biggest table on slow storage rather than starving it every pass
+* One table's failure never blocks the rest, and none escapes the cycle
+* The worker cycle never reclaims; the web process schedules it, on its own
+  connection, where a restore has already stopped Flask
+"""
+
+import os
+
+import psycopg2
+
+from taskqueue import maintenance, sql
+
+_REPO_ROOT = os.path.normpath(
+    os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..')
+)
+
+_ROWS = [
+    ('public.ivf_dir', 6, '153 MB'),
+    ('public.artist_metadata_data', 1, '31 MB'),
+]
+
+
+class _Cursor:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, statement, params=None):
+        flat = ' '.join(statement.split())
+        self._conn.statements.append(flat)
+        self._conn.autocommit_at_execute.append(self._conn.autocommit)
+        if flat.startswith('VACUUM'):
+            target = flat.split(' ', 1)[1]
+            if target in self._conn.busy:
+                raise psycopg2.errors.LockNotAvailable('lock timeout')
+            if target in self._conn.failing:
+                raise RuntimeError('permission denied: ' + target)
+
+    def fetchone(self):
+        return ('x',) if self._conn.sentinel else None
+
+    def fetchall(self):
+        return list(self._conn.rows)
+
+    def close(self):
+        pass
+
+
+class _Conn:
+    def __init__(self, rows=()):
+        self.autocommit = False
+        self.rows = list(rows)
+        self.statements = []
+        self.autocommit_at_execute = []
+        self.busy = set()
+        self.failing = set()
+        self.sentinel = False
+
+    def cursor(self):
+        return _Cursor(self)
+
+    def commit(self):
+        pass
+
+    def rollback(self):
+        pass
+
+
+def _quiet(monkeypatch, conn, live=False, snapshot=False):
+    monkeypatch.setattr(sql, 'begin_reclaim_session', lambda cur: None)
+    monkeypatch.setattr(sql, 'any_live_task', lambda cur: live)
+    monkeypatch.setattr(sql, 'snapshot_holder_blocking_reclaim', lambda cur: snapshot)
+    monkeypatch.setattr(
+        sql, 'blob_tables_autovacuum_cannot_reach', lambda cur, min_bytes=None: list(conn.rows)
+    )
+
+
+def _vacuums(conn):
+    return [s for s in conn.statements if s.startswith('VACUUM')]
+
+
+class TestNeverBlocksAnyone:
+    def test_it_only_ever_runs_a_plain_vacuum_never_full(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn)
+        maintenance.reclaim_blob_space(conn)
+        assert _vacuums(conn) == ['VACUUM public.ivf_dir', 'VACUUM public.artist_metadata_data']
+        assert not any('FULL' in s for s in conn.statements)
+
+    def test_a_busy_table_is_skipped_rather_than_queued_behind(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        conn.busy = {'public.ivf_dir'}
+        _quiet(monkeypatch, conn)
+        assert maintenance.reclaim_blob_space(conn) == ['public.artist_metadata_data']
+
+    def test_the_session_caps_how_long_it_waits_for_a_lock(self):
+        import inspect
+
+        src = inspect.getsource(sql.begin_reclaim_session)
+        assert 'lock_timeout' in src
+        assert 'statement_timeout' in src
+
+    def test_the_lock_timeout_is_short_enough_to_never_stall_a_restore(self):
+        assert sql.BLOB_RECLAIM_LOCK_TIMEOUT.endswith('s')
+        assert int(sql.BLOB_RECLAIM_LOCK_TIMEOUT.rstrip('s')) <= 5
+
+    def test_the_statement_timeout_is_generous_enough_to_finish_a_big_table(self):
+        assert sql.BLOB_RECLAIM_STATEMENT_TIMEOUT == '10min'
+
+    def test_the_session_caps_are_reapplied_every_pass_because_reconnects_reset_them(
+        self, monkeypatch
+    ):
+        conn = _Conn(_ROWS)
+        applied = []
+        monkeypatch.setattr(sql, 'begin_reclaim_session', lambda cur: applied.append(cur))
+        monkeypatch.setattr(sql, 'any_live_task', lambda cur: False)
+        monkeypatch.setattr(sql, 'snapshot_holder_blocking_reclaim', lambda cur: False)
+        monkeypatch.setattr(
+            sql, 'blob_tables_autovacuum_cannot_reach', lambda cur, min_bytes=None: []
+        )
+        maintenance.reclaim_blob_space(conn)
+        maintenance.reclaim_blob_space(conn)
+        assert len(applied) == 2
+
+
+class TestStandsDownForOtherWork:
+    def test_a_live_task_defers_the_whole_sweep(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn, live=True)
+        assert maintenance.reclaim_blob_space(conn) == []
+        assert _vacuums(conn) == []
+
+    def test_a_backups_long_snapshot_defers_the_whole_sweep(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn, snapshot=True)
+        assert maintenance.reclaim_blob_space(conn) == []
+        assert _vacuums(conn) == []
+
+    def test_the_snapshot_probe_ignores_this_sessions_own_backend(self):
+        assert 'pid <> pg_backend_pid()' in ' '.join(sql._OLD_SNAPSHOT_HOLDER.split())
+
+    def test_the_snapshot_probe_looks_for_a_held_xmin_not_just_an_idle_session(self):
+        flat = ' '.join(sql._OLD_SNAPSHOT_HOLDER.split())
+        assert 'backend_xmin IS NOT NULL' in flat
+
+
+class TestSweepMechanics:
+    def test_every_vacuum_runs_with_autocommit_on(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn)
+        maintenance.reclaim_blob_space(conn)
+        during = [
+            on
+            for stmt, on in zip(conn.statements, conn.autocommit_at_execute)
+            if stmt.startswith('VACUUM')
+        ]
+        assert during == [True, True]
+
+    def test_autocommit_is_restored_afterwards(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn)
+        maintenance.reclaim_blob_space(conn)
+        assert conn.autocommit is False
+
+    def test_autocommit_is_restored_when_a_vacuum_raises(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        conn.failing = {name for name, _d, _t in _ROWS}
+        _quiet(monkeypatch, conn)
+        assert maintenance.reclaim_blob_space(conn) == []
+        assert conn.autocommit is False
+
+    def test_one_failing_table_never_blocks_the_others(self, monkeypatch):
+        conn = _Conn(_ROWS)
+        conn.failing = {'public.ivf_dir'}
+        _quiet(monkeypatch, conn)
+        assert maintenance.reclaim_blob_space(conn) == ['public.artist_metadata_data']
+
+    def test_nothing_dead_runs_no_vacuum(self, monkeypatch):
+        conn = _Conn([])
+        _quiet(monkeypatch, conn)
+        assert maintenance.reclaim_blob_space(conn) == []
+        assert _vacuums(conn) == []
+
+
+class TestAlwaysLogs:
+    def test_a_pass_with_nothing_to_do_still_logs(self, monkeypatch, caplog):
+        conn = _Conn([])
+        _quiet(monkeypatch, conn)
+        with caplog.at_level('INFO', logger='taskqueue.maintenance'):
+            maintenance.reclaim_blob_space(conn)
+        assert any('found no tables' in record.message for record in caplog.records)
+
+    def test_a_pass_that_cleaned_tables_logs_a_summary(self, monkeypatch, caplog):
+        conn = _Conn(_ROWS)
+        _quiet(monkeypatch, conn)
+        with caplog.at_level('INFO', logger='taskqueue.maintenance'):
+            maintenance.reclaim_blob_space(conn)
+        assert any('vacuumed 2 table(s)' in record.message for record in caplog.records)
+
+
+class TestDetectionQuery:
+    def test_threshold_mirrors_postgres_own_autovacuum_settings(self):
+        query = sql._BLOB_TABLES_AUTOVACUUM_CANNOT_REACH
+        assert 'autovacuum_vacuum_threshold' in query
+        assert 'autovacuum_vacuum_scale_factor' in query
+
+    def test_only_tables_that_already_have_dead_rows_are_swept(self):
+        assert 'n_dead_tup > 0' in ' '.join(
+            sql._BLOB_TABLES_AUTOVACUUM_CANNOT_REACH.split()
+        )
+
+    def test_a_big_table_is_swept_however_many_live_rows_it_carries(self):
+        assert 'n_live_tup <' not in ' '.join(
+            sql._BLOB_TABLES_AUTOVACUUM_CANNOT_REACH.split()
+        )
+
+    def test_target_is_schema_qualified_so_search_path_cannot_redirect_it(self):
+        flat = ' '.join(sql._BLOB_TABLES_AUTOVACUUM_CANNOT_REACH.split())
+        assert "quote_ident(s.schemaname) || '.' || quote_ident(s.relname)" in flat
+
+    def test_trivially_small_tables_stay_with_autovacuum(self):
+        assert sql.BLOB_RECLAIM_MIN_BYTES >= 1024 * 1024
+
+    def test_bytea_tables_are_swept_however_small(self):
+        flat = ' '.join(sql._BLOB_TABLES_AUTOVACUUM_CANNOT_REACH.split())
+        assert "'bytea'::regtype" in flat
+
+
+class TestWhereItRuns:
+    def _app_source(self):
+        with open(os.path.join(_REPO_ROOT, 'app.py'), encoding='utf-8') as fh:
+            return fh.read()
+
+    def _loop(self):
+        return self._app_source().split('def _blob_reclaim_loop')[1].split(
+            'blob_reclaim_thread.start()'
+        )[0]
+
+    def test_the_worker_retention_cycle_never_reclaims(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(maintenance, 'reclaim_blob_space', calls.append)
+        monkeypatch.setattr(sql, 'try_maintenance_lock', lambda cur: True)
+        monkeypatch.setattr(sql, 'release_maintenance_lock', lambda cur: None)
+        monkeypatch.setattr(maintenance, 'reclaim_orphans', lambda conn: None)
+        monkeypatch.setattr(maintenance, 'fail_stale_inline_rows', lambda conn: None)
+        monkeypatch.setattr(maintenance, 'recover_migration_handshakes', lambda: None)
+        monkeypatch.setattr(maintenance, 'clear_terminal_shared_payloads', lambda conn: None)
+        maintenance.run_cycle(_Conn(), with_retention=True)
+        assert calls == []
+
+    def test_the_web_process_starts_it_as_a_daemon_thread(self):
+        src = self._app_source()
+        assert '_blob_reclaim_loop' in src
+        assert 'blob_reclaim_thread = threading.Thread(' in src
+        assert 'daemon=True' in src.split('_blob_reclaim_loop')[2]
+
+    def test_it_uses_its_own_connection_never_the_app_context_one(self):
+        loop = self._loop()
+        assert 'connect_raw' in loop
+        assert 'get_db' not in loop
+
+    def test_it_sweeps_hourly_not_every_few_minutes(self):
+        assert 'queue_sql.BLOB_RECLAIM_INTERVAL_SECONDS' in self._loop()
+        assert sql.BLOB_RECLAIM_INTERVAL_SECONDS >= 3600
+
+    def test_a_reconnect_cannot_leave_a_pass_running_without_its_caps(self):
+        loop = self._loop()
+        assert 'conn = None' in loop
+        assert 'connect_raw' in loop
+
+    def test_a_restore_stops_flask_before_replacing_the_database(self):
+        with open(os.path.join(_REPO_ROOT, 'app_backup.py'), encoding='utf-8') as fh:
+            src = fh.read()
+        assert 'flask_stopped' in src
+        assert 'Never run psql while the application may still be writing' in src


### PR DESCRIPTION
This PR is about ram cleaning improvement for when Flask, Worker or Postgresql container are in idle. The goals is have less memory possible in idle but at the same time don't slow the application.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165222315/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165221486/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165221486/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165221486/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165221486/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32165221482/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-865`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-865-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-865-noavx2`
<!-- pr-test-build:end -->