### PR TITLE
Scale-Tempo-Energy fix + Native build fix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -51,6 +51,7 @@ env
 README.md
 docs/
 query/
+metadata/
 screenshot/
 .pytest_cache/
 htmlcov/

--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,9 @@ student_clap/config.local.yaml
 student_clap/models/FMA_SONGS_LICENSE.md
 student_clap/models/FMA_SONGS_2247_LICENSE.md
 
+# bn research prototype artifacts
+query/
+
 # macOS standalone build artifacts (PyInstaller output)
 /build/
 /dist/
@@ -74,3 +77,4 @@ analysis.md
 .claude/
 lyrics_model_gte_vnni.tar.gz
 .reasonix/
+metadata/

--- a/config.py
+++ b/config.py
@@ -1120,8 +1120,13 @@ ALCHEMY_MAX_ANCHOR_POINTS = int(os.environ.get("ALCHEMY_MAX_ANCHOR_POINTS", "16"
 # Mood-specific models (danceability, mood_aggressive, etc.) have been removed.
 
 # --- Energy Normalization Range ---
-ENERGY_MIN = float(os.getenv("ENERGY_MIN", "0.01"))
-ENERGY_MAX = float(os.getenv("ENERGY_MAX", "0.15"))
+# The stored energy value is a mean per-frame loudness on a dBFS-linear 0..1 scale
+# (a -60 dBFS frame is 0.0, a full-scale frame is 1.0), so these bounds are the
+# music-like band of that scale, not raw RMS amplitude. Measured over quiet
+# ambient through modern loud masters, real material lands in roughly 0.32..0.93;
+# the bounds below cover that band unclipped so consumers get the full 0..1 spread.
+ENERGY_MIN = float(os.getenv("ENERGY_MIN", "0.30"))
+ENERGY_MAX = float(os.getenv("ENERGY_MAX", "0.95"))
 
 # --- Mood/Feature Score Matching ---
 # A 0-1 mood/other-feature score at or above this counts as the tag applying.

--- a/config.py
+++ b/config.py
@@ -256,7 +256,7 @@ SETUP_BOOTSTRAP_EXCLUDED_KEYS = {
 }
 
 # --- General Constants (Read from Environment Variables where applicable) ---
-APP_VERSION = "v3.3.1"
+APP_VERSION = "v3.4.0"
 MAX_DISTANCE = float(os.environ.get("MAX_DISTANCE", "0.5"))
 MAX_SONGS_PER_CLUSTER = int(os.environ.get("MAX_SONGS_PER_CLUSTER", "0"))
 MAX_SONGS_PER_ARTIST = int(os.getenv("MAX_SONGS_PER_ARTIST", "3")) # Max songs per artist in similarity results and clustering

--- a/taskqueue/worker.py
+++ b/taskqueue/worker.py
@@ -12,12 +12,11 @@ Run as python -m taskqueue.worker --queue high or --queue default. The
 claim is a single UPDATE whose subquery takes FOR UPDATE SKIP LOCKED, so N
 workers racing need no coordination.
 
-Where the OS can fork (Linux, macOS, every container - detected by os.fork
-existing) the job runs in a FORKED CHILD that reports its outcome over a pipe
-and exits,
-so all the memory the job allocated - ONNX models, the transformers stack,
-numpy buffers - is returned to the OS the moment the job ends, exactly like
-the old RQ fork-per-job worker. The child inherits the claim by copy but only
+In the container (a non-frozen Linux process) the job runs in a FORKED CHILD
+that reports its outcome over a pipe and exits, so all the memory the job
+allocated - ONNX models, the transformers stack, numpy buffers - is returned
+to the OS the moment the job ends, exactly like the old RQ fork-per-job
+worker. The child inherits the claim by copy but only
 the parent ever touches the claim connection and the advisory lock; the child
 opens its own database connections through the task's app context and leaves
 through os._exit, so the parent's sockets are never written or closed by the
@@ -30,13 +29,15 @@ advisory lock died with the parent and reclaim handed the row to another
 worker. Config is hydrated in the parent before forking so a first-success
 refresh latches in the worker instead of being thrown away with the child.
 
-Windows cannot fork, so there the job runs in the worker process itself (the
-shape the old SimpleWorker had) and any heavy analysis models the job loaded
-are unloaded again when it finishes (_unload_job_models): the sessions are
-dropped and the heap trimmed, keeping an idle worker at the library floor
-instead of the loaded-model footprint. Either way cancelling means ending the
-worker's process tree, which includes the job child, and the worker recycles
-after QUEUE_MAX_JOBS.
+Frozen native builds (Windows, macOS, Linux) run the job in the worker
+process itself (the shape the old SimpleWorker had) instead of forking:
+macOS cannot fork and keep its CoreML/Metal sessions alive, and Windows
+cannot fork at all. Any heavy analysis models the job loaded are unloaded
+again when it finishes (_unload_job_models): the sessions are dropped and
+the heap trimmed, keeping an idle worker at the library floor instead of the
+loaded-model footprint. Either way cancelling means ending the worker's
+process tree, which includes the job child, and the worker recycles after
+QUEUE_MAX_JOBS.
 
 Liveness is the advisory lock held on the task's own connection; if the process
 dies the lock dies with it, so no heartbeat is needed. ensure_hold retakes
@@ -50,8 +51,9 @@ ordering reason.
 
 Main Features:
 * Claim/drain loop that blocks on LISTEN when no work exists
-* Fork-per-job on POSIX gives every byte of job memory back to the OS;
-  Windows runs the job in-process and unloads the models after each job
+* Fork-per-job in the container gives every byte of job memory back to the
+  OS; frozen native builds run the job in-process and unload the models
+  after each job
 * A cancel notification ends the process tree in about 50ms
 * Boot reclaims orphaned tasks bounded by QUEUE_MAX_ATTEMPTS
 * A lost connection (SQLSTATE class 08, 57Pxx, InterfaceError) requeues the row
@@ -166,7 +168,7 @@ class Worker:
         self._abandoned = []
         self._uncharged = {}
         self._claim_txn = threading.Lock()
-        self._fork_jobs = hasattr(os, 'fork')
+        self._fork_jobs = hasattr(os, 'fork') and not getattr(sys, 'frozen', False)
 
     def reconnect(self):
         try:

--- a/tasks/analysis/album.py
+++ b/tasks/analysis/album.py
@@ -89,6 +89,8 @@ from .song import (
     cleanup_musicnn_sessions,
     cleanup_optional_models,
     decode_audio_once,
+    extract_basic_features,
+    resample_audio,
     robust_load_audio_with_fallback,
 )
 
@@ -215,6 +217,41 @@ def _stage_persist_musicnn(item, track_name_full, track_id_str, musicnn_analysis
     )
 
 
+def _base_features_from(analysis):
+    if not analysis:
+        return None
+    values = (
+        analysis.get('tempo'), analysis.get('energy'),
+        analysis.get('key'), analysis.get('scale'),
+    )
+    return None if any(v is None for v in values) else values
+
+
+def _stage_base(path, track_id_str, track_name_full, native_audio=None, native_sr=None,
+                precomputed=None):
+    if precomputed is not None:
+        tempo, energy, musical_key, scale = precomputed
+    else:
+        if native_audio is not None and native_sr is not None:
+            audio, sr = resample_audio(native_audio, native_sr, 16000), 16000
+        else:
+            audio, sr = robust_load_audio_with_fallback(path, target_sr=16000)
+        if audio is None or audio.size == 0:
+            logger.warning(
+                "  - Could not decode audio to recompute base features for '%s'",
+                track_name_full,
+            )
+            return False
+        tempo, energy, musical_key, scale = extract_basic_features(audio, sr)
+    if _ah.refresh_base_features(track_id_str, tempo, energy, musical_key, scale):
+        logger.info(
+            "  - Base features stored for '%s': tempo %.2f, energy %.4f, key %s %s",
+            track_name_full, tempo, energy, musical_key, scale,
+        )
+        return True
+    return False
+
+
 def _stage_clap(path, track_id_str, track_name_full, clap_label_embeddings,
                 native_audio=None, native_sr=None):
     embedding = _ah.run_clap_for_track(
@@ -260,6 +297,7 @@ def _analyze_single_track(
     track_audio = track_sr = None
     native_audio = native_sr = None
     musicnn_analysis = musicnn_embedding = None
+    base_features = None
     clap_embedding = None
     top_moods = None
     produced = False
@@ -270,7 +308,7 @@ def _analyze_single_track(
         if plan.musicnn:
             _stage_collect_chromaprint(item, path, track_name_full)
 
-        if path and (plan.musicnn or plan.clap):
+        if path and plan.needs_audio:
             native_audio, native_sr = decode_audio_once(path)
 
         def ensure_download():
@@ -295,6 +333,7 @@ def _analyze_single_track(
                 pending_track_maps,
                 track_duration=musicnn_analysis.get('duration_seconds'),
             )
+            base_features = _base_features_from(musicnn_analysis)
             if not keep_analysis:
                 musicnn_analysis = musicnn_embedding = None
             if not plan.any_stage:
@@ -311,6 +350,13 @@ def _analyze_single_track(
                 item, track_name_full, track_id_str, musicnn_analysis,
                 top_moods, musicnn_embedding,
             )
+
+        if plan.base:
+            produced = _stage_base(
+                path, track_id_str, track_name_full,
+                native_audio=native_audio, native_sr=native_sr,
+                precomputed=base_features,
+            ) or produced
 
         if plan.clap:
             clap_embedding, clap_saved = _stage_clap(
@@ -455,6 +501,7 @@ def _analyze_album_task_impl(album_id, album_name, top_n_moods, parent_task_id):
                 existing_track_ids_set,
                 missing_clap_ids_set,
                 missing_lyrics_ids_set,
+                missing_base_ids_set,
                 clap_label_embeddings,
                 existing_top_moods_by_id,
             ) = _ah.build_album_plan(album_name, tracks, top_n_moods, LYRICS_ENABLED)
@@ -515,6 +562,7 @@ def _analyze_album_task_impl(album_id, album_name, top_n_moods, parent_task_id):
                     existing_track_ids_set,
                     missing_clap_ids_set,
                     missing_lyrics_ids_set,
+                    missing_base_ids_set,
                     LYRICS_ENABLED,
                 )
 

--- a/tasks/analysis/helper.py
+++ b/tasks/analysis/helper.py
@@ -57,8 +57,9 @@ _SONG_EXPORTS = frozenset((
     'analysis_server_identity', 'catalog_item_id', 'provider_item_id',
     'compute_other_features_str', 'ensure_musicnn_sessions',
     'load_musicnn_sessions', 'persist_clap_embedding', 'persist_musicnn_results',
-    'refresh_other_features', 'run_clap_for_track', 'run_lyrics_for_track',
-    'run_song_analyzed_hook', 'zero_other_features', 'ZERO_OTHER_FEATURES',
+    'refresh_base_features', 'refresh_other_features', 'run_clap_for_track',
+    'run_lyrics_for_track', 'run_song_analyzed_hook', 'zero_other_features',
+    'ZERO_OTHER_FEATURES',
 ))
 
 
@@ -211,8 +212,20 @@ def get_existing_track_ids(track_ids):
     with get_db() as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT s.item_id FROM score s JOIN embedding e ON s.item_id = e.item_id "
-            f"WHERE s.item_id IN %s AND {_WORK_ANALYZED}",
+            f"WHERE s.item_id IN %s AND {_MUSICNN_ANALYZED}",
             (tuple(_str_ids(track_ids)),),
+        )
+        return {row[0] for row in cur.fetchall()}
+
+
+def get_missing_base_ids(track_ids):
+    if not track_ids:
+        return set()
+    ids = _str_ids(track_ids)
+    with get_db() as conn, conn.cursor() as cur:
+        cur.execute(
+            f"SELECT s.item_id FROM score s WHERE s.item_id IN %s AND NOT ({_BASE_ANALYZED})",
+            (tuple(ids),),
         )
         return {row[0] for row in cur.fetchall()}
 
@@ -289,30 +302,38 @@ class TrackPlan(NamedTuple):
     musicnn: bool
     clap: bool
     lyrics: bool
+    base: bool = False
 
     @property
     def any_stage(self):
-        return self.musicnn or self.clap or self.lyrics
+        return self.musicnn or self.clap or self.lyrics or self.base
 
     @property
     def needs_audio(self):
-        return self.musicnn or self.clap
+        return self.musicnn or self.clap or self.base
 
     def describe(self):
         wanted = [
             name
-            for name, on in (('MusiCNN', self.musicnn), ('CLAP', self.clap), ('Lyrics', self.lyrics))
+            for name, on in (
+                ('MusiCNN', self.musicnn),
+                ('CLAP', self.clap),
+                ('Lyrics', self.lyrics),
+                ('Base', self.base),
+            )
             if on
         ]
         return ' + '.join(wanted) if wanted else 'nothing'
 
 
 def plan_track_stages(track_id, existing_ids, missing_clap_ids, missing_lyrics_ids,
-                      lyrics_enabled):
+                      missing_base_ids, lyrics_enabled):
+    musicnn = track_id not in existing_ids
     return TrackPlan(
-        track_id not in existing_ids,
+        musicnn,
         track_id in missing_clap_ids,
         bool(lyrics_enabled) and track_id in missing_lyrics_ids,
+        bool(not musicnn and track_id in missing_base_ids),
     )
 
 
@@ -321,6 +342,7 @@ def replan_for_catalogue_row(plan, item_id):
         False,
         plan.clap and bool(get_missing_ids_in_table('clap_embedding', [item_id])),
         plan.lyrics and bool(get_missing_ids_in_table('lyrics_embedding', [item_id])),
+        bool(get_missing_base_ids([item_id])),
     )
 
 
@@ -401,6 +423,7 @@ def build_album_plan(album_name, tracks, top_n_moods, lyrics_enabled):
 
     track_ids = [catalog_item_id(t) for t in tracks]
     existing_ids = get_existing_track_ids(track_ids)
+    missing_base_ids = get_missing_base_ids(track_ids)
     missing_clap_ids = (
         get_missing_ids_in_table('clap_embedding', track_ids)
         if clap_analyzer.is_clap_available()
@@ -410,8 +433,9 @@ def build_album_plan(album_name, tracks, top_n_moods, lyrics_enabled):
         get_missing_ids_in_table('lyrics_embedding', track_ids) if lyrics_enabled else set()
     )
     logger.info(
-        "Feature plan for album '%s': MusiCNN=%d, DCLAP=%d, Lyrics=%d of %d tracks.",
+        "Feature plan for album '%s': Base=%d, MusiCNN=%d, DCLAP=%d, Lyrics=%d of %d tracks.",
         album_name,
+        len(missing_base_ids),
         len(tracks) - len(existing_ids),
         len(missing_clap_ids),
         len(missing_lyrics_ids),
@@ -423,7 +447,10 @@ def build_album_plan(album_name, tracks, top_n_moods, lyrics_enabled):
     prior_moods = _prior_moods_for_lyrics(
         track_ids, existing_ids, missing_lyrics_ids, top_n_moods, lyrics_enabled, album_name
     )
-    return existing_ids, missing_clap_ids, missing_lyrics_ids, clap_label_embeddings, prior_moods
+    return (
+        existing_ids, missing_clap_ids, missing_lyrics_ids, missing_base_ids,
+        clap_label_embeddings, prior_moods,
+    )
 
 
 def load_album_analysis_exclusions(tracks):
@@ -484,7 +511,8 @@ def album_feature_needs(masks, done_bits, clap_available, lyrics_enabled):
     needs_musicnn = any(not m & WORK_MUSICNN for m in masks)
     needs_clap = clap_available and any(not m & WORK_CLAP for m in masks)
     needs_lyrics = lyrics_enabled and any(not m & WORK_LYRICS for m in masks)
-    return album_done, needs_musicnn, needs_clap, needs_lyrics
+    needs_base = any(not m & WORK_BASE for m in masks)
+    return album_done, needs_musicnn, needs_clap, needs_lyrics, needs_base
 
 
 WORK_MUSICNN = 1
@@ -496,17 +524,26 @@ WORK_CLAP = 2
 WORK_LYRICS = 4
 
 
+WORK_BASE = 8
+
+
 def work_done_bits(clap_available, lyrics_enabled):
     return (
         WORK_MUSICNN
+        | WORK_BASE
         | (WORK_CLAP if clap_available else 0)
         | (WORK_LYRICS if lyrics_enabled else 0)
     )
 
 
-_WORK_ANALYZED = (
-    "s.other_features IS NOT NULL AND s.energy IS NOT NULL "
-    "AND s.mood_vector IS NOT NULL AND s.tempo IS NOT NULL"
+_BASE_ANALYZED = (
+    "s.tempo IS NOT NULL AND s.energy IS NOT NULL "
+    "AND s.key IS NOT NULL AND s.scale IS NOT NULL"
+)
+
+
+_MUSICNN_ANALYZED = (
+    "s.mood_vector IS NOT NULL AND s.other_features IS NOT NULL"
 )
 
 
@@ -524,13 +561,15 @@ def _work_feature_parts(clap_available, lyrics_enabled, key_column):
     return selects, " ".join(joins)
 
 
-def _apply_work_bits(work_map, provider_id, has_musicnn, has_clap, has_lyrics):
+def _apply_work_bits(work_map, provider_id, has_musicnn, has_clap, has_lyrics, has_base):
     key = str(provider_id)
     mask = WORK_MUSICNN if has_musicnn else 0
     if has_clap:
         mask |= WORK_CLAP
     if has_lyrics:
         mask |= WORK_LYRICS
+    if has_base:
+        mask |= WORK_BASE
     work_map[key] = work_map.get(key, 0) | mask
 
 
@@ -541,8 +580,10 @@ def _work_map_scan(cur, sql, params, work_map, chunk_size):
         rows = cur.fetchall()
         if not rows:
             return
-        for provider_id, has_musicnn, has_clap, has_lyrics in rows:
-            _apply_work_bits(work_map, provider_id, has_musicnn, has_clap, has_lyrics)
+        for provider_id, has_musicnn, has_clap, has_lyrics, has_base in rows:
+            _apply_work_bits(
+                work_map, provider_id, has_musicnn, has_clap, has_lyrics, has_base
+            )
         last = str(rows[-1][0])
 
 
@@ -550,7 +591,8 @@ def _work_sql(clap_available, lyrics_enabled):
     mapped_selects, mapped_joins = _work_feature_parts(clap_available, lyrics_enabled, 'm.item_id')
     mapped_sql = (
         "SELECT m.provider_track_id, "
-        f"(e.item_id IS NOT NULL AND {_WORK_ANALYZED}), {', '.join(mapped_selects)} "
+        f"(e.item_id IS NOT NULL AND {_MUSICNN_ANALYZED}), "
+        f"{', '.join(mapped_selects)}, ({_BASE_ANALYZED}) "
         "FROM track_server_map m "
         "JOIN score s ON s.item_id = m.item_id "
         "LEFT JOIN embedding e ON e.item_id = m.item_id "
@@ -559,11 +601,11 @@ def _work_sql(clap_available, lyrics_enabled):
     )
     legacy_selects, legacy_joins = _work_feature_parts(clap_available, lyrics_enabled, 's.item_id')
     legacy_sql = (
-        f"SELECT s.item_id, TRUE, {', '.join(legacy_selects)} "
+        f"SELECT s.item_id, TRUE, {', '.join(legacy_selects)}, ({_BASE_ANALYZED}) "
         "FROM score s "
         "JOIN embedding e ON e.item_id = s.item_id "
         f"{legacy_joins} "
-        f"WHERE s.item_id NOT LIKE 'fp\\_%%' AND {_WORK_ANALYZED}"
+        f"WHERE s.item_id NOT LIKE 'fp\\_%%' AND {_MUSICNN_ANALYZED}"
     )
     return mapped_sql, legacy_sql
 
@@ -811,7 +853,7 @@ def claim_new_canonical_id(resolver, minted_id, embedding, duration=None, finger
 
 
 def build_feature_status_parts(clap_available, lyrics_enabled, include_check_marks=False):
-    parts = ["MusiCNN"]
+    parts = ["Base", "MusiCNN"]
     if clap_available:
         parts.append("CLAP")
     if lyrics_enabled:

--- a/tasks/analysis/main.py
+++ b/tasks/analysis/main.py
@@ -452,6 +452,7 @@ def _run_analysis_server_task_impl(
             albums_needing_musicnn = 0
             albums_needing_clap = 0
             albums_needing_lyrics = 0
+            albums_needing_base = 0
             songs_seen = 0
             songs_done = 0
             last_monitor_db_check = float('-inf')
@@ -595,6 +596,7 @@ def _run_analysis_server_task_impl(
                     needs_musicnn_analysis,
                     needs_clap_analysis,
                     needs_lyrics_analysis,
+                    needs_base_analysis,
                 ) = _ah.album_feature_needs(masks, done_bits, clap_available, LYRICS_ENABLED)
                 songs_seen += len(tracks)
                 songs_done += album_done
@@ -625,6 +627,7 @@ def _run_analysis_server_task_impl(
                 albums_needing_musicnn += int(needs_musicnn_analysis)
                 albums_needing_clap += int(needs_clap_analysis)
                 albums_needing_lyrics += int(needs_lyrics_analysis)
+                albums_needing_base += int(needs_base_analysis)
                 report_progress()
 
             if (
@@ -676,10 +679,11 @@ def _run_analysis_server_task_impl(
             logger.info(
                 "Phase complete. Albums: %d launched, %d skipped of %d, %d failed. "
                 "Songs: %d sent for analysis, %d already analyzed of %d. "
-                "Feature albums: MusiCNN %d, DCLAP %d, Lyrics %d.",
+                "Feature albums: Base %d, MusiCNN %d, DCLAP %d, Lyrics %d.",
                 albums_launched, albums_skipped, total_albums_to_check, failed_count,
                 songs_seen - songs_done, songs_done, songs_seen,
-                albums_needing_musicnn, albums_needing_clap, albums_needing_lyrics,
+                albums_needing_base, albums_needing_musicnn,
+                albums_needing_clap, albums_needing_lyrics,
             )
             final_message, phase_status, final_kwargs = _phase_outcome(
                 albums_offset + albums_skipped + albums_completed + albums_work_check_failed,

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -608,6 +608,27 @@ def refresh_other_features(item_id, other_features_str):
         return False
 
 
+def refresh_base_features(item_id, tempo, energy, musical_key, scale):
+    try:
+        with get_db() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE score SET tempo = %s, energy = %s, key = %s, scale = %s "
+                "WHERE item_id = %s",
+                (tempo, energy, musical_key, scale, str(item_id)),
+            )
+            updated = cur.rowcount
+            conn.commit()
+        return bool(updated)
+    except OperationalError:
+        raise
+    except Exception as e:
+        error_manager.record(
+            ERR_DB_QUERY, f"Could not refresh base features for {item_id}: {e}",
+            exc=e, logger=logger, level=logging.WARNING,
+        )
+        return False
+
+
 def persist_clap_embedding(item_id, embedding):
     if embedding is None:
         return False

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -199,7 +199,7 @@ def _estimate_tempo(audio, sr):
     return tempo
 
 
-def _estimate_energy(audio, sr):
+def _estimate_energy(audio):
     if audio is None or audio.size == 0:
         return 0.0
     rms = librosa.feature.rms(y=audio)
@@ -232,7 +232,7 @@ def _estimate_key_scale(audio, sr):
 
 def extract_basic_features(audio, sr):
     tempo = _estimate_tempo(audio, sr)
-    energy = _estimate_energy(audio, sr)
+    energy = _estimate_energy(audio)
     musical_key, scale = _estimate_key_scale(audio, sr)
     return tempo, energy, musical_key, scale
 

--- a/tasks/analysis/song.py
+++ b/tasks/analysis/song.py
@@ -44,6 +44,8 @@ from config import (
     MUSICNN_BATCH_SIZE,
     OTHER_FEATURE_LABELS,
     PER_SONG_MODEL_RELOAD,
+    TEMPO_MAX_BPM,
+    TEMPO_MIN_BPM,
 )
 from database import (
     get_db,
@@ -177,24 +179,62 @@ def cleanup_optional_models(context=""):
 
 _KEYS = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B']
 
+_KS_MAJOR = np.array([6.35, 2.23, 3.48, 2.33, 4.38, 4.09, 2.52, 5.19, 2.39, 3.66, 2.29, 2.88])
+_KS_MINOR = np.array([6.33, 2.68, 3.52, 5.38, 2.60, 3.53, 2.54, 4.75, 3.98, 2.69, 3.34, 3.17])
 
-_MAJOR = np.array([1, 0, 1, 0, 1, 1, 0, 1, 0, 1, 0, 1])
+
+def _estimate_tempo(audio, sr):
+    if audio is None or audio.size == 0:
+        return 0.0
+    tempo, _ = librosa.beat.beat_track(y=audio, sr=sr)
+    tempo = float(np.ravel(tempo)[0])
+    if tempo <= 0:
+        return 0.0
+    if TEMPO_MIN_BPM <= 0 or TEMPO_MAX_BPM < TEMPO_MIN_BPM:
+        return tempo
+    while tempo < TEMPO_MIN_BPM:
+        tempo *= 2.0
+    while tempo > TEMPO_MAX_BPM:
+        tempo /= 2.0
+    return tempo
 
 
-_MINOR = np.array([1, 0, 1, 1, 0, 1, 0, 1, 1, 0, 1, 0])
+def _estimate_energy(audio, sr):
+    if audio is None or audio.size == 0:
+        return 0.0
+    rms = librosa.feature.rms(y=audio)
+    if rms is None or rms.size == 0:
+        return 0.0
+    rms_db = librosa.amplitude_to_db(rms, ref=1.0, top_db=None)
+    energy = np.clip((rms_db + 60.0) / 60.0, 0.0, 1.0)
+    return float(np.mean(energy))
+
+
+def _estimate_key_scale(audio, sr):
+    if audio is None or audio.size == 0:
+        return 'C', 'major'
+    chroma = librosa.feature.chroma_cqt(y=audio, sr=sr)
+    if chroma is None or chroma.size == 0:
+        return 'C', 'major'
+    chroma_mean = np.mean(chroma, axis=1)
+    if chroma_mean.sum() <= 0:
+        return 'C', 'major'
+    c = chroma_mean / (np.linalg.norm(chroma_mean) + 1e-9)
+    maj = np.array([np.dot(c, np.roll(_KS_MAJOR, i)) for i in range(12)])
+    mnr = np.array([np.dot(c, np.roll(_KS_MINOR, i)) for i in range(12)])
+    maj = (maj - maj.mean()) / (maj.std() + 1e-9)
+    mnr = (mnr - mnr.mean()) / (mnr.std() + 1e-9)
+    mi, ni = int(np.argmax(maj)), int(np.argmax(mnr))
+    if maj[mi] > mnr[ni]:
+        return _KEYS[mi], 'major'
+    return _KEYS[ni], 'minor'
 
 
 def extract_basic_features(audio, sr):
-    tempo, _ = librosa.beat.beat_track(y=audio, sr=sr)
-    tempo = float(np.ravel(tempo)[0])
-    energy = float(np.mean(librosa.feature.rms(y=audio)))
-    chroma_mean = np.mean(librosa.feature.chroma_stft(y=audio, sr=sr), axis=1)
-    maj = np.array([np.corrcoef(chroma_mean, np.roll(_MAJOR, i))[0, 1] for i in range(12)])
-    mnr = np.array([np.corrcoef(chroma_mean, np.roll(_MINOR, i))[0, 1] for i in range(12)])
-    mi, ni = int(np.argmax(maj)), int(np.argmax(mnr))
-    if maj[mi] > mnr[ni]:
-        return float(tempo), energy, _KEYS[mi], 'major'
-    return float(tempo), energy, _KEYS[ni], 'minor'
+    tempo = _estimate_tempo(audio, sr)
+    energy = _estimate_energy(audio, sr)
+    musical_key, scale = _estimate_key_scale(audio, sr)
+    return tempo, energy, musical_key, scale
 
 
 def prepare_spectrogram_patches(audio, sr):

--- a/test/integration/test_analysis_integration.py
+++ b/test/integration/test_analysis_integration.py
@@ -167,7 +167,7 @@ def test_real_analysis_runs_and_returns_expected_shape():
             'name': 'Art Flower - Art Flower - Creamy Snowflakes.mp3',
             'expected': {
                 "tempo": 75.0,
-                "key": "G",
+                "key": "D",
                 "scale": "minor",
                 "moods": {
                     "rock": 0.5461238026618958,
@@ -221,7 +221,7 @@ def test_real_analysis_runs_and_returns_expected_shape():
                     "House": 0.5007247924804688,
                     "happy": 0.5004531145095825,
                 },
-                "energy": 0.11941074579954147,
+                "energy": 0.6611433029174805,
                 "danceable": 0.09910931438207626,
                 "aggressive": 0.021448878571391106,
                 "happy": 0.06873109191656113,
@@ -238,8 +238,8 @@ def test_real_analysis_runs_and_returns_expected_shape():
             'name': 'Aaron Dunn - Minuet - Notebook for Anna Magdalena.mp3',
             'expected': {
                 "tempo": 125.0,
-                "key": "E",
-                "scale": "minor",
+                "key": "G",
+                "scale": "major",
                 "moods": {
                     "rock": 0.5274592638015747,
                     "pop": 0.5133988261222839,
@@ -292,7 +292,7 @@ def test_real_analysis_runs_and_returns_expected_shape():
                     "House": 0.5008860230445862,
                     "happy": 0.5007311105728149,
                 },
-                "energy": 0.006939841900020838,
+                "energy": 0.24952411651611328,
                 "danceable": 0.017882201820611954,
                 "aggressive": 0.000734207103960216,
                 "happy": 0.006147411186248064,
@@ -309,8 +309,8 @@ def test_real_analysis_runs_and_returns_expected_shape():
             'name': "Michael Hawley - Sonata 'Waldstein', Op. 53 - II. Introduzione-Adagio molto.mp3",
             'expected': {
                 "tempo": 104.16666666666667,
-                "key": "A#",
-                "scale": "minor",
+                "key": "F#",
+                "scale": "major",
                 "moods": {
                     "rock": 0.546576976776123,
                     "pop": 0.5153129696846008,
@@ -363,7 +363,7 @@ def test_real_analysis_runs_and_returns_expected_shape():
                     "House": 0.5015008449554443,
                     "happy": 0.5005825161933899,
                 },
-                "energy": 0.01083404291421175,
+                "energy": 0.34370046854019165,
                 "danceable": 0.07516419887542725,
                 "aggressive": 0.07692281156778336,
                 "happy": 0.015692999586462975,

--- a/test/unit/test_analysis.py
+++ b/test/unit/test_analysis.py
@@ -35,7 +35,12 @@ from tasks.analysis import (
     analyze_track,
 )
 from tasks.onnx_utils import run_inference, _find_onnx_name
-from tasks.analysis.song import _decode_audio_with_pyav
+from tasks.analysis.song import (
+    _decode_audio_with_pyav,
+    _estimate_energy,
+    _estimate_key_scale,
+    _estimate_tempo,
+)
 
 
 def test_union_analysis_runs_each_server_once_with_no_sweeps(monkeypatch):
@@ -1523,20 +1528,20 @@ class TestPyAVDecodeDownmix:
 
 class TestAnalyzeTrack:
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_successful_track_analysis(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100, 200]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         mock_session = Mock()
@@ -1610,19 +1615,19 @@ class TestAnalyzeTrack:
         assert embeddings is None
 
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_returns_none_on_short_audio(
-        self, mock_audio_load, mock_beat, mock_rms, mock_chroma, mock_mel
+        self, mock_audio_load, mock_tempo, mock_energy, mock_key_scale, mock_mel
     ):
         mock_audio = np.random.rand(100)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 10)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 10)
 
         mood_labels = ['happy']
@@ -1634,20 +1639,20 @@ class TestAnalyzeTrack:
         assert embeddings is None
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_spectrogram_dtype_conversion(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000).astype(np.float64)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000).astype(np.float64)
 
         captured_input = None
@@ -1689,21 +1694,21 @@ class TestAnalyzeTrack:
         assert captured_input.dtype == np.dtype('float32')
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_key_detection_logic(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
 
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         mock_session = Mock()
@@ -1737,20 +1742,20 @@ class TestAnalyzeTrack:
         assert result['scale'] in ['major', 'minor']
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_model_inference_failure_handling(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         mock_onnx_session.side_effect = Exception("Model loading failed")
@@ -1764,21 +1769,21 @@ class TestAnalyzeTrack:
         assert embeddings is None
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_tempo_extraction(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
         expected_tempo = 128.5
-        mock_beat.return_value = (expected_tempo, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = expected_tempo
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         mock_session = Mock()
@@ -1810,23 +1815,22 @@ class TestAnalyzeTrack:
         assert isinstance(result['tempo'], float)
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     def test_energy_calculation(
-        self, mock_audio_load, mock_mel, mock_beat, mock_rms, mock_chroma, mock_onnx_session
+        self, mock_audio_load, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_onnx_session
     ):
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
+        mock_tempo.return_value = 120.0
 
-        rms_values = np.array([[0.1, 0.2, 0.3, 0.4]])
-        expected_energy = np.mean(rms_values)
-        mock_rms.return_value = rms_values
-        mock_chroma.return_value = np.random.rand(12, 100)
+        expected_energy = 0.75
+        mock_energy.return_value = expected_energy
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         mock_session = Mock()
@@ -1860,9 +1864,9 @@ class TestAnalyzeTrack:
 
 class TestOOMFallback:
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     @patch('tasks.analysis.song.ort.get_available_providers')
@@ -1871,9 +1875,9 @@ class TestOOMFallback:
         mock_providers,
         mock_audio_load,
         mock_mel,
-        mock_beat,
-        mock_rms,
-        mock_chroma,
+        mock_tempo,
+        mock_energy,
+        mock_key_scale,
         mock_onnx_session,
     ):
         mock_providers.return_value = ['CUDAExecutionProvider', 'CPUExecutionProvider']
@@ -1881,9 +1885,9 @@ class TestOOMFallback:
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         gpu_session_call_count = [0]
@@ -1949,9 +1953,9 @@ class TestOOMFallback:
         assert cpu_session_call_count[0] > 0
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     @patch('tasks.analysis.song.ort.get_available_providers')
@@ -1960,9 +1964,9 @@ class TestOOMFallback:
         mock_providers,
         mock_audio_load,
         mock_mel,
-        mock_beat,
-        mock_rms,
-        mock_chroma,
+        mock_tempo,
+        mock_energy,
+        mock_key_scale,
         mock_onnx_session,
     ):
         mock_providers.return_value = ['CUDAExecutionProvider', 'CPUExecutionProvider']
@@ -1970,9 +1974,9 @@ class TestOOMFallback:
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         gpu_session_call_count = [0]
@@ -2038,9 +2042,9 @@ class TestOOMFallback:
         assert cpu_session_call_count[0] > 0
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     @patch('tasks.analysis.song.ort.get_available_providers')
@@ -2049,9 +2053,9 @@ class TestOOMFallback:
         mock_providers,
         mock_audio_load,
         mock_mel,
-        mock_beat,
-        mock_rms,
-        mock_chroma,
+        mock_tempo,
+        mock_energy,
+        mock_key_scale,
         mock_onnx_session,
     ):
         mock_providers.return_value = ['CUDAExecutionProvider', 'CPUExecutionProvider']
@@ -2059,9 +2063,9 @@ class TestOOMFallback:
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         def gpu_run(output_names, feed_dict):
@@ -2099,9 +2103,9 @@ class TestOOMFallback:
         assert embeddings is None
 
     @patch('tasks.analysis.song.ort.InferenceSession')
-    @patch('tasks.analysis.song.librosa.feature.chroma_stft')
-    @patch('tasks.analysis.song.librosa.feature.rms')
-    @patch('tasks.analysis.song.librosa.beat.beat_track')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
     @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
     @patch('tasks.analysis.song.ort.get_available_providers')
@@ -2110,9 +2114,9 @@ class TestOOMFallback:
         mock_providers,
         mock_audio_load,
         mock_mel,
-        mock_beat,
-        mock_rms,
-        mock_chroma,
+        mock_tempo,
+        mock_energy,
+        mock_key_scale,
         mock_onnx_session,
     ):
         mock_providers.return_value = ['CUDAExecutionProvider', 'CPUExecutionProvider']
@@ -2120,9 +2124,9 @@ class TestOOMFallback:
         mock_audio = np.random.rand(16000)
         mock_audio_load.return_value = (mock_audio, 16000)
 
-        mock_beat.return_value = (120.0, np.array([0, 100]))
-        mock_rms.return_value = np.array([[0.5]])
-        mock_chroma.return_value = np.random.rand(12, 100)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
         mock_mel.return_value = np.random.rand(96, 1000)
 
         cpu_fallback_used = [False]
@@ -2517,3 +2521,142 @@ class TestARetryKeepsTheSongsItAlreadyAnalysed:
         assert analysis_main._carried_over_tracks('parent-1') == 0, (
             'an index rebuild is a child of the same parent but is not an album'
         )
+
+
+CHROMA_C_MAJOR = [1.0, 0.05, 0.5, 0.05, 0.8, 0.5, 0.05, 0.9, 0.05, 0.5, 0.05, 0.4]
+CHROMA_A_MINOR = [0.8, 0.05, 0.4, 0.05, 0.9, 0.4, 0.05, 0.5, 0.05, 1.0, 0.05, 0.5]
+
+
+def _chroma_frames(weights):
+    return np.tile(np.array(weights, dtype=float).reshape(12, 1), (1, 50))
+
+
+def _patched_chroma(weights):
+    return patch(
+        'tasks.analysis.song.librosa.feature.chroma_cqt',
+        return_value=_chroma_frames(weights),
+    )
+
+
+class TestEstimateKeyScale:
+    def test_tonic_weighted_white_key_chroma_returns_c_major(self):
+        with _patched_chroma(CHROMA_C_MAJOR):
+            assert _estimate_key_scale(np.ones(1000, dtype=np.float32), 16000) == ('C', 'major')
+
+    def test_tonic_weighted_white_key_chroma_returns_a_minor(self):
+        with _patched_chroma(CHROMA_A_MINOR):
+            assert _estimate_key_scale(np.ones(1000, dtype=np.float32), 16000) == ('A', 'minor')
+
+    def test_relative_major_and_minor_share_pitch_classes_but_are_distinguished(self):
+        major_classes = sorted(np.nonzero(np.array(CHROMA_C_MAJOR) > 0.1)[0].tolist())
+        minor_classes = sorted(np.nonzero(np.array(CHROMA_A_MINOR) > 0.1)[0].tolist())
+        assert major_classes == minor_classes
+        audio = np.ones(1000, dtype=np.float32)
+        with _patched_chroma(CHROMA_C_MAJOR):
+            major = _estimate_key_scale(audio, 16000)
+        with _patched_chroma(CHROMA_A_MINOR):
+            minor = _estimate_key_scale(audio, 16000)
+        assert major == ('C', 'major')
+        assert minor == ('A', 'minor')
+
+    def test_major_scale_is_reachable_at_all(self):
+        with _patched_chroma(CHROMA_C_MAJOR):
+            _, scale = _estimate_key_scale(np.ones(1000, dtype=np.float32), 16000)
+        assert scale == 'major'
+
+    @pytest.mark.parametrize('shift,expected', [(0, 'C'), (3, 'D#'), (5, 'F'), (7, 'G')])
+    def test_transposing_the_chroma_transposes_the_detected_key(self, shift, expected):
+        with _patched_chroma(np.roll(CHROMA_C_MAJOR, shift)):
+            key, scale = _estimate_key_scale(np.ones(1000, dtype=np.float32), 16000)
+        assert (key, scale) == (expected, 'major')
+
+    def test_all_zero_chroma_falls_back_to_c_major(self):
+        with patch(
+            'tasks.analysis.song.librosa.feature.chroma_cqt',
+            return_value=np.zeros((12, 50)),
+        ):
+            assert _estimate_key_scale(np.ones(1000, dtype=np.float32), 16000) == ('C', 'major')
+
+    def test_empty_audio_falls_back_to_c_major(self):
+        assert _estimate_key_scale(np.array([], dtype=np.float32), 16000) == ('C', 'major')
+
+
+class TestEstimateEnergy:
+    def test_digital_silence_maps_to_zero(self):
+        assert _estimate_energy(np.zeros(32000, dtype=np.float32), 16000) == 0.0
+
+    def test_near_full_scale_signal_maps_close_to_one(self):
+        rng = np.random.default_rng(0)
+        signal = (rng.standard_normal(32000) * 0.9).astype(np.float32)
+        assert _estimate_energy(signal, 16000) > 0.95
+
+    def test_energy_increases_monotonically_with_level(self):
+        rng = np.random.default_rng(0)
+        values = [
+            _estimate_energy(
+                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32), 16000
+            )
+            for db in (-40, -30, -20, -10)
+        ]
+        assert values == sorted(values)
+
+    def test_silent_frames_are_not_lifted_by_a_loud_peak(self):
+        rng = np.random.default_rng(0)
+        loud_then_silent = np.concatenate([
+            (rng.standard_normal(16000) * 10.0).astype(np.float32),
+            np.zeros(16000, dtype=np.float32),
+        ])
+        assert _estimate_energy(loud_then_silent, 16000) < 0.6
+
+    def test_typical_music_levels_land_inside_the_configured_range(self):
+        rng = np.random.default_rng(0)
+        for db in (-30, -20, -12, -8):
+            value = _estimate_energy(
+                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32), 16000
+            )
+            assert config.ENERGY_MIN <= value <= config.ENERGY_MAX
+
+    def test_empty_audio_maps_to_zero(self):
+        assert _estimate_energy(np.array([], dtype=np.float32), 16000) == 0.0
+
+
+def _patched_raw_tempo(raw):
+    return patch(
+        'tasks.analysis.song.librosa.beat.beat_track',
+        return_value=(np.array([raw]), None),
+    )
+
+
+class TestEstimateTempo:
+    @pytest.mark.parametrize('raw', [60.0, 110.0, 174.0, 180.0])
+    def test_in_range_tempo_is_returned_unchanged(self, raw):
+        with _patched_raw_tempo(raw):
+            assert _estimate_tempo(np.ones(1000, dtype=np.float32), 16000) == raw
+
+    @pytest.mark.parametrize('raw', [40.0, 200.0])
+    def test_tempo_exactly_on_a_configured_bound_is_returned_unchanged(self, raw):
+        with _patched_raw_tempo(raw):
+            assert _estimate_tempo(np.ones(1000, dtype=np.float32), 16000) == raw
+
+    @pytest.mark.parametrize('raw,expected', [(35.0, 70.0), (20.0, 40.0)])
+    def test_tempo_below_the_configured_minimum_is_doubled_into_range(self, raw, expected):
+        with _patched_raw_tempo(raw):
+            assert _estimate_tempo(np.ones(1000, dtype=np.float32), 16000) == expected
+
+    @pytest.mark.parametrize('raw,expected', [(260.0, 130.0), (410.0, 102.5)])
+    def test_tempo_above_the_configured_maximum_is_halved_into_range(self, raw, expected):
+        with _patched_raw_tempo(raw):
+            assert _estimate_tempo(np.ones(1000, dtype=np.float32), 16000) == expected
+
+    @pytest.mark.parametrize('raw', [12.0, 33.0, 95.0, 210.0, 333.0, 640.0])
+    def test_folding_never_leaves_the_configured_range(self, raw):
+        with _patched_raw_tempo(raw):
+            value = _estimate_tempo(np.ones(1000, dtype=np.float32), 16000)
+        assert config.TEMPO_MIN_BPM <= value <= config.TEMPO_MAX_BPM
+
+    def test_non_positive_tempo_maps_to_zero(self):
+        with _patched_raw_tempo(0.0):
+            assert _estimate_tempo(np.ones(1000, dtype=np.float32), 16000) == 0.0
+
+    def test_empty_audio_maps_to_zero(self):
+        assert _estimate_tempo(np.array([], dtype=np.float32), 16000) == 0.0

--- a/test/unit/test_analysis.py
+++ b/test/unit/test_analysis.py
@@ -2583,18 +2583,18 @@ class TestEstimateKeyScale:
 
 class TestEstimateEnergy:
     def test_digital_silence_maps_to_zero(self):
-        assert _estimate_energy(np.zeros(32000, dtype=np.float32), 16000) == 0.0
+        assert _estimate_energy(np.zeros(32000, dtype=np.float32)) == 0.0
 
     def test_near_full_scale_signal_maps_close_to_one(self):
         rng = np.random.default_rng(0)
         signal = (rng.standard_normal(32000) * 0.9).astype(np.float32)
-        assert _estimate_energy(signal, 16000) > 0.95
+        assert _estimate_energy(signal) > 0.95
 
     def test_energy_increases_monotonically_with_level(self):
         rng = np.random.default_rng(0)
         values = [
             _estimate_energy(
-                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32), 16000
+                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32)
             )
             for db in (-40, -30, -20, -10)
         ]
@@ -2606,18 +2606,18 @@ class TestEstimateEnergy:
             (rng.standard_normal(16000) * 10.0).astype(np.float32),
             np.zeros(16000, dtype=np.float32),
         ])
-        assert _estimate_energy(loud_then_silent, 16000) < 0.6
+        assert _estimate_energy(loud_then_silent) < 0.6
 
     def test_typical_music_levels_land_inside_the_configured_range(self):
         rng = np.random.default_rng(0)
         for db in (-30, -20, -12, -8):
             value = _estimate_energy(
-                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32), 16000
+                (rng.standard_normal(32000) * 10 ** (db / 20.0)).astype(np.float32)
             )
             assert config.ENERGY_MIN <= value <= config.ENERGY_MAX
 
     def test_empty_audio_maps_to_zero(self):
-        assert _estimate_energy(np.array([], dtype=np.float32), 16000) == 0.0
+        assert _estimate_energy(np.array([], dtype=np.float32)) == 0.0
 
 
 def _patched_raw_tempo(raw):

--- a/test/unit/test_analysis.py
+++ b/test/unit/test_analysis.py
@@ -376,6 +376,7 @@ def _run_album_impl(monkeypatch, tmp_path, item, known_index, persisted_ids, map
             else set()
         ),
     )
+    monkeypatch.setattr(helper, 'get_missing_base_ids', lambda ids: set())
     monkeypatch.setattr(helper, 'load_fingerprint_index', lambda: known_index)
     monkeypatch.setattr(
         helper, 'upsert_artist_mappings_for_tracks', lambda tracks, album_name=None: None
@@ -813,7 +814,7 @@ def _run_parent_phase(monkeypatch, albums, tracks_by_album, work_map,
         raise AssertionError('the album loop must not query the DB per album')
 
     for name in ('get_existing_track_ids', 'get_missing_ids_in_table',
-                 'attach_catalog_item_ids'):
+                 'get_missing_base_ids', 'attach_catalog_item_ids'):
         monkeypatch.setattr(helper, name, forbidden)
 
     enqueued = []
@@ -937,7 +938,8 @@ def test_settled_library_enqueues_nothing_and_never_queries_per_album(monkeypatc
         for i in range(3)
     }
     work_map = {
-        f'p{i}-{t}': helper.WORK_MUSICNN for i in range(3) for t in range(2)
+        f'p{i}-{t}': helper.WORK_MUSICNN | helper.WORK_BASE
+        for i in range(3) for t in range(2)
     }
 
     result, enqueued = _run_parent_phase(monkeypatch, albums, tracks_by_album, work_map)
@@ -956,9 +958,9 @@ def test_album_with_one_unanalyzed_track_is_still_enqueued(monkeypatch):
         'al1': [{'Id': 'done-3', 'Name': 't'}, {'Id': 'missing', 'Name': 't'}],
     }
     work_map = {
-        'done-1': helper.WORK_MUSICNN,
-        'done-2': helper.WORK_MUSICNN,
-        'done-3': helper.WORK_MUSICNN,
+        'done-1': helper.WORK_MUSICNN | helper.WORK_BASE,
+        'done-2': helper.WORK_MUSICNN | helper.WORK_BASE,
+        'done-3': helper.WORK_MUSICNN | helper.WORK_BASE,
     }
 
     result, enqueued = _run_parent_phase(monkeypatch, albums, tracks_by_album, work_map)
@@ -1076,8 +1078,9 @@ def test_unknown_catalogue_track_requires_real_musicnn_analysis():
         existing_ids={'fp_existing'},
         missing_clap_ids={'provider-new'},
         missing_lyrics_ids={'provider-new'},
+        missing_base_ids=set(),
         lyrics_enabled=True,
-    ) == (True, True, True)
+    ) == (True, True, True, False)
 
 
 class TestFindOnnxName:
@@ -2660,3 +2663,242 @@ class TestEstimateTempo:
 
     def test_empty_audio_maps_to_zero(self):
         assert _estimate_tempo(np.array([], dtype=np.float32), 16000) == 0.0
+
+
+class _StageCalls:
+    def __init__(self):
+        self.downloads = 0
+        self.decodes = 0
+        self.native_seen = {}
+
+    def download(self, temp_dir, item):
+        self.downloads += 1
+        return f'/nonexistent/track-{self.downloads}.mp3'
+
+    def decode(self, path):
+        self.decodes += 1
+        return ('NATIVE_AUDIO', 44100)
+
+
+def _run_single_track(plan, calls, monkeypatch):
+    from tasks.analysis import album as album_mod
+    from tasks.analysis.helper import TrackPlan
+
+    monkeypatch.setattr(album_mod, 'download_track', calls.download)
+    monkeypatch.setattr(album_mod, 'decode_audio_once', calls.decode)
+    monkeypatch.setattr(album_mod._ah, 'catalog_item_id', lambda item: 'track-1')
+    monkeypatch.setattr(album_mod._ah, 'run_song_analyzed_hook', lambda *a, **k: None)
+    monkeypatch.setattr(album_mod._ah, 'top_moods_from', lambda *a, **k: {'rock': 0.5})
+    monkeypatch.setattr(album_mod, '_stage_collect_chromaprint', lambda *a, **k: None)
+    monkeypatch.setattr(album_mod, '_stage_persist_musicnn', lambda *a, **k: None)
+
+    def fake_musicnn(path, name, plan_, *a, native_audio=None, native_sr=None, **k):
+        calls.native_seen['musicnn'] = (native_audio, native_sr)
+        return (None, {'duration_seconds': 1.0}, 'EMB', None, None)
+
+    def fake_identity(item, plan_, name, emb, index, pending, track_duration=None):
+        return index, plan_, 'track-1', True
+
+    def fake_base(path, tid, name, native_audio=None, native_sr=None, precomputed=None):
+        calls.native_seen['base'] = (native_audio, native_sr)
+        return True
+
+    def fake_clap(path, tid, name, labels, native_audio=None, native_sr=None):
+        calls.native_seen['clap'] = (native_audio, native_sr)
+        return 'CLAP_EMB', True
+
+    def fake_lyrics(item, path, audio, sr, name, moods, ensure_download):
+        calls.native_seen['lyrics_path'] = ensure_download()
+        return True
+
+    monkeypatch.setattr(album_mod, '_stage_musicnn', fake_musicnn)
+    monkeypatch.setattr(album_mod, '_stage_identity', fake_identity)
+    monkeypatch.setattr(album_mod, '_stage_base', fake_base)
+    monkeypatch.setattr(album_mod, '_stage_clap', fake_clap)
+    monkeypatch.setattr(album_mod, '_stage_lyrics', fake_lyrics)
+
+    assert isinstance(plan, TrackPlan)
+    album_mod._analyze_single_track(
+        {'Id': 'x', 'Name': 'x'}, plan, 'Artist - Track', 'album-1', 'Album',
+        'parent-1', 3, {}, Mock(), None, None, None, {}, {},
+    )
+    return calls
+
+
+class TestAudioIsFetchedOncePerTrack:
+    def test_a_brand_new_song_downloads_once_and_decodes_once(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_single_track(
+            TrackPlan(musicnn=True, clap=True, lyrics=True, base=False),
+            _StageCalls(), monkeypatch,
+        )
+        assert calls.downloads == 1
+        assert calls.decodes == 1
+
+    def test_a_base_only_reanalysis_downloads_once_and_decodes_once(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_single_track(
+            TrackPlan(musicnn=False, clap=False, lyrics=False, base=True),
+            _StageCalls(), monkeypatch,
+        )
+        assert calls.downloads == 1
+        assert calls.decodes == 1
+
+    def test_base_plus_clap_reanalysis_downloads_once_and_decodes_once(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_single_track(
+            TrackPlan(musicnn=False, clap=True, lyrics=False, base=True),
+            _StageCalls(), monkeypatch,
+        )
+        assert calls.downloads == 1
+        assert calls.decodes == 1
+
+    def test_every_stage_receives_the_same_decoded_audio(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_single_track(
+            TrackPlan(musicnn=True, clap=True, lyrics=False, base=True),
+            _StageCalls(), monkeypatch,
+        )
+        assert calls.decodes == 1
+        assert calls.native_seen['musicnn'] == ('NATIVE_AUDIO', 44100)
+        assert calls.native_seen['clap'] == ('NATIVE_AUDIO', 44100)
+        assert calls.native_seen['base'] == ('NATIVE_AUDIO', 44100)
+
+    def test_a_lyrics_only_plan_still_downloads_exactly_once(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_single_track(
+            TrackPlan(musicnn=False, clap=False, lyrics=True, base=False),
+            _StageCalls(), monkeypatch,
+        )
+        assert calls.downloads == 1
+        assert calls.decodes == 0
+
+    def test_base_stage_is_counted_as_needing_audio(self):
+        from tasks.analysis.helper import TrackPlan
+
+        assert TrackPlan(musicnn=False, clap=False, lyrics=False, base=True).needs_audio
+        assert TrackPlan(musicnn=False, clap=False, lyrics=True, base=False).needs_audio is False
+
+
+class _BaseCalls:
+    def __init__(self):
+        self.downloads = 0
+        self.decodes = 0
+        self.musicnn_runs = 0
+        self.feature_computations = 0
+        self.written = []
+
+    def download(self, temp_dir, item):
+        self.downloads += 1
+        return f'/nonexistent/track-{self.downloads}.mp3'
+
+    def decode(self, path):
+        self.decodes += 1
+        return ('NATIVE_AUDIO', 44100)
+
+
+def _run_track(plan, calls, monkeypatch, catalogued_elsewhere=False):
+    from tasks.analysis import album as album_mod
+
+    monkeypatch.setattr(album_mod, 'download_track', calls.download)
+    monkeypatch.setattr(album_mod, 'decode_audio_once', calls.decode)
+    monkeypatch.setattr(album_mod._ah, 'catalog_item_id', lambda item: 'track-1')
+    monkeypatch.setattr(album_mod._ah, 'run_song_analyzed_hook', lambda *a, **k: None)
+    monkeypatch.setattr(album_mod._ah, 'top_moods_from', lambda *a, **k: {'rock': 0.5})
+    monkeypatch.setattr(album_mod, '_stage_collect_chromaprint', lambda *a, **k: None)
+    monkeypatch.setattr(album_mod, '_stage_persist_musicnn', lambda *a, **k: None)
+    monkeypatch.setattr(album_mod, '_stage_clap', lambda *a, **k: (None, True))
+    monkeypatch.setattr(album_mod, '_stage_lyrics', lambda *a, **k: True)
+
+    analysis = {
+        'tempo': 128.0, 'energy': 0.75, 'key': 'C', 'scale': 'major',
+        'duration_seconds': 200.0,
+    }
+
+    def fake_musicnn(path, name, plan_, *a, native_audio=None, native_sr=None, **k):
+        calls.musicnn_runs += 1
+        calls.feature_computations += 1
+        return (None, dict(analysis), 'EMB', None, None)
+
+    def fake_identity(item, plan_, name, emb, index, pending, track_duration=None):
+        if catalogued_elsewhere:
+            return index, plan_._replace(musicnn=False, base=True), 'canonical-9', False
+        return index, plan_, 'track-1', True
+
+    def fake_extract(audio, sr):
+        calls.feature_computations += 1
+        return (128.0, 0.75, 'C', 'major')
+
+    def fake_refresh(tid, tempo, energy, key, scale):
+        calls.written.append((tid, tempo, energy, key, scale))
+        return True
+
+    monkeypatch.setattr(album_mod, '_stage_musicnn', fake_musicnn)
+    monkeypatch.setattr(album_mod, '_stage_identity', fake_identity)
+    monkeypatch.setattr(album_mod, 'extract_basic_features', fake_extract)
+    monkeypatch.setattr(album_mod, 'resample_audio', lambda a, o, t: np.ones(16000, dtype=np.float32))
+    monkeypatch.setattr(album_mod._ah, 'refresh_base_features', fake_refresh)
+
+    album_mod._analyze_single_track(
+        {'Id': 'x', 'Name': 'x'}, plan, 'Artist - Track', 'album-1', 'Album',
+        'parent-1', 3, {}, Mock(), None, None, None, {}, {},
+    )
+    return calls
+
+
+class TestBaseFeaturesAreComputedExactlyOnce:
+    def test_an_already_analyzed_track_never_runs_musicnn_for_a_base_refresh(
+        self, monkeypatch
+    ):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_track(
+            TrackPlan(musicnn=False, clap=False, lyrics=False, base=True),
+            _BaseCalls(), monkeypatch,
+        )
+        assert calls.musicnn_runs == 0
+        assert calls.feature_computations == 1
+        assert calls.downloads == 1
+        assert calls.decodes == 1
+        assert calls.written == [('track-1', 128.0, 0.75, 'C', 'major')]
+
+    def test_a_brand_new_track_computes_base_features_only_once(self, monkeypatch):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_track(
+            TrackPlan(musicnn=True, clap=True, lyrics=True, base=False),
+            _BaseCalls(), monkeypatch,
+        )
+        assert calls.musicnn_runs == 1
+        assert calls.feature_computations == 1
+        assert calls.downloads == 1
+        assert calls.decodes == 1
+
+    def test_a_duplicate_resolved_to_a_catalogue_row_reuses_the_features_already_computed(
+        self, monkeypatch
+    ):
+        from tasks.analysis.helper import TrackPlan
+
+        calls = _run_track(
+            TrackPlan(musicnn=True, clap=False, lyrics=False, base=False),
+            _BaseCalls(), monkeypatch, catalogued_elsewhere=True,
+        )
+        assert calls.musicnn_runs == 1
+        assert calls.feature_computations == 1
+        assert calls.decodes == 1
+        assert calls.written == [('canonical-9', 128.0, 0.75, 'C', 'major')]
+
+    def test_a_base_refresh_falls_back_to_computing_when_nothing_was_precomputed(self):
+        from tasks.analysis.album import _base_features_from
+
+        assert _base_features_from(None) is None
+        assert _base_features_from({}) is None
+        assert _base_features_from({'tempo': 1.0, 'energy': 0.5, 'key': 'C'}) is None
+        assert _base_features_from(
+            {'tempo': 1.0, 'energy': 0.5, 'key': 'C', 'scale': 'major'}
+        ) == (1.0, 0.5, 'C', 'major')

--- a/test/unit/test_memory_cleanup.py
+++ b/test/unit/test_memory_cleanup.py
@@ -103,7 +103,10 @@ class TestMusicnnSessionRecycleFreesGpuBeforeAlloc:
 
 class TestAnalyzeTrackMemoryCleanup:
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
-    @patch('tasks.analysis.song.librosa')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
+    @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.analysis.song.create_onnx_session')
     @patch('tasks.analysis.song.cleanup_onnx_session')
     @patch('tasks.analysis.song.cleanup_cuda_memory')
@@ -112,16 +115,19 @@ class TestAnalyzeTrackMemoryCleanup:
         mock_cuda_cleanup,
         mock_session_cleanup,
         mock_create_sess,
-        mock_librosa,
+        mock_mel,
+        mock_tempo,
+        mock_energy,
+        mock_key_scale,
         mock_load_audio,
     ):
         from tasks.analysis import analyze_track
 
         mock_load_audio.return_value = (np.random.randn(16000), 16000)
-        mock_librosa.beat.beat_track.return_value = (120.0, None)
-        mock_librosa.feature.rms.return_value = np.array([[0.5]])
-        mock_librosa.feature.chroma_stft.return_value = np.random.randn(12, 100)
-        mock_librosa.feature.melspectrogram.return_value = np.random.randn(96, 500)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
+        mock_mel.return_value = np.random.randn(96, 500)
 
         mock_embedding_sess = MagicMock()
         mock_prediction_sess = MagicMock()
@@ -150,16 +156,21 @@ class TestAnalyzeTrackMemoryCleanup:
         assert mock_cuda_cleanup.called
 
     @patch('tasks.analysis.song.robust_load_audio_with_fallback')
-    @patch('tasks.analysis.song.librosa')
+    @patch('tasks.analysis.song._estimate_key_scale')
+    @patch('tasks.analysis.song._estimate_energy')
+    @patch('tasks.analysis.song._estimate_tempo')
+    @patch('tasks.analysis.song.librosa.feature.melspectrogram')
     @patch('tasks.onnx_utils.ort')
-    def test_no_cleanup_with_album_sessions(self, mock_ort, mock_librosa, mock_load_audio):
+    def test_no_cleanup_with_album_sessions(
+        self, mock_ort, mock_mel, mock_tempo, mock_energy, mock_key_scale, mock_load_audio
+    ):
         from tasks.analysis import analyze_track
 
         mock_load_audio.return_value = (np.random.randn(16000), 16000)
-        mock_librosa.beat.beat_track.return_value = (120.0, None)
-        mock_librosa.feature.rms.return_value = np.array([[0.5]])
-        mock_librosa.feature.chroma_stft.return_value = np.random.randn(12, 100)
-        mock_librosa.feature.melspectrogram.return_value = np.random.randn(96, 500)
+        mock_tempo.return_value = 120.0
+        mock_energy.return_value = 0.5
+        mock_key_scale.return_value = ('C', 'major')
+        mock_mel.return_value = np.random.randn(96, 500)
 
         mock_embedding_sess = MagicMock()
         mock_prediction_sess = MagicMock()

--- a/test/unit/test_multi_server.py
+++ b/test/unit/test_multi_server.py
@@ -788,10 +788,11 @@ class TestServerWorkMap:
         import tasks.analysis.helper as helper
 
         cur, _ = self._cursor({'mapped': [[
-            ('p-done', True, True, True),
-            ('p-no-embedding', False, True, True),
-            ('p-no-clap', True, False, True),
-            ('p-no-lyrics', True, True, False),
+            ('p-done', True, True, True, True),
+            ('p-no-embedding', False, True, True, True),
+            ('p-no-clap', True, False, True, True),
+            ('p-no-lyrics', True, True, False, True),
+            ('p-no-base', True, True, True, False),
         ]]})
         self._patch_db(monkeypatch, cur)
 
@@ -803,19 +804,21 @@ class TestServerWorkMap:
         assert not work_map['p-no-embedding'] & helper.WORK_MUSICNN
         assert not work_map['p-no-clap'] & helper.WORK_CLAP
         assert not work_map['p-no-lyrics'] & helper.WORK_LYRICS
+        assert not work_map['p-no-base'] & helper.WORK_BASE
         assert work_map['p-no-clap'] & done != done
+        assert work_map['p-no-base'] & done != done
 
     def test_disabled_features_are_not_required(self, monkeypatch):
         import tasks.analysis.helper as helper
 
-        cur, executed = self._cursor({'mapped': [[('p1', True, True, True)]]})
+        cur, executed = self._cursor({'mapped': [[('p1', True, True, True, True)]]})
         self._patch_db(monkeypatch, cur)
 
         monkeypatch.setattr(helper, '_is_default_server', lambda sid: False)
         work_map = helper.load_server_work_map('srv', False, False)
         done = helper.work_done_bits(False, False)
 
-        assert done == helper.WORK_MUSICNN
+        assert done == (helper.WORK_MUSICNN | helper.WORK_BASE)
         assert work_map['p1'] & done == done
         sql = executed[0][0]
         assert 'clap_embedding' not in sql
@@ -825,8 +828,8 @@ class TestServerWorkMap:
         import tasks.analysis.helper as helper
 
         cur, executed = self._cursor({'mapped': [[
-            ('p-done', True, True, True),
-            ('p-no-clap', True, False, True),
+            ('p-done', True, True, True, True),
+            ('p-no-clap', True, False, True, True),
         ]]})
         self._patch_db(monkeypatch, cur)
 
@@ -844,8 +847,8 @@ class TestServerWorkMap:
         import tasks.analysis.helper as helper
 
         cur, _ = self._cursor({
-            'mapped': [[('p1', True, True, True)]],
-            'legacy': [[('legacy-id', True, True, True)]],
+            'mapped': [[('p1', True, True, True, True)]],
+            'legacy': [[('legacy-id', True, True, True, True)]],
         })
         self._patch_db(monkeypatch, cur)
         monkeypatch.setattr(helper, '_is_default_server', lambda sid: True)
@@ -858,16 +861,16 @@ class TestServerWorkMap:
         import tasks.analysis.helper as helper
 
         cur, _ = self._cursor({
-            'mapped': [[('p1', True, True, True)]],
-            'legacy': [[('legacy-id', True, True, True)]],
+            'mapped': [[('p1', True, True, True, True)]],
+            'legacy': [[('legacy-id', True, True, True, True)]],
         })
         self._patch_db(monkeypatch, cur)
         monkeypatch.setattr(helper, '_is_default_server', lambda sid: sid == 'srv-def')
         default_map = helper.load_server_work_map('srv-def', True, True)
 
         cur2, _ = self._cursor({
-            'mapped': [[('p1', True, True, True)]],
-            'legacy': [[('legacy-id', True, True, True)]],
+            'mapped': [[('p1', True, True, True, True)]],
+            'legacy': [[('legacy-id', True, True, True, True)]],
         })
         self._patch_db(monkeypatch, cur2)
         secondary_map = helper.load_server_work_map('srv-b', True, True)
@@ -880,8 +883,8 @@ class TestServerWorkMap:
         import tasks.analysis.helper as helper
 
         cur, executed = self._cursor({'mapped': [
-            [('p1', True, True, True), ('p2', True, True, True)],
-            [('p3', True, True, True)],
+            [('p1', True, True, True, True), ('p2', True, True, True, True)],
+            [('p3', True, True, True, True)],
             [],
         ]})
         self._patch_db(monkeypatch, cur)


### PR DESCRIPTION
This PR fix the way of calculating Scale, tempo and Energy, this will need a re-analysis to have them accurate, even if this information are used mainly in the Instant Playlist (chat) functionality only.

To re analyze this value you need to drop the old one on the already analyzed song:

**Docker Compose**

```bash
docker compose exec -T -e PGPASSWORD=audiomusepassword postgres psql -U audiomuse -d audiomusedb -c "UPDATE score SET tempo = NULL, energy = NULL, key = NULL, scale = NULL;"
```

**Kubernetes**

```bash
kubectl -n playlist exec deploy/postgres-deployment -- env PGPASSWORD=audiomusepassword psql -U audiomuse -d audiomusedb -c "UPDATE score SET tempo = NULL, energy = NULL, key = NULL, scale = NULL;"
```

**Direct `psql` (standalone PostgreSQL)**

Replace `127.0.0.1` with your PostgreSQL host (e.g. the host published by Docker Compose, or `127.0.0.1` after `kubectl -n playlist port-forward svc/postgres-service 5432:5432`).

```bash
PGPASSWORD=audiomusepassword psql -h 127.0.0.1 -p 5432 -U audiomuse -d audiomusedb -c "UPDATE score SET tempo = NULL, energy = NULL, key = NULL, scale = NULL;"
```

Also a fix on the native build to don't use forked process. Windows didn't supported. MacOS seems crash accordingly to #869 and Linux was changed to be all homogeneous with the other native build.

## TEMPO TEST

| tolerance | estimator | correct | octave error | other miss |
|---|---|---:|---:|---:|
| +/-5 BPM | Production (today) | **69/100** (69%) | 12 | 19 |
| +/-10 BPM | Production (today) | **72/100** (72%) | 13 | 15 |

In short this PR show that 72% of the TEMPO result, over 100 song tested, have an error of only +/- 10 BPM so we can tag as acorrect. The rest of error are half double count due to different octave and half just error > +/- 10 BPM

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760822/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760499/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760499/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760499/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760499/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/32502760620/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-870`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-870-nvidia`
- Docker image (noavx2): `ghcr.io/neptunehub/audiomuse-ai:pr-870-noavx2`
<!-- pr-test-build:end -->