### PR TITLE
NON-ROOT image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -553,10 +553,21 @@ ENV ORT_DISABLE_MEMORY_PATTERN_OPTIMIZATION=1
 # Point numba to /tmp so it always has write access (issue: NeptuneHub/AudioMuse-AI#479).
 ENV NUMBA_CACHE_DIR=/tmp/numba_cache
 
+ENV PYTHONPYCACHEPREFIX=/tmp/pycache \
+    XDG_CACHE_HOME=/tmp/.cache \
+    CUPY_CACHE_DIR=/tmp/cupy_cache
+
 ENV PYTHONPATH=/usr/local/lib/python3/dist-packages:/app
+
+RUN getent passwd 1000 && getent group 1000 || { echo "ERROR: base image has no uid/gid 1000"; exit 1; }
+
+RUN mkdir -p /app/temp_audio /app/ivf_cache /app/backup /app/plugin/installed /workspace && \
+    chown -R 1000:1000 /app/temp_audio /app/ivf_cache /app/backup /app/plugin/installed /workspace && \
+    chown 1000:1000 /app/model
 
 EXPOSE 8000
 
 WORKDIR /workspace
+USER 1000:1000
 ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD []

--- a/deployment/deployment.yaml
+++ b/deployment/deployment.yaml
@@ -147,9 +147,7 @@ spec:
         component: flask
     spec:
       securityContext:
-        runAsUser: 0 # Or a non-root user if your image supports it
-        runAsGroup: 0 # Added fsGroup for consistency if needed by volumes
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: flask-app
         image: ghcr.io/neptunehub/audiomuse-ai:latest # Your image from GHCR
@@ -283,9 +281,7 @@ spec:
         component: worker
     spec:
       securityContext:
-        runAsUser: 0
-        runAsGroup: 0
-        fsGroup: 0
+        fsGroup: 1000
       containers:
       - name: queue-worker
         image: ghcr.io/neptunehub/audiomuse-ai:latest # Your image from GHCR


### PR DESCRIPTION
This PR is to enable AudioMuse-AI in fully work as NON ROOT image.

It will work on UID 1000 GID 1000 that is the default user for ubuntu image (the default of both CPU and NVIDIA image).

NOAVX2 image, being legacy image, are not affected.

<!-- pr-test-build:start -->
### PR test builds:
- macOS app (Apple Silicon): [AudioMuse-AI-arm64-macos.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186339/AudioMuse-AI-arm64-macos.zip)
- Linux x86_64 (.deb): [AudioMuse-AI-x86_64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186335/AudioMuse-AI-x86_64-linux-deb.zip)
- Linux x86_64 (.rpm): [AudioMuse-AI-x86_64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186335/AudioMuse-AI-x86_64-linux-rpm.zip)
- Linux aarch64 (.deb): [AudioMuse-AI-aarch64-linux-deb.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186335/AudioMuse-AI-aarch64-linux-deb.zip)
- Linux aarch64 (.rpm): [AudioMuse-AI-aarch64-linux-rpm.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186335/AudioMuse-AI-aarch64-linux-rpm.zip)
- Windows x86_64 (.zip): [AudioMuse-AI-amd64-windows-zip.zip](https://nightly.link/NeptuneHub/AudioMuse-AI/actions/runs/33152186342/AudioMuse-AI-amd64-windows-zip.zip)
- Docker image: `ghcr.io/neptunehub/audiomuse-ai:pr-878`
- Docker image (nvidia): `ghcr.io/neptunehub/audiomuse-ai:pr-878-nvidia`
<!-- pr-test-build:end -->